### PR TITLE
Fixed Color options not disabling if Randomize All is already selected.

### DIFF
--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -195,6 +195,13 @@ class Settings:
         self.music_fanfares = None
         self.music_events = None
 
+        #  Color
+        self.dk_colors = None
+        self.diddy_colors = None
+        self.lanky_colors = None
+        self.tiny_colors = None
+        self.chunky_colors = None
+
         #  Misc
         self.generate_spoilerlog = None
         self.fast_start_beginning_of_game = None

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,6 +1,6 @@
 """Import functions within the UI folder to have them run on load of the UI."""
 from ui.generate_buttons import disable_input
-from ui.rando_options import set_preset_options, toggle_b_locker_boxes, toggle_counts_boxes, unlock_kongs_toggle, update_boss_required
+from ui.rando_options import set_preset_options, toggle_b_locker_boxes, toggle_counts_boxes, unlock_kongs_toggle, update_boss_required, disable_colors, disable_music
 
 disable_input(None)
 set_preset_options()
@@ -8,3 +8,5 @@ toggle_counts_boxes(None)
 toggle_b_locker_boxes(None)
 unlock_kongs_toggle(None)
 update_boss_required(None)
+disable_colors(None)
+disable_music(None)


### PR DESCRIPTION
Now that cookies work on cosmetics fixed the color/music options not being disabled if 'Randomize All' is already on.