### PR TITLE
Level Rando fixes

### DIFF
--- a/randomizer/ApplyRandomizer.py
+++ b/randomizer/ApplyRandomizer.py
@@ -103,13 +103,14 @@ def patching_response(responded_data):
         Transitions.IslesToCastle: Transitions.CastleToIsles,
     }
     key_mapping = {
-        Transitions.JapesToIsles: 0x01E,
-        Transitions.AztecToIsles: 0x1A,
-        Transitions.FactoryToIsles: 0x4A,
-        Transitions.GalleonToIsles: 0x8A,
-        Transitions.ForestToIsles: 0xA8,
-        Transitions.CavesToIsles: 0xEC,
-        Transitions.CastleToIsles: 0x124,
+        # key given in each level. (Item 1 is Japes etc. flags=[0x1A,0x4A,0x8A,0xA8,0xEC,0x124,0x13D] <- Item 1 of this array is Key 1 etc.)
+        Transitions.JapesToIsles: 0x1A,
+        Transitions.AztecToIsles: 0x4A,
+        Transitions.FactoryToIsles: 0x8A,
+        Transitions.GalleonToIsles: 0xA8,
+        Transitions.ForestToIsles: 0xEC,
+        Transitions.CavesToIsles: 0x124,
+        Transitions.CastleToIsles: 0x13D,
     }
     order = 0
     for key, value in map_pointers.items():

--- a/randomizer/ApplyRandomizer.py
+++ b/randomizer/ApplyRandomizer.py
@@ -73,11 +73,10 @@ def patching_response(responded_data):
         Transitions.CastleToIsles,
     ]
     order = 0
-    # for level in vanilla_entrace_order:
-    #     ROM().seek(sav + 0x001 + order)
-    #     print(spoiler.shuffled_exit_data)
-    #     ROM().write(vanilla_lobby_order.index(spoiler.shuffled_exit_data[int(level)]))
-    #     order += 1
+    for level in vanilla_entrace_order:
+        ROM().seek(sav + 0x001 + order)
+        ROM().write(vanilla_lobby_order.index(spoiler.shuffled_exit_data[int(level)].reverse))
+        order += 1
 
     # Color Banana Requirements
     order = 0
@@ -113,11 +112,11 @@ def patching_response(responded_data):
         Transitions.CastleToIsles: 0x124,
     }
     order = 0
-    # for key, value in map_pointers.items():
-    #     new_world = spoiler.shuffled_exit_data.get(key)
-    #     ROM().seek(sav + 0x01E + order)
-    #     ROM().writeMultipleBytes(key_mapping[int(new_world)], 2)
-    #     order += 2
+    for key, value in map_pointers.items():
+        new_world = spoiler.shuffled_exit_data.get(key).reverse
+        ROM().seek(sav + 0x01E + order)
+        ROM().writeMultipleBytes(key_mapping[int(new_world)], 2)
+        order += 2
 
     # Unlock All Kongs
     if spoiler.settings.unlock_all_kongs:

--- a/randomizer/ApplyRandomizer.py
+++ b/randomizer/ApplyRandomizer.py
@@ -54,28 +54,28 @@ def patching_response(responded_data):
         ROM().write(1)
 
     # Update Level Order
