### PR TITLE
No more Pirate Tiny until crash is fixed.

### DIFF
--- a/randomizer/Patching/CosmeticColors.py
+++ b/randomizer/Patching/CosmeticColors.py
@@ -58,7 +58,7 @@ def apply_cosmetic_colors(spoiler: Spoiler):
         enable = True
         color = 0
         if js.document.getElementById("tiny_colors").value == "randomized":
-            color = randint(0, 3)
+            color = randint(0, 2)  # Change back to 3 once Red Tiny Color is fixed.
         elif js.document.getElementById("tiny_colors").value == "green":
             color = 1
         elif js.document.getElementById("tiny_colors").value == "purple":

--- a/templates/cosmetics.html.jinja2
+++ b/templates/cosmetics.html.jinja2
@@ -188,9 +188,10 @@
                                 <option value="purple">
                                     Purple
                                 </option>
-                                <option value="red">
+                                {#  Temporary until Tiny Crash fix #}
+                                {# <option value="red">
                                     Red
-                                </option>
+                                </option> #}
                             </select>
                         </div>
                     </td>


### PR DESCRIPTION
Removed 'Red' as an option for Tiny's color until crash is fixed.