### PR TITLE
Split off crown and speed randomizers

### DIFF
--- a/randomizer/Patching/EnemyRando.py
+++ b/randomizer/Patching/EnemyRando.py
@@ -267,7 +267,7 @@ def randomize_enemies(spoiler: Spoiler):
                                                     ROM().writeMultipleBytes(agg_speed, 1)
                                                     ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xC)
                                                     ROM().writeMultipleBytes(random.randint(min_speed, agg_speed), 1)
-            if spoiler.settings.crown_rando and cont_map_id in crown_maps:
+            if spoiler.settings.crown_enemy_rando and cont_map_id in crown_maps:
                 crown_index = 0
                 for spawner in vanilla_spawners:
                     if spawner["enemy_id"] in crown_enemies:

--- a/randomizer/Patching/EnemyRando.py
+++ b/randomizer/Patching/EnemyRando.py
@@ -258,15 +258,16 @@ def randomize_enemies(spoiler: Spoiler):
                                                 if default_scale > EnemyMetaData[new_enemy_id].size_cap:
                                                     ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xF)
                                                     ROM().writeMultipleBytes(EnemyMetaData[new_enemy_id].size_cap, 1)
-                                            min_speed = EnemyMetaData[new_enemy_id].min_speed
-                                            max_speed = EnemyMetaData[new_enemy_id].max_speed
-                                            if min_speed > 0 and max_speed > 0:
-                                                ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xD)
-                                                agg_speed = random.randint(min_speed, max_speed)
-                                                ROM().writeMultipleBytes(agg_speed, 1)
-                                                ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xC)
-                                                ROM().writeMultipleBytes(random.randint(min_speed, agg_speed), 1)
-            if spoiler.settings.enemy_rando and cont_map_id in crown_maps:  # TODO: Change the first condition to a unique condition
+                                            if spoiler.settings.enemy_speed_rando:
+                                                min_speed = EnemyMetaData[new_enemy_id].min_speed
+                                                max_speed = EnemyMetaData[new_enemy_id].max_speed
+                                                if min_speed > 0 and max_speed > 0:
+                                                    ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xD)
+                                                    agg_speed = random.randint(min_speed, max_speed)
+                                                    ROM().writeMultipleBytes(agg_speed, 1)
+                                                    ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xC)
+                                                    ROM().writeMultipleBytes(random.randint(min_speed, agg_speed), 1)
+            if spoiler.settings.crown_rando and cont_map_id in crown_maps:
                 crown_index = 0
                 for spawner in vanilla_spawners:
                     if spawner["enemy_id"] in crown_enemies:
@@ -289,14 +290,15 @@ def randomize_enemies(spoiler: Spoiler):
                                 if default_scale > EnemyMetaData[new_enemy_id].size_cap:
                                     ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xF)
                                     ROM().writeMultipleBytes(EnemyMetaData[new_enemy_id].size_cap, 1)
-                            min_speed = EnemyMetaData[new_enemy_id].min_speed
-                            max_speed = EnemyMetaData[new_enemy_id].max_speed
-                            if min_speed > 0 and max_speed > 0:
-                                ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xD)
-                                agg_speed = random.randint(min_speed, max_speed)
-                                ROM().writeMultipleBytes(agg_speed, 1)
-                                ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xC)
-                                ROM().writeMultipleBytes(random.randint(min_speed, agg_speed), 1)
+                            if spoiler.settings.enemy_speed_rando:
+                                min_speed = EnemyMetaData[new_enemy_id].min_speed
+                                max_speed = EnemyMetaData[new_enemy_id].max_speed
+                                if min_speed > 0 and max_speed > 0:
+                                    ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xD)
+                                    agg_speed = random.randint(min_speed, max_speed)
+                                    ROM().writeMultipleBytes(agg_speed, 1)
+                                    ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xC)
+                                    ROM().writeMultipleBytes(random.randint(min_speed, agg_speed), 1)
                     elif spawner["enemy_id"] == Enemies.BattleCrownController:
                         ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xB)
                         ROM().writeMultipleBytes(random.randint(5, 60), 1)  # Determine Crown length. DK64 caps at 255 seconds