-    vanilla_entrace_order = [
-        Transitions.IslesToJapes,
-        Transitions.IslesToAztec,
-        Transitions.IslesToFactory,
-        Transitions.IslesToGalleon,
-        Transitions.IslesToForest,
-        Transitions.IslesToCaves,
-        Transitions.IslesToCastle,
+    vanilla_lobby_entrance_order = [
+        Transitions.IslesMainToJapesLobby,
+        Transitions.IslesMainToAztecLobby,
+        Transitions.IslesMainToFactoryLobby,
+        Transitions.IslesMainToGalleonLobby,
+        Transitions.IslesMainToForestLobby,
+        Transitions.IslesMainToCavesLobby,
+        Transitions.IslesMainToCastleLobby,
     ]
-    vanilla_lobby_order = [
-        Transitions.JapesToIsles,
-        Transitions.AztecToIsles,
-        Transitions.FactoryToIsles,
-        Transitions.GalleonToIsles,
-        Transitions.ForestToIsles,
-        Transitions.CavesToIsles,
-        Transitions.CastleToIsles,
+    vanilla_lobby_exit_order = [
+        Transitions.IslesJapesLobbyToMain,
+        Transitions.IslesAztecLobbyToMain,
+        Transitions.IslesFactoryLobbyToMain,
+        Transitions.IslesGalleonLobbyToMain,
+        Transitions.IslesForestLobbyToMain,
+        Transitions.IslesCavesLobbyToMain,
+        Transitions.IslesCastleLobbyToMain,
     ]
     order = 0
-    for level in vanilla_entrace_order:
+    for level in vanilla_lobby_entrance_order:
         ROM().seek(sav + 0x001 + order)
-        ROM().write(vanilla_lobby_order.index(spoiler.shuffled_exit_data[int(level)].reverse))
+        ROM().write(vanilla_lobby_exit_order.index(spoiler.shuffled_exit_data[int(level)].reverse))
         order += 1
 
     # Color Banana Requirements
@@ -94,23 +94,23 @@ def patching_response(responded_data):
 
     # Key Order
     map_pointers = {
-        Transitions.IslesToJapes: Transitions.JapesToIsles,
-        Transitions.IslesToAztec: Transitions.AztecToIsles,
-        Transitions.IslesToFactory: Transitions.FactoryToIsles,
-        Transitions.IslesToGalleon: Transitions.GalleonToIsles,
-        Transitions.IslesToForest: Transitions.ForestToIsles,
-        Transitions.IslesToCaves: Transitions.CavesToIsles,
-        Transitions.IslesToCastle: Transitions.CastleToIsles,
+        Transitions.IslesMainToJapesLobby: Transitions.IslesJapesLobbyToMain,
+        Transitions.IslesMainToAztecLobby: Transitions.IslesAztecLobbyToMain,
+        Transitions.IslesMainToFactoryLobby: Transitions.IslesFactoryLobbyToMain,
+        Transitions.IslesMainToGalleonLobby: Transitions.IslesGalleonLobbyToMain,
+        Transitions.IslesMainToForestLobby: Transitions.IslesForestLobbyToMain,
+        Transitions.IslesMainToCavesLobby: Transitions.IslesCavesLobbyToMain,
+        Transitions.IslesMainToCastleLobby: Transitions.IslesCastleLobbyToMain,
     }
     key_mapping = {
         # key given in each level. (Item 1 is Japes etc. flags=[0x1A,0x4A,0x8A,0xA8,0xEC,0x124,0x13D] <- Item 1 of this array is Key 1 etc.)
-        Transitions.JapesToIsles: 0x1A,
-        Transitions.AztecToIsles: 0x4A,
-        Transitions.FactoryToIsles: 0x8A,
-        Transitions.GalleonToIsles: 0xA8,
-        Transitions.ForestToIsles: 0xEC,
-        Transitions.CavesToIsles: 0x124,
-        Transitions.CastleToIsles: 0x13D,
+        Transitions.IslesJapesLobbyToMain: 0x1A,
+        Transitions.IslesAztecLobbyToMain: 0x4A,
+        Transitions.IslesFactoryLobbyToMain: 0x8A,
+        Transitions.IslesGalleonLobbyToMain: 0xA8,
+        Transitions.IslesForestLobbyToMain: 0xEC,
+        Transitions.IslesCavesLobbyToMain: 0x124,
+        Transitions.IslesCastleLobbyToMain: 0x13D,
     }
     order = 0
     for key, value in map_pointers.items():

--- a/randomizer/EntranceRando.py
+++ b/randomizer/EntranceRando.py
@@ -36,7 +36,7 @@ def intToArr(val, size):
 
 def randomize_entrances(spoiler: Spoiler):
     """Randomize Entrances based on shuffled_exit_instructions."""
-    if spoiler.settings.shuffle_loading_zones != "none" and spoiler.shuffled_exit_instructions is not None:
+    if spoiler.settings.shuffle_loading_zones == "all" and spoiler.shuffled_exit_instructions is not None:
         for cont_map in spoiler.shuffled_exit_instructions:
             # Pointer table 18, use the map index detailed in cont_map["container_map"] to get the starting address of the map lz file
             cont_map_id = int(cont_map["container_map"])

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -88,6 +88,7 @@ class Settings:
         self.seed = None
         self.download_json = None
         self.bonus_barrel_rando = None
+        self.shuffle_levels = None
         self.loading_zone_rando = None
         self.loading_zone_coupled = None
         self.shop_location_rando = None
@@ -210,6 +211,8 @@ class Settings:
         # Loading Zone Rando
         if self.loading_zone_rando:
             self.shuffle_loading_zones = "all"
+        elif self.shuffle_levels:
+            self.shuffle_loading_zones = "levels"
         if self.loading_zone_coupled:
             self.decoupled_loading_zones = False
 

--- a/randomizer/ShuffleExits.py
+++ b/randomizer/ShuffleExits.py
@@ -12,21 +12,24 @@ from randomizer.ItemPool import AllItems, PlaceConstants
 from randomizer.Lists.ShufflableExit import ShufflableExits
 from randomizer.LogicClasses import TransitionFront
 
+# Used when level order rando is ON
 LevelExitPool = [
-    Transitions.IslesToJapes,
-    Transitions.JapesToIsles,
-    Transitions.IslesToAztec,
-    Transitions.AztecToIsles,
-    Transitions.IslesToFactory,
-    Transitions.FactoryToIsles,
-    Transitions.IslesToGalleon,
-    Transitions.GalleonToIsles,
-    Transitions.IslesToForest,
-    Transitions.ForestToIsles,
-    Transitions.IslesToCaves,
-    Transitions.CavesToIsles,
-    Transitions.IslesToCastle,
-    Transitions.CastleToIsles,
+    # Going into lobbies
+    Transitions.IslesMainToJapesLobby,
+    Transitions.IslesMainToAztecLobby,
+    Transitions.IslesMainToFactoryLobby,
+    Transitions.IslesMainToGalleonLobby,
+    Transitions.IslesMainToForestLobby,
+    Transitions.IslesMainToCavesLobby,
+    Transitions.IslesMainToCastleLobby,
+    # Going out of lobbies
+    Transitions.IslesJapesLobbyToMain,
+    Transitions.IslesAztecLobbyToMain,
+    Transitions.IslesFactoryLobbyToMain,
+    Transitions.IslesGalleonLobbyToMain,
+    Transitions.IslesForestLobbyToMain,
+    Transitions.IslesCavesLobbyToMain,
+    Transitions.IslesCastleLobbyToMain,
 ]
 
 # Root is the starting spawn, which is the main area of DK Isles.

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -7,6 +7,7 @@ from randomizer import Logic
 from randomizer.Enums.Levels import Levels
 from randomizer.Enums.Locations import Locations
 from randomizer.Enums.Kongs import Kongs
+from randomizer.Enums.Transitions import Transitions
 from randomizer.Enums.Types import Types
 from randomizer.Enums.MoveTypes import MoveTypes
 from randomizer.Lists.Item import ItemFromKong, ItemList
@@ -110,19 +111,38 @@ class Spoiler:
                 prices[movename] = price
             humanspoiler["Prices"] = prices
 
-        if self.settings.shuffle_loading_zones != "none":
-            # Shuffled exit data
+        if self.settings.shuffle_loading_zones == "levels":
+            # Just show level order
+            shuffled_exits = OrderedDict()
+            lobby_entrance_order = {
+                Transitions.IslesMainToJapesLobby: Levels.JungleJapes,
+                Transitions.IslesMainToAztecLobby: Levels.AngryAztec,
+                Transitions.IslesMainToFactoryLobby: Levels.FranticFactory,
+                Transitions.IslesMainToGalleonLobby: Levels.GloomyGalleon,
+                Transitions.IslesMainToForestLobby: Levels.FungiForest,
+                Transitions.IslesMainToCavesLobby: Levels.CrystalCaves,
+                Transitions.IslesMainToCastleLobby: Levels.CreepyCastle,
+            }
+            lobby_exit_order = {
+                Transitions.IslesJapesLobbyToMain: Levels.JungleJapes,
+                Transitions.IslesAztecLobbyToMain: Levels.AngryAztec,
+                Transitions.IslesFactoryLobbyToMain: Levels.FranticFactory,
+                Transitions.IslesGalleonLobbyToMain: Levels.GloomyGalleon,
+                Transitions.IslesForestLobbyToMain: Levels.FungiForest,
+                Transitions.IslesCavesLobbyToMain: Levels.CrystalCaves,
+                Transitions.IslesCastleLobbyToMain: Levels.CreepyCastle,
+            }
+            for transition, vanilla_level in lobby_entrance_order.items():
+                shuffled_level = lobby_exit_order[self.shuffled_exit_data[transition].reverse]
+                shuffled_exits[vanilla_level.name] = shuffled_level.name
+            humanspoiler["Shuffled Level Order"] = shuffled_exits
+        elif self.settings.shuffle_loading_zones != "none":
+            # Show full shuffled_exits data if more than just levels are shuffled
             shuffled_exits = OrderedDict()
             for exit, dest in self.shuffled_exit_data.items():
                 shuffled_exits[ShufflableExits[exit].name] = Logic.Regions[dest.regionId].name + " " + dest.name
             humanspoiler["Shuffled Exits"] = shuffled_exits
-
-        if self.settings.bonus_barrels == "random":
-            shuffled_barrels = OrderedDict()
-            for location, minigame in self.shuffled_barrel_data.items():
-                shuffled_barrels[LocationList[location].name] = MinigameRequirements[minigame].name
-            humanspoiler["Shuffled Bonus Barrels"] = shuffled_barrels
-
+        
         if self.settings.boss_location_rando:
             shuffled_bosses = OrderedDict()
             for i in range(7):
@@ -138,6 +158,12 @@ class Spoiler:
             for kong in self.settings.kutout_kongs:
                 kutout_order = kutout_order + Kongs(kong).name + ", "
             humanspoiler["Shuffled Kutout Kong Order"] = kutout_order.removesuffix(", ")
+
+        if self.settings.bonus_barrels == "random":
+            shuffled_barrels = OrderedDict()
+            for location, minigame in self.shuffled_barrel_data.items():
+                shuffled_barrels[LocationList[location].name] = MinigameRequirements[minigame].name
+            humanspoiler["Shuffled Bonus Barrels"] = shuffled_barrels
 
         if self.settings.music_bgm == "randomized":
             humanspoiler["Shuffled Music (BGM)"] = self.music_bgm_data


### PR DESCRIPTION
-Got level order rando working
-B.Locker and T&S progression is set to match the new level order
-Confirmed boss location rando still works when level order rando is on