### PR TITLE
Add simple html spoiler tracker

### DIFF
--- a/GenTracker.py
+++ b/GenTracker.py
@@ -1,0 +1,52 @@
+"""File which generates a basic HTML tracker table for your seed."""
+import js
+import json
+
+
+def generateTracker(spoilerJson):
+    """Use the tracker template and spoiler data to generate a basic tracker."""
+    tracker = js.getFile("./TrackerTemplate.html")
+    spoiler = json.loads(spoilerJson)
+
+    header = "<!--Start Generated Content-->"
+
+    start = tracker.index(header) + len(header)
+
+    generated = "\n"
+    generated += "<h4>Seed: " + spoiler["Settings"]["seed"] + "</h4>\n"
+
+    if "Locations" in spoiler:
+        generated += "<h3>Locations</h3>\n"
+        generated += "<table>\n"
+        i = 0
+        for location, item in spoiler["Locations"].items():
+            generated += "<tr>\n"
+            generated += '<td id="loc_' + str(i) + '">' + location + "</td>\n"
+            generated += '<td class="check-cell"><input id="itemCheck_' + str(i) + '" type="checkbox" onclick="showRow(\'item\', ' + str(i) + ')"/></td>\n'
+            generated += '<td id="item_' + str(i) + '" class="spoiler">' + item + "</td>\n"
+            generated += "</tr>\n"
+            i += 1
+        generated += "</table>\n"
+        generated += '<input type="hidden" id="locCount" value="' + str(i) + '">'
+    else:
+        generated += '<input type="hidden" id="locCount" value="0">'
+
+    if "Shuffled Exits" in spoiler:
+        generated += "<h3>Exits</h3>\n"
+        generated += "<table>\n"
+        i = 0
+        for front, back in spoiler["Shuffled Exits"].items():
+            generated += "<tr>\n"
+            generated += '<td id="front_' + str(i) + '">' + front + "</td>\n"
+            generated += '<td class="check-cell"><input id="backCheck_' + str(i) + '" type="checkbox" onclick="showRow(\'back\', ' + str(i) + ')"/></td>\n'
+            generated += '<td id="back_' + str(i) + '" class="spoiler">' + back + "</td>\n"
+            generated += "</tr>\n"
+            i += 1
+        generated += "</table>\n"
+        generated += '<input type="hidden" id="exitCount" value="' + str(i) + '">'
+    else:
+        generated += '<input type="hidden" id="exitCount" value="0">'
+
+    tracker = tracker[:start] + generated + tracker[start:]
+
+    return tracker

--- a/TrackerTemplate.html
+++ b/TrackerTemplate.html
@@ -1,0 +1,159 @@
+<html>
+    <head>
+        <style>
+            body {
+                color: #e3e3e3;
+                background-color: #212529;
+                font-family: "Lato", -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;;
+                font-size: 1rem;
+                line-height: 1.5rem;
+                font-weight: 400;
+            }
+
+            h3 {
+                font-size: 1.75rem;
+                font-family: "Catamaran", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+                margin-top: 0;
+                margin-bottom: 1rem;
+            }
+
+            h4 {
+                font-size: 1.5rem;
+                font-family: "Catamaran", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+                margin-top: 0;
+                margin-bottom: 1rem;
+            }
+
+            table {
+                width: 100%;
+                margin-bottom: 1rem;
+                vertical-align: top;
+                text-align: center;
+            }
+
+            tr:nth-child(even) {
+                background-color: #2c3034;
+            }
+
+            td {
+                width: 44.5%;
+            }
+
+            .check-cell {
+                width: 1%;
+            }
+
+            .state-row {
+                display: flex;
+                justify-content: flex-start;
+                margin-top: 1rem;
+                margin-bottom: 1rem;
+            }
+
+            .state-text {
+                margin: 0;
+            }
+
+            .state-item {
+                margin-right: 1rem!important;
+            }
+
+            .btn {
+                color: #fff;
+                background-color: #6c757d;
+                border-color: #6c757d;
+                border-style: solid;
+                border-radius: .25rem;
+                transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+            }
+            .btn:hover {
+                color: #fff;
+                background-color: #08caca;
+                border-color: #08caca;
+            }
+            .btn:active
+            {
+                border-color: black;
+            }
+
+            .spoiler {
+                background-color: gray;
+                color: gray;
+            }
+            .spoiler:hover {
+                background-color: transparent;
+                color: #e3e3e3;
+            }
+
+        </style>
+    </head>
+    <body>
+        <div class="state-row">
+            <h4 class="state-text state-item">Tracker State: </h4>
+            <input id="state" class="state-item" type="text"/><br/>
+            <button type="button" class="btn state-item" onclick="loadState()">Load State</button>
+        </div>
+        <!--Start Generated Content-->
+    </body>
+    <script>
+        function showRow(prefix, index, update=true) {
+            id = prefix + "_" + index;
+            checkId = prefix + "Check_" + index;
+            var row = document.getElementById(id);
+            var checkbox = document.getElementById(checkId);
+            if (checkbox.checked) {
+                row.classList.remove("spoiler");
+            }
+            else {
+                row.classList.add("spoiler");
+            }
+            if (update) {
+                updateState();
+            }
+        }
+
+        locCount = document.getElementById("locCount").value;
+        exitCount = document.getElementById("exitCount").value;
+
+        function updateState() {
+            state = {};
+            locations = {};
+            if (locCount > 0) {
+                for (var i = 0; i < locCount; i++) {
+                    checked = document.getElementById("itemCheck_" + i).checked;
+                    locations["loc_" + i] = checked;
+                }
+                state["locations"] = locations;
+            }
+            exits = {};
+            if (exitCount > 0) {
+                for (var i = 0; i < exitCount; i++) {
+                    checked = document.getElementById("backCheck_" + i).checked;
+                    exits["exit_" + i] = checked;
+                }
+                state["exits"] = exits;
+            }
+            stateEncoded = btoa(JSON.stringify(state));
+            document.getElementById("state").value = stateEncoded;
+        }
+
+        function loadState() {
+            stateEncoded = document.getElementById("state").value;
+            state = JSON.parse(atob(stateEncoded));
+            if ("locations" in state) {
+                for (const [key, value] of Object.entries(state["locations"])) {
+                    index = key.replace("loc_", "");
+                    document.getElementById("itemCheck_" + index).checked = value;
+                    showRow("item", index, false);
+                }
+            }
+            if ("exits" in state) {
+                for (const [key, value] of Object.entries(state["exits"])) {
+                    index = key.replace("exit_", "");
+                    document.getElementById("backCheck_" + index).checked = value;
+                    showRow("back", index, false);
+                }
+            }
+        }
+    </script>
+</html>

