### PR TITLE
Update time of day logic

### DIFF
--- a/randomizer/CollectibleLogicFiles/FungiForest.py
+++ b/randomizer/CollectibleLogicFiles/FungiForest.py
@@ -5,6 +5,7 @@ from randomizer.Enums.Collectibles import Collectibles
 from randomizer.Enums.Events import Events
 from randomizer.Enums.Kongs import Kongs
 from randomizer.Enums.Regions import Regions
+from randomizer.Enums.Time import Time
 from randomizer.LogicClasses import Collectible
 
 LogicRegions = {
@@ -75,7 +76,7 @@ LogicRegions = {
         Collectible(Collectibles.banana, Kongs.diddy, lambda l: True, None, 10),
         Collectible(Collectibles.bunch, Kongs.lanky, lambda l: l.handstand, None, 1),  # Top of mushroom
 
-        Collectible(Collectibles.coin, Kongs.diddy, lambda l: Events.Night in l.Events, None, 3),  # Around crown pad
+        Collectible(Collectibles.coin, Kongs.diddy, lambda l: True, None, 3),  # Around crown pad
         Collectible(Collectibles.coin, Kongs.chunky, lambda l: True, None, 3),  # On switch to face puzzle room
     ],
     Regions.MushroomChunkyRoom: [
@@ -98,20 +99,20 @@ LogicRegions = {
         Collectible(Collectibles.banana, Kongs.tiny, lambda l: True, None, 8),
         Collectible(Collectibles.bunch, Kongs.tiny, lambda l: l.saxophone and l.mini, None, 1),
 
-        Collectible(Collectibles.coin, Kongs.diddy, lambda l: l.jetpack and Events.Night in l.Events, None, 4),  # Alcove in tree
+        Collectible(Collectibles.coin, Kongs.diddy, lambda l: l.jetpack and l.TimeAccess(Regions.HollowTreeArea, Time.Night), None, 4),  # Alcove in tree
         Collectible(Collectibles.coin, Kongs.lanky, lambda l: True, None, 3),  # Near Lanky BP
-        Collectible(Collectibles.coin, Kongs.lanky, lambda l: l.trombone, None, 3),  # Beat first rabbit race
+        Collectible(Collectibles.coin, Kongs.lanky, lambda l: l.TimeAccess(Regions.HollowTreeArea, Time.Day) and l.trombone, None, 3),  # Beat first rabbit race
     ],
     Regions.Anthill: [
     ],
     Regions.MillArea: [
         Collectible(Collectibles.balloon, Kongs.donkey, lambda l: l.coconut, None, 1),  # Behind Barn
-        Collectible(Collectibles.balloon, Kongs.diddy, lambda l: l.peanut, None, 1),  # Snide
+        Collectible(Collectibles.balloon, Kongs.diddy, lambda l: l.peanut and l.TimeAccess(Regions.MillArea, Time.Day), None, 1),  # Snide
         Collectible(Collectibles.banana, Kongs.diddy, lambda l: True, None, 3),  # Near Rafter Barn
         Collectible(Collectibles.bunch, Kongs.diddy, lambda l: l.spring, None, 1),  # Near Rafter Barn
         Collectible(Collectibles.banana, Kongs.lanky, lambda l: True, None, 7),  # Mill roof
         Collectible(Collectibles.bunch, Kongs.lanky, lambda l: True, None, 1),  # Above Balloon pad
-        Collectible(Collectibles.bunch, Kongs.lanky, lambda l: Events.Night in l.Events, None, 1),  # Attic Entrance
+        Collectible(Collectibles.bunch, Kongs.lanky, lambda l: l.TimeAccess(Regions.MillArea, Time.Night), None, 1),  # Attic Entrance
         Collectible(Collectibles.banana, Kongs.tiny, lambda l: True, None, 17),  # Underwater
 
         Collectible(Collectibles.coin, Kongs.any, lambda l: l.shockwave, None, 1),  # In patch of grass
@@ -170,6 +171,6 @@ LogicRegions = {
 
         Collectible(Collectibles.coin, Kongs.any, lambda l: l.shockwave, None, 1),  # In front of beanstalk
         Collectible(Collectibles.coin, Kongs.tiny, lambda l: True, None, 3),  # By Mini Monkey barrel
-        Collectible(Collectibles.coin, Kongs.chunky, lambda l: Events.Night in l.Events, None, 3),  # By T&S portal
+        Collectible(Collectibles.coin, Kongs.chunky, lambda l: l.TimeAccess(Regions.WormArea, Time.Night), None, 3),  # By T&S portal
     ],
 }

--- a/randomizer/Enums/Time.py
+++ b/randomizer/Enums/Time.py
@@ -1,0 +1,10 @@
+"""Time enum."""
+from enum import IntEnum, auto
+
+
+class Time(IntEnum):
+    """Time enum."""
+
+    Both = auto()
+    Day = auto()
+    Night = auto()

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -8,12 +8,14 @@ from randomizer.Lists.ShufflableExit import GetLevelShuffledToIndex, GetShuffled
 import randomizer.Logic as Logic
 from randomizer.Settings import Settings
 import randomizer.ShuffleExits as ShuffleExits
+from randomizer.Enums.Events import Events
 from randomizer.Enums.Items import Items
 from randomizer.Enums.Kongs import Kongs
 from randomizer.Enums.Levels import Levels
 from randomizer.Enums.Locations import Locations
 from randomizer.Enums.Regions import Regions
 from randomizer.Enums.SearchMode import SearchMode
+from randomizer.Enums.Time import Time
 from randomizer.Enums.Transitions import Transitions
 from randomizer.Enums.Types import Types
 from randomizer.Lists.Item import ItemList, KongFromItem
@@ -96,6 +98,8 @@ def GetAccessibleLocations(settings, ownedItems, searchType=SearchMode.GetReacha
 
             startRegion = Logic.Regions[Regions.IslesMain]
             startRegion.id = Regions.IslesMain
+            startRegion.dayAccess = True
+            startRegion.nightAccess = Events.Night in LogicVariables.Events
             regionPool = [startRegion]
             addedRegions = [Regions.IslesMain]
 
@@ -114,6 +118,11 @@ def GetAccessibleLocations(settings, ownedItems, searchType=SearchMode.GetReacha
                     if event.name not in LogicVariables.Events and event.logic(LogicVariables):
                         eventAdded = True
                         LogicVariables.Events.append(event.name)
+                    # Can start searching with night access
+                    # Check this even if Night's already been added, because you could
+                    # lose night access from start to Forest main, then regain it here
+                    if event.name == Events.Night and event.logic(LogicVariables):
+                        region.nightAccess = True
                 # Check accessibility for collectibles
                 if region.id in Logic.CollectibleRegions.keys():
                     for collectible in Logic.CollectibleRegions[region.id]:
@@ -161,10 +170,31 @@ def GetAccessibleLocations(settings, ownedItems, searchType=SearchMode.GetReacha
                             continue
                     # If a region is accessible through this exit and has not yet been added, add it to the queue to be visited eventually
                     if destination not in addedRegions and exit.logic(LogicVariables):
-                        addedRegions.append(destination)
-                        newRegion = Logic.Regions[destination]
-                        newRegion.id = destination
-                        regionPool.append(newRegion)
+                        # Check time of day
+                        timeAccess = True
+                        if exit.time == Time.Night and not region.nightAccess:
+                            timeAccess = False
+                        elif exit.time == Time.Day and not region.dayAccess:
+                            timeAccess = False
+                        if timeAccess:
+                            addedRegions.append(destination)
+                            newRegion = Logic.Regions[destination]
+                            newRegion.id = destination
+                            regionPool.append(newRegion)
+                    # If it's accessible, update time of day access whether already added or not
+                    # This way if a region has access from 2 different regions, one time-restricted and one not,
+                    # it will be known that it can be accessed during either time of day
+                    if exit.logic(LogicVariables):
+                        # If this region has day access and the exit isn't restricted to night-only, then the destination has day access
+                        if region.dayAccess and exit.time != Time.Night and not Logic.Regions[destination].dayAccess:
+                            Logic.Regions[destination].dayAccess = True
+                            # Count as event added so search doesn't get stuck if region is searched, 
+                            # then later a new time of day access is found so it should be re-visited
+                            eventAdded = True
+                        # And vice versa
+                        if region.nightAccess and exit.time != Time.Day and not Logic.Regions[destination].nightAccess:
+                            Logic.Regions[destination].nightAccess = True
+                            eventAdded = True
                 # Deathwarps currently send to the vanilla destination
                 if region.deathwarp is not None:
                     destination = region.deathwarp.dest

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -188,7 +188,7 @@ def GetAccessibleLocations(settings, ownedItems, searchType=SearchMode.GetReacha
                         # If this region has day access and the exit isn't restricted to night-only, then the destination has day access
                         if region.dayAccess and exit.time != Time.Night and not Logic.Regions[destination].dayAccess:
                             Logic.Regions[destination].dayAccess = True
-                            # Count as event added so search doesn't get stuck if region is searched, 
+                            # Count as event added so search doesn't get stuck if region is searched,
                             # then later a new time of day access is found so it should be re-visited
                             eventAdded = True
                         # And vice versa

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -24,6 +24,7 @@ from randomizer.Enums.Items import Items
 from randomizer.Enums.Kongs import Kongs
 from randomizer.Enums.Levels import Levels
 from randomizer.Enums.Locations import Locations
+from randomizer.Enums.Time import Time
 from randomizer.Lists.Location import Location, LocationList
 from randomizer.Lists.MapsAndExits import Maps
 from randomizer.Prices import CanBuy, GetPriceOfMoveItem
@@ -435,6 +436,16 @@ class LogicVarHolder:
         Usually the region's own HasAccess function is used, but this is necessary for checking access for other regions in logic files.
         """
         return Regions[region].HasAccess(kong)
+
+    def TimeAccess(self, region, time):
+        """Checks if a certain region has the given time of day access."""
+        if time == Time.Day:
+            return Regions[region].dayAccess
+        elif time == Time.Night:
+            return Regions[region].nightAccess
+        # Not sure when this'd be used
+        else: # if time == Time.Both
+            return Regions[region].dayAccess or Regions[region].nightAccess
 
     def KasplatAccess(self, location):
         """Use the kasplat map to check kasplat logic for blueprint locations."""

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -438,13 +438,13 @@ class LogicVarHolder:
         return Regions[region].HasAccess(kong)
 
     def TimeAccess(self, region, time):
-        """Checks if a certain region has the given time of day access."""
+        """Check if a certain region has the given time of day access."""
         if time == Time.Day:
             return Regions[region].dayAccess
         elif time == Time.Night:
             return Regions[region].nightAccess
         # Not sure when this'd be used
-        else: # if time == Time.Both
+        else:  # if time == Time.Both
             return Regions[region].dayAccess or Regions[region].nightAccess
 
     def KasplatAccess(self, location):

--- a/randomizer/LogicClasses.py
+++ b/randomizer/LogicClasses.py
@@ -2,6 +2,7 @@
 from randomizer.Enums.Kongs import Kongs
 from randomizer.Enums.Levels import Levels
 from randomizer.Enums.Regions import Regions
+from randomizer.Enums.Time import Time
 from randomizer.Enums.Transitions import Transitions
 
 
@@ -55,6 +56,9 @@ class Region:
         self.events = events
         self.exits = transitionFronts  # In the context of a region, exits are how you leave the region
         self.restart = restart
+
+        self.dayAccess = False
+        self.nightAccess = False
 
         # If possible to die in this region, add an exit to where dying will take you
         # deathwarp is also set to none in regions in which a deathwarp would take you to itself
@@ -120,12 +124,16 @@ class Region:
             return self.donkeyAccess or self.diddyAccess or self.lankyAccess or self.tinyAccess or self.chunkyAccess
 
     def ResetAccess(self):
-        """Clear access for all kongs."""
+        """Clear access variables set during search."""
+        # Kong access
         self.donkeyAccess = False
         self.diddyAccess = False
         self.lankyAccess = False
         self.tinyAccess = False
         self.chunkyAccess = False
+        # Time access
+        self.dayAccess = False
+        self.nightAccess = False
 
     def GetDefaultDeathwarp(self):
         """Get the default deathwarp depending on the region's level."""
@@ -163,9 +171,10 @@ class TransitionBack:
 class TransitionFront:
     """The entered side of a transition between regions."""
 
-    def __init__(self, dest, logic, exitShuffleId=None, assumed=False):
+    def __init__(self, dest, logic, exitShuffleId=None, assumed=False, time=Time.Both,):
         """Initialize with given parameters."""
         self.dest = dest  # Planning to remove this
         self.logic = logic  # Lambda function for accessibility
         self.exitShuffleId = exitShuffleId  # Planning to remove this
+        self.time = time
         self.assumed = assumed  # Indicates this is an assumed exit attached to the root

--- a/randomizer/LogicClasses.py
+++ b/randomizer/LogicClasses.py
@@ -171,7 +171,14 @@ class TransitionBack:
 class TransitionFront:
     """The entered side of a transition between regions."""
 
-    def __init__(self, dest, logic, exitShuffleId=None, assumed=False, time=Time.Both,):
+    def __init__(
+        self,
+        dest,
+        logic,
+        exitShuffleId=None,
+        assumed=False,
+        time=Time.Both,
+    ):
         """Initialize with given parameters."""
         self.dest = dest  # Planning to remove this
         self.logic = logic  # Lambda function for accessibility

--- a/randomizer/LogicFiles/AngryAztec.py
+++ b/randomizer/LogicFiles/AngryAztec.py
@@ -19,7 +19,8 @@ LogicRegions = {
         LocationLogic(Locations.AztecChunkyMedal, lambda l: l.ColoredBananas[Levels.AngryAztec][Kongs.chunky] >= 75),
         LocationLogic(Locations.AztecDonkeyFreeLlama, lambda l: Events.LlamaFreed in l.Events and l.donkey),
         LocationLogic(Locations.AztecChunkyVases, lambda l: l.pineapple and l.chunky),
-        LocationLogic(Locations.AztecKasplatSandyBridge, lambda l: l.coconut),
+        # If default damage can just walk to the bridge and take damage with any kong, otherwise need strong kong and to be donkey
+        LocationLogic(Locations.AztecKasplatSandyBridge, lambda l: l.coconut and ((l.strongKong and l.isdonkey) or l.settings.damage_amount == "default")),
         LocationLogic(Locations.AztecKasplatOnTinyTemple, lambda l: l.jetpack),
     ], [
         Event(Events.AztecEntered, lambda l: True),

--- a/randomizer/LogicFiles/CreepyCastle.py
+++ b/randomizer/LogicFiles/CreepyCastle.py
@@ -67,7 +67,7 @@ LogicRegions = {
 
     Regions.Library: Region("Library", Levels.CreepyCastle, False, -1, [
         # Another case where you're supposed to use Strong Kong but it can be brute forced
-        LocationLogic(Locations.CastleDonkeyLibrary, lambda l: l.superDuperSlam and l.isdonkey),
+        LocationLogic(Locations.CastleDonkeyLibrary, lambda l: l.superDuperSlam and l.isdonkey and (l.strongKong or l.settings.damage_amount == "default")),
     ], [], [
         TransitionFront(Regions.CreepyCastleMain, lambda l: True, Transitions.CastleLibraryStartToMain),
         TransitionFront(Regions.CreepyCastleMain, lambda l: l.superDuperSlam and l.isdonkey, Transitions.CastleLibraryEndToMain),

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -174,7 +174,7 @@ LogicRegions = {
     ]),
 
     Regions.MillTinyArea: Region("Mill Tiny Area", Levels.FungiForest, False, -1, [], [], [
-        TransitionFront(Regions.MillArea, lambda l: l.mini and l.istiny, Transitions.ForestTinyMillToMain),
+        TransitionFront(Regions.MillArea, lambda l: Events.MillBoxBroken in l.Events and l.mini and l.istiny, Transitions.ForestTinyMillToMain),
         TransitionFront(Regions.MillChunkyArea, lambda l: True),
         TransitionFront(Regions.SpiderRoom, lambda l: True, Transitions.ForestTinyMillToSpider, time=Time.Night),
         TransitionFront(Regions.GrinderRoom, lambda l: l.mini and l.istiny, Transitions.ForestTinyMillToGrinder),
@@ -218,8 +218,8 @@ LogicRegions = {
         LocationLogic(Locations.ForestKasplatNearBarn, lambda l: True),
     ], [], [
         TransitionFront(Regions.MillArea, lambda l: True, time=Time.Night),
-        # You're supposed to use strong kong to hit the switch in the thorns, but can brute force it
-        TransitionFront(Regions.ThornvineBarn, lambda l: l.superSlam and l.isdonkey, Transitions.ForestMainToBarn),
+        # You're supposed to use strong kong to hit the switch in the thorns, but can brute force it, unless on higher damage values
+        TransitionFront(Regions.ThornvineBarn, lambda l: l.superSlam and l.isdonkey and (l.strongKong or l.settings.damage_amount == "default"), Transitions.ForestMainToBarn),
         TransitionFront(Regions.ForestBossLobby, lambda l: True),
     ]),
 

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -6,6 +6,7 @@ from randomizer.Enums.Kongs import Kongs
 from randomizer.Enums.Levels import Levels
 from randomizer.Enums.Locations import Locations
 from randomizer.Enums.Regions import Regions
+from randomizer.Enums.Time import Time
 from randomizer.Enums.Transitions import Transitions
 from randomizer.LogicClasses import (Event, LocationLogic, Region,
                                      TransitionFront)
@@ -89,13 +90,13 @@ LogicRegions = {
     # This region basically just exists to facilitate the two entrances into upper mushroom
     Regions.MushroomNightDoor: Region("Mushroom Night Door", Levels.FungiForest, False, None, [], [], [
         TransitionFront(Regions.MushroomUpper, lambda l: True),
-        TransitionFront(Regions.MushroomNightExterior, lambda l: Events.Night in l.Events, Transitions.ForestNightToExterior),
+        TransitionFront(Regions.MushroomNightExterior, lambda l: True, Transitions.ForestNightToExterior, time=Time.Night),
     ]),
 
     Regions.MushroomNightExterior: Region("Mushroom Night Exterior", Levels.FungiForest, False, None, [
         LocationLogic(Locations.ForestKasplatUpperMushroomExterior, lambda l: True),
     ], [], [
-        TransitionFront(Regions.MushroomNightDoor, lambda l: Events.Night in l.Events, Transitions.ForestExteriorToNight),
+        TransitionFront(Regions.MushroomNightDoor, lambda l: True, Transitions.ForestExteriorToNight, time=Time.Night),
         TransitionFront(Regions.GiantMushroomArea, lambda l: True),
     ]),
 
@@ -130,8 +131,8 @@ LogicRegions = {
     ]),
 
     Regions.HollowTreeArea: Region("Hollow Tree Area", Levels.FungiForest, True, -1, [
-        LocationLogic(Locations.ForestDiddyOwlRace, lambda l: Events.Night in l.Events and l.jetpack and l.guitar and l.isdiddy, True),
-        LocationLogic(Locations.ForestLankyRabbitRace, lambda l: l.trombone and l.sprint and l.lanky),
+        LocationLogic(Locations.ForestDiddyOwlRace, lambda l: l.TimeAccess(Regions.HollowTreeArea, Time.Night) and l.jetpack and l.guitar and l.isdiddy, True),
+        LocationLogic(Locations.ForestLankyRabbitRace, lambda l: l.TimeAccess(Regions.HollowTreeArea, Time.Day) and l.trombone and l.sprint and l.lanky),
         LocationLogic(Locations.ForestKasplatOwlTree, lambda l: True),
     ], [], [
         TransitionFront(Regions.GiantMushroomArea, lambda l: Events.HollowTreeGateOpened in l.Events),
@@ -148,19 +149,19 @@ LogicRegions = {
     ]),
 
     Regions.MillArea: Region("Mill Area", Levels.FungiForest, True, None, [
-        LocationLogic(Locations.ForestDonkeyMill, lambda l: Events.ConveyorActivated in l.Events and Events.Night in l.Events and l.donkey),
-        LocationLogic(Locations.ForestDiddyCagedBanana, lambda l: Events.WinchRaised in l.Events and Events.Night in l.Events and l.diddy),
+        LocationLogic(Locations.ForestDonkeyMill, lambda l: l.TimeAccess(Regions.MillArea, Time.Night) and Events.ConveyorActivated in l.Events and l.donkey),
+        LocationLogic(Locations.ForestDiddyCagedBanana, lambda l: l.TimeAccess(Regions.MillArea, Time.Night) and Events.WinchRaised in l.Events and l.diddy),
     ], [], [
         TransitionFront(Regions.FungiForestStart, lambda l: True),
-        TransitionFront(Regions.MillChunkyArea, lambda l: l.punch and l.ischunky, Transitions.ForestMainToChunkyMill),
+        TransitionFront(Regions.MillChunkyArea, lambda l: l.punch and l.ischunky, Transitions.ForestMainToChunkyMill, time=Time.Day),
         TransitionFront(Regions.MillTinyArea, lambda l: Events.MillBoxBroken in l.Events and l.mini and l.istiny, Transitions.ForestMainToTinyMill),
-        TransitionFront(Regions.GrinderRoom, lambda l: True, Transitions.ForestMainToGrinder),
-        TransitionFront(Regions.MillRafters, lambda l: Events.Night in l.Events and l.spring and l.isdiddy, Transitions.ForestMainToRafters),
-        TransitionFront(Regions.WinchRoom, lambda l: Events.Night in l.Events and l.superSlam and l.isdiddy, Transitions.ForestMainToWinch),
-        TransitionFront(Regions.MillAttic, lambda l: Events.Night in l.Events, Transitions.ForestMainToAttic),
-        TransitionFront(Regions.ThornvineArea, lambda l: Events.Night in l.Events),
-        TransitionFront(Regions.Snide, lambda l: True),
-        TransitionFront(Regions.ForestBossLobby, lambda l: True),
+        TransitionFront(Regions.GrinderRoom, lambda l: True, Transitions.ForestMainToGrinder, time=Time.Day),
+        TransitionFront(Regions.MillRafters, lambda l: l.spring and l.isdiddy, Transitions.ForestMainToRafters, time=Time.Night),
+        TransitionFront(Regions.WinchRoom, lambda l: l.superSlam and l.isdiddy, Transitions.ForestMainToWinch, time=Time.Night),
+        TransitionFront(Regions.MillAttic, lambda l: True, Transitions.ForestMainToAttic, time=Time.Night),
+        TransitionFront(Regions.ThornvineArea, lambda l: True, time=Time.Night),
+        TransitionFront(Regions.Snide, lambda l: True, time=Time.Day),
+        TransitionFront(Regions.ForestBossLobby, lambda l: True, time=Time.Day),
     ]),
 
     # Physically chunky and tiny share an area but they're split for logical convenience
@@ -168,14 +169,14 @@ LogicRegions = {
         Event(Events.GrinderActivated, lambda l: l.triangle and l.ischunky),
         Event(Events.MillBoxBroken, lambda l: l.punch and l.ischunky),
     ], [
-        TransitionFront(Regions.MillArea, lambda l: l.ischunky, Transitions.ForestChunkyMillToMain),
+        TransitionFront(Regions.MillArea, lambda l: l.ischunky, Transitions.ForestChunkyMillToMain, time=Time.Day),
         TransitionFront(Regions.MillTinyArea, lambda l: True),
     ]),
 
     Regions.MillTinyArea: Region("Mill Tiny Area", Levels.FungiForest, False, -1, [], [], [
         TransitionFront(Regions.MillArea, lambda l: l.mini and l.istiny, Transitions.ForestTinyMillToMain),
         TransitionFront(Regions.MillChunkyArea, lambda l: True),
-        TransitionFront(Regions.SpiderRoom, lambda l: Events.Night in l.Events, Transitions.ForestTinyMillToSpider),
+        TransitionFront(Regions.SpiderRoom, lambda l: True, Transitions.ForestTinyMillToSpider, time=Time.Night),
         TransitionFront(Regions.GrinderRoom, lambda l: l.mini and l.istiny, Transitions.ForestTinyMillToGrinder),
     ]),
 
@@ -190,7 +191,7 @@ LogicRegions = {
     ], [
         Event(Events.ConveyorActivated, lambda l: l.superSlam and l.grab and l.donkey),
     ], [
-        TransitionFront(Regions.MillArea, lambda l: True, Transitions.ForestGrinderToMain),
+        TransitionFront(Regions.MillArea, lambda l: True, Transitions.ForestGrinderToMain, time=Time.Day),
         TransitionFront(Regions.MillTinyArea, lambda l: l.mini and l.istiny, Transitions.ForestGrinderToTinyMill),
     ]),
 
@@ -216,7 +217,7 @@ LogicRegions = {
     Regions.ThornvineArea: Region("Thornvine Area", Levels.FungiForest, True, -1, [
         LocationLogic(Locations.ForestKasplatNearBarn, lambda l: True),
     ], [], [
-        TransitionFront(Regions.MillArea, lambda l: Events.Night in l.Events),
+        TransitionFront(Regions.MillArea, lambda l: True, time=Time.Night),
         # You're supposed to use strong kong to hit the switch in the thorns, but can brute force it
         TransitionFront(Regions.ThornvineBarn, lambda l: l.superSlam and l.isdonkey, Transitions.ForestMainToBarn),
         TransitionFront(Regions.ForestBossLobby, lambda l: True),
@@ -235,7 +236,7 @@ LogicRegions = {
     ], [], [
         TransitionFront(Regions.FungiForestStart, lambda l: True),
         TransitionFront(Regions.FunkyForest, lambda l: True),
-        TransitionFront(Regions.ForestBossLobby, lambda l: Events.Night in l.Events),
+        TransitionFront(Regions.ForestBossLobby, lambda l: True, time=Time.Night),
     ]),
 
     Regions.ForestBossLobby: Region("Forest Boss Lobby", Levels.FungiForest, True, None, [], [], [


### PR DESCRIPTION
Previously, exits which required day were just assumed to be okay, and night exits only required access to change time of day. I hoped this was sufficient, but it was not. Thus, a more complex time of day system has been added.

It basically works by each region having a dayAccess and nightAccess variable. When you start, the starting region is granted day access, and night access if the night switch has been reached since night persists across resets. Night access is also granted to the forest start region when the night switch is reached there.

When an exit is checked, the source region will transfer its dayAccess status to the destination unless the exit is night-only, and vice versa. This causes the time access variables to propagate across the world graph, but be stopped at exits which restrict the time. This should be proper functionality to ensure correct time logic.

If an exit requires a certain time (indicated by the TransitionFront class's new property, time) and the region does not have that time access, it will not be traversed. Locations and collectibles use the new TimeAccess logic function which checks if the parent region has a certain time access available.

Time access variables are reset in the region's reset function. If a region gains a new time access, this counts as an event being added so that another search can be done if necessary, since this could grant new locations.

Also has a couple more minor logic fixes:
1) Logic was not originally written with high damage multipliers in mind. There are 3 places logic expect you to go without strong kong and take damage: The sandy bridge kasplat in Aztec, the thornvine switch in Forest, and the library in Castle. These have been fixed so you're only expected to take damage with a default damage multiplier, to be safe since even a double damage multiplier could easily kill you in these places if you're hit twice.
2) Tiny's exit from the back of the mill to outside didn't require the box to be broken