### PR TITLE
Add setting to randomize medal requirement, take away sniper scope special cases

### DIFF
--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -328,9 +328,10 @@ def LowPriorityItems(settings):
     if not settings.coin_door_open:
         itemPool.append(Items.NintendoCoin)
         itemPool.append(Items.RarewareCoin)
-    itemPool.append(Items.SniperSight)
-    if not settings.hard_shooting:
-        itemPool.append(Items.HomingAmmo)
+    if not settings.unlock_all_moves:
+        itemPool.append(Items.SniperSight)
+        if not settings.hard_shooting:
+            itemPool.append(Items.HomingAmmo)
     return itemPool
 
 

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -81,7 +81,6 @@ def PlaceConstants(settings):
         LocationList[Locations.TinyKong].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.ChunkyKong].PlaceConstantItem(Items.NoItem)
     if settings.unlock_all_moves:
-        # Empty all shop locations EXCEPT sniper scope which is still optional
         LocationList[Locations.SimianSlam].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.SuperSimianSlam].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.SuperDuperSimianSlam].PlaceConstantItem(Items.NoItem)
@@ -108,6 +107,7 @@ def PlaceConstants(settings):
         LocationList[Locations.AmmoBelt1].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.HomingAmmo].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.AmmoBelt2].PlaceConstantItem(Items.NoItem)
+        LocationList[Locations.SniperSight].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.Bongos].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.Guitar].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.Trombone].PlaceConstantItem(Items.NoItem)

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -99,7 +99,7 @@ class LogicVarHolder:
         self.camera = self.settings.unlock_fairy_shockwave
         self.shockwave = self.settings.unlock_fairy_shockwave
 
-        self.scope = False  # Start with moves doesn't give scope
+        self.scope = self.settings.unlock_all_moves
         self.homing = self.settings.unlock_all_moves
 
         self.JapesKey = False