--- a/static/presets/2dos_special.json
+++ b/static/presets/2dos_special.json
@@ -4,7 +4,7 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
-    "crown_rando":true,
+    "crown_enemy_rando":true,
     "enemy_speed_rando":true,
     "krool_phase_order_rando":true,
     "boss_kong_rando":true,

--- a/static/presets/2dos_special.json
+++ b/static/presets/2dos_special.json
@@ -4,6 +4,8 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
+    "crown_rando":true,
+    "enemy_speed_rando":true,
     "krool_phase_order_rando":true,
     "boss_kong_rando":true,
     "boss_location_rando":true,

--- a/static/presets/coupled_lzr_balanced.json
+++ b/static/presets/coupled_lzr_balanced.json
@@ -4,7 +4,7 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
-    "crown_rando":true,
+    "crown_enemy_rando":true,
     "enemy_speed_rando":true,
     "krool_phase_order_rando":true,
     "boss_kong_rando":true,

--- a/static/presets/coupled_lzr_balanced.json
+++ b/static/presets/coupled_lzr_balanced.json
@@ -4,6 +4,8 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
+    "crown_rando":true,
+    "enemy_speed_rando":true,
     "krool_phase_order_rando":true,
     "boss_kong_rando":true,
     "boss_location_rando":true,

--- a/static/presets/decoupled_lzr_balanced.json
+++ b/static/presets/decoupled_lzr_balanced.json
@@ -4,7 +4,7 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
-    "crown_rando":true,
+    "crown_enemy_rando":true,
     "enemy_speed_rando":true,
     "krool_phase_order_rando":true,
     "boss_kong_rando":true,

--- a/static/presets/decoupled_lzr_balanced.json
+++ b/static/presets/decoupled_lzr_balanced.json
@@ -4,6 +4,8 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
+    "crown_rando":true,
+    "enemy_speed_rando":true,
     "krool_phase_order_rando":true,
     "boss_kong_rando":true,
     "boss_location_rando":true,

--- a/static/presets/go_bananas.json
+++ b/static/presets/go_bananas.json
@@ -4,7 +4,7 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
-    "crown_rando":true,
+    "crown_enemy_rando":true,
     "enemy_speed_rando":true,
     "krool_phase_order_rando":true,
     "boss_kong_rando":true,

--- a/static/presets/go_bananas.json
+++ b/static/presets/go_bananas.json
@@ -4,6 +4,8 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
+    "crown_rando":true,
+    "enemy_speed_rando":true,
     "krool_phase_order_rando":true,
     "boss_kong_rando":true,
     "boss_location_rando":true,

--- a/static/presets/hell.json
+++ b/static/presets/hell.json
@@ -4,7 +4,7 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
-    "crown_rando":true,
+    "crown_enemy_rando":true,
     "enemy_speed_rando":true,
     "krool_phase_order_rando":true,
     "boss_kong_rando":true,

--- a/static/presets/hell.json
+++ b/static/presets/hell.json
@@ -4,6 +4,8 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
+    "crown_rando":true,
+    "enemy_speed_rando":true,
     "krool_phase_order_rando":true,
     "boss_kong_rando":true,
     "boss_location_rando":true,

--- a/static/presets/level_order_balanced.json
+++ b/static/presets/level_order_balanced.json
@@ -4,7 +4,7 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
-    "crown_rando":true,
+    "crown_enemy_rando":true,
     "enemy_speed_rando":true,
     "krool_phase_order_rando":true,
     "boss_kong_rando":true,

--- a/static/presets/level_order_balanced.json
+++ b/static/presets/level_order_balanced.json
@@ -4,6 +4,8 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
+    "crown_rando":true,
+    "enemy_speed_rando":true,
     "krool_phase_order_rando":true,
     "boss_kong_rando":true,
     "boss_location_rando":true,

