### PR TITLE
Realized kasplat shuffle was breaking because of B.Locker amounts whi…

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -904,6 +904,8 @@ def Generate_Spoiler(spoiler):
         # Handle Level Order
         ShuffleExits.ShuffleLevelOrderWithRestrictions(spoiler.settings)
         spoiler.UpdateExits()
+        # Assume we can progress through the levels, since these will be adjusted within FillKongsAndMovesForLevelRando
+        WipeProgressionRequirements(spoiler.settings)
         # Handle misc randomizations
         ShuffleMisc(spoiler)
         # Handle Item Fill


### PR DESCRIPTION
…ch are not yet adjusted in level rando, fixed by WipeProgressionRequirements before shuffle misc settings