--- a/randomizer/LogicFiles/Shops.py
+++ b/randomizer/LogicFiles/Shops.py
@@ -85,7 +85,6 @@ LogicRegions = {
     ]),
 
     Regions.FunkyCastle: Region("Funky Castle", Levels.Shops, False, None, [
-        # Sniper sight is the only non-Snide shop location not zeroed out when starting with all shop moves.
         LocationLogic(Locations.SniperSight, lambda l: l.LevelEntered(Levels.CreepyCastle) and l.CanBuy(Locations.SniperSight)),
         LocationLogic(Locations.DonkeyCastleGun, lambda l: l.LevelEntered(Levels.CreepyCastle) and l.isdonkey and l.CanBuy(Locations.DonkeyCastleGun)),
         LocationLogic(Locations.DiddyCastleGun, lambda l: l.LevelEntered(Levels.CreepyCastle) and l.isdiddy and l.CanBuy(Locations.DiddyCavesGun)),

--- a/randomizer/LogicFiles/Shops.py
+++ b/randomizer/LogicFiles/Shops.py
@@ -160,7 +160,7 @@ LogicRegions = {
 
     Regions.CrankyGeneric: Region("Cranky Generic", Levels.Shops, False, None, [
         LocationLogic(Locations.SimianSlam, lambda l: True),
-        LocationLogic(Locations.RarewareCoin, lambda l: l.BananaMedals >= 15),
+        LocationLogic(Locations.RarewareCoin, lambda l: l.BananaMedals >= l.settings.BananaMedalsRequired),
     ], [], [
         TransitionFront(Regions.CrankyJapes, lambda l: l.settings.shuffle_items == "none"),
         TransitionFront(Regions.CrankyAztec, lambda l: l.settings.shuffle_items == "none"),

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -209,6 +209,8 @@ class Settings:
         self.quality_of_life = None
         self.enable_tag_anywhere = None
         self.random_krool_phase_order = None
+        self.random_medal_requirement = True
+        self.bananaport_rando = False
         self.shop_indicator = False
         self.randomize_cb_required_amounts = False
         self.randomize_blocker_required_amounts = False
@@ -275,6 +277,13 @@ class Settings:
                     self.krool_keys_required.append(event)
         if self.krool_access == "random_helm" and Events.HelmKeyTurnedIn not in self.krool_keys_required:
             self.krool_keys_required.append(Events.HelmKeyTurnedIn)
+
+        # Banana medals
+        if self.random_medal_requirement:
+            # Range roughly from 4 to 15, average around 10
+            self.BananaMedalsRequired = round(random.normalvariate(10, .15))
+        else:
+            self.BananaMedalsRequired = 15
 
         # Boss Rando
         self.boss_maps = ShuffleBosses(self.boss_location_rando)

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -281,7 +281,7 @@ class Settings:
         # Banana medals
         if self.random_medal_requirement:
             # Range roughly from 4 to 15, average around 10
-            self.BananaMedalsRequired = round(random.normalvariate(10, .15))
+            self.BananaMedalsRequired = round(random.normalvariate(10, 0.15))
         else:
             self.BananaMedalsRequired = 15
 

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -50,6 +50,8 @@ class Spoiler:
                 moves.append(kongmoves)
             self.move_data.append(moves)
 
+        self.jetpac_medals_required = self.settings.BananaMedalsRequired
+
     def toJson(self):
         """Convert spoiler to JSON."""
         # Verify we match our hash
@@ -71,6 +73,10 @@ class Spoiler:
         settings["crown_door_open"] = self.settings.crown_door_open
         settings["coin_door_open"] = self.settings.coin_door_open
         settings["unlock_fairy_shockwave"] = self.settings.unlock_fairy_shockwave
+        settings["random_medal_requirement"] = self.settings.random_medal_requirement
+        if self.settings.random_medal_requirement:
+            settings["banana_medals_required"] = self.settings.BananaMedalsRequired
+        settings["bananaport_rando"] = self.settings.bananaport_rando
         settings["krool_phases"] = self.settings.krool_order
         settings["krool_access"] = self.settings.krool_access
         settings["krool_keys_required"] = self.GetKroolKeysRequired(self.settings.krool_keys_required)

--- a/templates/overworld.html.jinja2
+++ b/templates/overworld.html.jinja2
@@ -21,7 +21,7 @@
                 <tr>
                     <td>
                         <div class="form-check form-switch w-75">
-                            <label title="This option will make all moves available from the start without purchasing them. &#013;Includes all Cranky, all Candy, and almost all Funky purchasables. &#013;Does not include access to JetPac in Cranky; you will still need 15 banana medals. &#013;Does not include snipe scope to reduce 1st person camera lag. &#013;Is still purchasable. &#013;Does not include the shockwave attack from the banana fairy queen.">
+                            <label title="This option will make all moves available from the start without purchasing them. &#013;Includes all Cranky, all Candy, and almost all Funky purchasables. &#013;Does not include access to JetPac in Cranky; you will still need some banana medals. &#013;Does not include the shockwave attack from the banana fairy queen.">
                                 <input class="form-check-input"
                                        type="checkbox"
                                        name="unlock_all_moves"

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -159,6 +159,19 @@
                 <tr>
                     <td>
                         <div class="form-check form-switch w-75">
+                            <label title="Randomizes the amount of banana medals needed for Jetpac. Range is roughly 4 to 15 with an average of 10.">
+                                <input class="form-check-input"
+                                       type="checkbox"
+                                       name="random_medal_requirement"
+                                       value="False"/>
+                                Random Medal Requirement
+                            </label>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div class="form-check form-switch w-75">
                             <label title="Battle Crown platforms are randomized in their spawn location.">
                                 <input class="form-check-input"
                                        type="checkbox"


### PR DESCRIPTION
Adds a setting that randomizes the medal requirement for jetpac in a range of 4 to 15 with an average of 10. This PR adds the toggle in the UI as well as the code to set it, and write the amount set in the spoiler for humans and the rom.

Also took out all the code that was treating the Sniper Sight as a special case that wasn't given when starting with all moves, since the lag issue was resolved.

Also I noticed that bananaport rando setting wasn't being displayed in the spoiler so I added that.