--- a/randomizer/Patching/ApplyRandomizer.py
+++ b/randomizer/Patching/ApplyRandomizer.py
@@ -24,6 +24,7 @@ from randomizer.Patching.Patcher import ROM
 from randomizer.Patching.PriceRando import randomize_prices
 from randomizer.Patching.PuzzleRando import randomize_puzzles
 from randomizer.Patching.UpdateHints import PushHints, wipeHints
+from GenTracker import generateTracker
 
 # from randomizer.Spoiler import Spoiler
 from randomizer.Settings import Settings
@@ -303,8 +304,10 @@ def patching_response(responded_data):
     if spoiler.settings.generate_spoilerlog is True:
         js.document.getElementById("spoiler_log_block").style.display = ""
         js.document.getElementById("spoiler_log_text").value = spoiler.toJson()
+        js.document.getElementById("tracker_text").value = generateTracker(spoiler.toJson())
     else:
         js.document.getElementById("spoiler_log_text").value = ""
+        js.document.getElementById("tracker_text").value = ""
         js.document.getElementById("spoiler_log_block").style.display = "none"
 
     js.document.getElementById("generated_seed_id").innerHTML = spoiler.settings.seed_id

--- a/templates/settings.html.jinja2
+++ b/templates/settings.html.jinja2
@@ -42,9 +42,15 @@
             </div>
         </div>
     </div>
+    <textarea id="tracker_text" hidden readonly></textarea>
     <button class="btn btn-primary"
             type="button"
             onClick="save_text_as_file(document.getElementById('spoiler_log_text').value, document.getElementById('generated_seed_id').innerHTML + '-spoilerlog.json')">
         Save Log
+    </button>
+    <button class="btn btn-primary"
+            type="button"
+            onClick="save_text_as_file(document.getElementById('tracker_text').value, document.getElementById('generated_seed_id').innerHTML + '-tracker.html')">
+        Save Tracker
     </button>
 </div>


### PR DESCRIPTION
Adds a simple HTML tracker for item locations and entrances. It uses an HTML template with some generated tables based on the spoiler, and can be downloaded from the site alongside the spoiler. The tracker is shown in the image below. The "answers" to each location and exit are "spoilered" by being hidden, unless you mouse over them, or check that row's checkbox. When you check the checkbox, that row will stay unhidden. The tracker also updates a "state" text field which keeps track of which checkboxes are checked. (The state string is just a base64 encoding of a json). If you save this string between sessions, you can put it back into the state box and hit "Load State" to load all the checkboxes you checked in your previous session.

For the CSS of the page, I copied values for colors, fonts, and sizes from the main website so that it has a uniform look with the site. I'm sure the look could be improved, but since the purpose of the tracker is meant to be a self-contained HTML file, options are fairly limited.
![image](https://user-images.githubusercontent.com/30701749/174461732-d2102c26-e0c3-4bf6-8b49-26e0699be01a.png)

More information could be added to the tracker as well potentially, but I didn't see anything else from the spoiler being particularly necessary.