--- a/static/presets/suggested.json
+++ b/static/presets/suggested.json
@@ -4,7 +4,7 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
-    "crown_rando":true,
+    "crown_enemy_rando":true,
     "enemy_speed_rando":true,
     "krool_phase_order_rando": true,
     "boss_kong_rando": true,

--- a/static/presets/suggested.json
+++ b/static/presets/suggested.json
@@ -4,6 +4,8 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":true,
+    "crown_rando":true,
+    "enemy_speed_rando":true,
     "krool_phase_order_rando": true,
     "boss_kong_rando": true,
     "boss_location_rando": true,

--- a/static/presets/vanillaesque.json
+++ b/static/presets/vanillaesque.json
@@ -4,6 +4,8 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":false,
+    "crown_rando":false,
+    "enemy_speed_rando":false,
     "krool_phase_order_rando":false,
     "boss_kong_rando":true,
     "boss_location_rando":true,

--- a/static/presets/vanillaesque.json
+++ b/static/presets/vanillaesque.json
@@ -4,7 +4,7 @@
     "fast_start_beginning_of_game":true,
     "unlock_all_moves":false,
     "enemy_rando":false,
-    "crown_rando":false,
+    "crown_enemy_rando":false,
     "enemy_speed_rando":false,
     "krool_phase_order_rando":false,
     "boss_kong_rando":true,

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -28,6 +28,22 @@
                                 Shuffle Enemies
                             </label>
                         </div>
+                        <div class="form-check form-switch w-75">
+                            <label data-toggle="tooltip" title="Battle crown enemies are randomized." style="font-size:14px; margin-right:2.75em;">
+                                <input class="form-check-input"
+                                    type="checkbox"
+                                    name="crown_rando"
+                                    value="True"/>
+                                Shuffle Crowns
+                            </label>
+                            <label data-toggle="tooltip" title="Enemy speeds are randomized." style="font-size:14px;">
+                                <input class="form-check-input"
+                                    type="checkbox"
+                                    name="enemy_speed_rando"
+                                    value="True"/>
+                                Shuffle Speed
+                            </label>
+                        </div>
                     </td>
                 </tr>
                 <tr>

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -29,19 +29,21 @@
                             </label>
                         </div>
                         <div class="form-check form-switch w-75">
-                            <label data-toggle="tooltip" title="Battle crown enemies are randomized." style="font-size:14px; margin-right:2.75em;">
+                            <label data-toggle="tooltip" title="Battle crown enemies are randomized.">
                                 <input class="form-check-input"
                                     type="checkbox"
                                     name="crown_enemy_rando"
                                     value="True"/>
-                                Shuffle Crowns
+                                Shuffle Crown Enemies
                             </label>
-                            <label data-toggle="tooltip" title="Enemy speeds are randomized." style="font-size:14px;">
+                        </div>
+                        <div class="form-check form-switch w-75">
+                            <label data-toggle="tooltip" title="Enemy speeds are randomized.">
                                 <input class="form-check-input"
                                     type="checkbox"
                                     name="enemy_speed_rando"
                                     value="True"/>
-                                Shuffle Speed
+                                Shuffle Enemy Speed
                             </label>
                         </div>
                     </td>

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -32,7 +32,7 @@
                             <label data-toggle="tooltip" title="Battle crown enemies are randomized." style="font-size:14px; margin-right:2.75em;">
                                 <input class="form-check-input"
                                     type="checkbox"
-                                    name="crown_rando"
+                                    name="crown_enemy_rando"
                                     value="True"/>
                                 Shuffle Crowns
                             </label>


### PR DESCRIPTION
Splits off crown enemy randomizing and enemy speed randomizing from the base enemy type randomizing.

Open to suggestions on the preset edits. I left them unchanged from live site behavior.