### PR TITLE
Add setting and logic for open levels

### DIFF
--- a/randomizer/LogicFiles/AngryAztec.py
+++ b/randomizer/LogicFiles/AngryAztec.py
@@ -29,7 +29,7 @@ LogicRegions = {
         TransitionFront(Regions.AngryAztecLobby, lambda l: True, Transitions.AztecToIsles),
         TransitionFront(Regions.TempleStart, lambda l: (l.peanut and l.isdiddy) or (l.grape and l.islanky)
                         or (l.feather and l.istiny) or (l.pineapple and l.ischunky)),
-        TransitionFront(Regions.AngryAztecMain, lambda l: l.guitar and l.diddy),
+        TransitionFront(Regions.AngryAztecMain, lambda l: l.settings.open_levels or (l.guitar and l.diddy)),
         TransitionFront(Regions.CandyAztec, lambda l: True),
         TransitionFront(Regions.AztecBossLobby, lambda l: True),
     ]),

--- a/randomizer/LogicFiles/CrystalCaves.py
+++ b/randomizer/LogicFiles/CrystalCaves.py
@@ -75,11 +75,11 @@ LogicRegions = {
     ], [], [
         TransitionFront(Regions.CrystalCavesMain, lambda l: True),
         TransitionFront(Regions.GiantKosha, lambda l: Events.CavesLargeBoulderButton in l.Events and l.monkeyport and l.istiny),
-        TransitionFront(Regions.DonkeyIgloo, lambda l: l.jetpack and l.bongos and l.isdonkey, Transitions.CavesIglooToDonkey),
-        TransitionFront(Regions.DiddyIgloo, lambda l: l.jetpack and l.guitar and l.isdiddy, Transitions.CavesIglooToDiddy),
-        TransitionFront(Regions.LankyIgloo, lambda l: l.jetpack and l.trombone and l.islanky, Transitions.CavesIglooToLanky),
-        TransitionFront(Regions.TinyIgloo, lambda l: l.jetpack and l.saxophone and l.istiny, Transitions.CavesIglooToTiny),
-        TransitionFront(Regions.ChunkyIgloo, lambda l: l.jetpack and l.triangle and l.ischunky, Transitions.CavesIglooToChunky),
+        TransitionFront(Regions.DonkeyIgloo, lambda l: (l.settings.open_levels or l.jetpack) and l.bongos and l.isdonkey, Transitions.CavesIglooToDonkey),
+        TransitionFront(Regions.DiddyIgloo, lambda l: (l.settings.open_levels or l.jetpack) and l.guitar and l.isdiddy, Transitions.CavesIglooToDiddy),
+        TransitionFront(Regions.LankyIgloo, lambda l: (l.settings.open_levels or l.jetpack) and l.trombone and l.islanky, Transitions.CavesIglooToLanky),
+        TransitionFront(Regions.TinyIgloo, lambda l: (l.settings.open_levels or l.jetpack) and l.saxophone and l.istiny, Transitions.CavesIglooToTiny),
+        TransitionFront(Regions.ChunkyIgloo, lambda l: (l.settings.open_levels or l.jetpack) and l.triangle and l.ischunky, Transitions.CavesIglooToChunky),
     ]),
 
     Regions.GiantKosha: Region("Giant Kosha", Levels.CrystalCaves, False, -1, [], [

--- a/randomizer/LogicFiles/FranticFactory.py
+++ b/randomizer/LogicFiles/FranticFactory.py
@@ -24,7 +24,7 @@ LogicRegions = {
         Event(Events.HatchOpened, lambda l: l.Slam),
     ], [
         TransitionFront(Regions.FranticFactoryLobby, lambda l: True, Transitions.FactoryToIsles),
-        TransitionFront(Regions.Testing, lambda l: Events.TestingGateOpened in l.Events),
+        TransitionFront(Regions.Testing, lambda l: l.settings.open_levels or Events.TestingGateOpened in l.Events),
         # Hatch opened already in rando if loading zones randomized
         TransitionFront(Regions.BeyondHatch, lambda l: l.settings.shuffle_loading_zones == "all" or Events.HatchOpened in l.Events),
     ]),
@@ -82,7 +82,7 @@ LogicRegions = {
     ]),
 
     Regions.PowerHut: Region("Power Hut", Levels.FranticFactory, False, None, [
-        LocationLogic(Locations.FactoryDonkeyPowerHut, lambda l: Events.MainCoreActivated in l.Events and l.isdonkey),
+        LocationLogic(Locations.FactoryDonkeyPowerHut, lambda l: (l.settings.open_levels or Events.MainCoreActivated in l.Events) and l.isdonkey),
     ], [
         Event(Events.MainCoreActivated, lambda l: l.coconut and l.grab and l.isdonkey),
     ], [
@@ -107,8 +107,8 @@ LogicRegions = {
         Event(Events.ChunkyCoreSwitch, lambda l: l.Slam and l.chunky),
     ], [
         TransitionFront(Regions.FranticFactoryStart, lambda l: l.settings.shuffle_loading_zones == "all" or Events.HatchOpened in l.Events),
-        TransitionFront(Regions.InsideCore, lambda l: Events.MainCoreActivated in l.Events, Transitions.FactoryBeyondHatchToInsideCore),
-        TransitionFront(Regions.MainCore, lambda l: Events.MainCoreActivated in l.Events),
+        TransitionFront(Regions.InsideCore, lambda l: l.settings.open_levels or Events.MainCoreActivated in l.Events, Transitions.FactoryBeyondHatchToInsideCore),
+        TransitionFront(Regions.MainCore, lambda l: l.settings.open_levels or Events.MainCoreActivated in l.Events),
         TransitionFront(Regions.CrankyFactory, lambda l: True),
         TransitionFront(Regions.CandyFactory, lambda l: True),
         TransitionFront(Regions.FactoryBossLobby, lambda l: True),

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -28,7 +28,7 @@ LogicRegions = {
         TransitionFront(Regions.ForestMinecarts, lambda l: l.Slam and l.ischunky),
         TransitionFront(Regions.GiantMushroomArea, lambda l: True),
         TransitionFront(Regions.MillArea, lambda l: True),
-        TransitionFront(Regions.WormArea, lambda l: Events.WormGatesOpened in l.Events),
+        TransitionFront(Regions.WormArea, lambda l: l.settings.open_levels or Events.WormGatesOpened in l.Events),
     ]),
 
     Regions.ForestMinecarts: Region("Forest Minecarts", Levels.FungiForest, False, None, [
@@ -47,7 +47,7 @@ LogicRegions = {
         TransitionFront(Regions.MushroomLower, lambda l: True, Transitions.ForestMainToLowerMushroom),
         TransitionFront(Regions.MushroomLowerExterior, lambda l: l.jetpack),
         TransitionFront(Regions.MushroomUpperExterior, lambda l: l.jetpack),
-        TransitionFront(Regions.HollowTreeArea, lambda l: Events.HollowTreeGateOpened in l.Events),
+        TransitionFront(Regions.HollowTreeArea, lambda l: l.settings.open_levels or Events.HollowTreeGateOpened in l.Events),
         TransitionFront(Regions.CrankyForest, lambda l: True),
     ]),
 
@@ -136,7 +136,7 @@ LogicRegions = {
         LocationLogic(Locations.ForestLankyRabbitRace, lambda l: l.TimeAccess(Regions.HollowTreeArea, Time.Day) and l.trombone and l.sprint and l.lanky),
         LocationLogic(Locations.ForestKasplatOwlTree, lambda l: True),
     ], [], [
-        TransitionFront(Regions.GiantMushroomArea, lambda l: Events.HollowTreeGateOpened in l.Events),
+        TransitionFront(Regions.GiantMushroomArea, lambda l: l.settings.open_levels or Events.HollowTreeGateOpened in l.Events),
         TransitionFront(Regions.Anthill, lambda l: l.mini and l.saxophone, Transitions.ForestTreeToAnthill),
         TransitionFront(Regions.ForestBossLobby, lambda l: True),
     ]),

--- a/randomizer/LogicFiles/GloomyGalleon.py
+++ b/randomizer/LogicFiles/GloomyGalleon.py
@@ -32,7 +32,7 @@ LogicRegions = {
     ], [
         TransitionFront(Regions.GloomyGalleonLobby, lambda l: True, Transitions.GalleonToIsles),
         TransitionFront(Regions.GalleonBeyondPineappleGate, lambda l: l.pineapple and l.chunky),
-        TransitionFront(Regions.LighthouseArea, lambda l: Events.LighthouseGateOpened in l.Events),
+        TransitionFront(Regions.LighthouseArea, lambda l: l.settings.open_levels or Events.LighthouseGateOpened in l.Events),
         TransitionFront(Regions.Shipyard, lambda l: Events.ShipyardGateOpened in l.Events),
         TransitionFront(Regions.CrankyGalleon, lambda l: True),
         TransitionFront(Regions.GalleonBossLobby, lambda l: True),
@@ -56,7 +56,7 @@ LogicRegions = {
         Event(Events.GalleonChunkyPad, lambda l: l.triangle and l.chunky),
     ], [
         # Rare case of needing to open gate before being able to go through backwards
-        TransitionFront(Regions.GloomyGalleonStart, lambda l: Events.LighthouseGateOpened in l.Events),
+        TransitionFront(Regions.GloomyGalleonStart, lambda l: l.settings.open_levels or Events.LighthouseGateOpened in l.Events),
         TransitionFront(Regions.Lighthouse, lambda l: l.Slam and l.isdonkey, Transitions.GalleonLighthouseAreaToLighthouse),
         TransitionFront(Regions.MermaidRoom, lambda l: l.mini and l.istiny, Transitions.GalleonLighthousAreaToMermaid),
         TransitionFront(Regions.SickBay, lambda l: Events.ActivatedLighthouse in l.Events and l.Slam and l.ischunky, Transitions.GalleonLighthouseAreaToSickBay),

--- a/randomizer/LogicFiles/JungleJapes.py
+++ b/randomizer/LogicFiles/JungleJapes.py
@@ -36,8 +36,8 @@ LogicRegions = {
     ], [
         TransitionFront(Regions.JungleJapesLobby, lambda l: True, Transitions.JapesToIsles),
         TransitionFront(Regions.JapesBeyondPeanutGate, lambda l: l.peanut and l.diddy),
-        TransitionFront(Regions.JapesBeyondCoconutGate1, lambda l: Events.JapesFreeKongOpenGates in l.Events),
-        TransitionFront(Regions.JapesBeyondCoconutGate2, lambda l: Events.JapesFreeKongOpenGates in l.Events),
+        TransitionFront(Regions.JapesBeyondCoconutGate1, lambda l: l.settings.open_levels or Events.JapesFreeKongOpenGates in l.Events),
+        TransitionFront(Regions.JapesBeyondCoconutGate2, lambda l: l.settings.open_levels or Events.JapesFreeKongOpenGates in l.Events),
         TransitionFront(Regions.Mine, lambda l: l.peanut and l.isdiddy, Transitions.JapesMainToMine),
         TransitionFront(Regions.JapesLankyCave, lambda l: l.peanut and l.diddy and l.handstand and l.islanky, Transitions.JapesMainToLankyCave),
         TransitionFront(Regions.JapesCatacomb, lambda l: l.Slam and l.chunkyAccess, Transitions.JapesMainToCatacomb),
@@ -67,7 +67,7 @@ LogicRegions = {
         LocationLogic(Locations.JapesKasplatLeftTunnelFar, lambda l: True),
     ], [], [
         TransitionFront(Regions.JungleJapesMain, lambda l: True),
-        TransitionFront(Regions.JapesBeyondFeatherGate, lambda l: l.feather and l.tinyAccess),
+        TransitionFront(Regions.JapesBeyondFeatherGate, lambda l: l.settings.open_levels or (l.feather and l.tinyAccess)),
     ]),
 
     Regions.JapesBeyondFeatherGate: Region("Japes Beyond Feather Gate", Levels.JungleJapes, True, -1, [

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -229,6 +229,7 @@ class Settings:
         self.krool_phase_order_rando = None
         self.krool_access = False
         self.open_lobbies = None
+        self.open_levels = None
         self.random_medal_requirement = True
         self.bananaport_rando = False
         self.shop_indicator = False

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -77,6 +77,7 @@ class Spoiler:
         settings["lanky_freeing_kong"] = ItemList[ItemFromKong(self.settings.lanky_freeing_kong)].name
         settings["chunky_freeing_kong"] = ItemList[ItemFromKong(self.settings.chunky_freeing_kong)].name
         settings["open_lobbies"] = self.settings.open_lobbies
+        settings["open_levels"] = self.settings.open_levels
         settings["crown_door_open"] = self.settings.crown_door_open
         settings["coin_door_open"] = self.settings.coin_door_open
         settings["unlock_fairy_shockwave"] = self.settings.unlock_fairy_shockwave

--- a/static/presets/2dos_special.json
+++ b/static/presets/2dos_special.json
@@ -41,6 +41,7 @@
     "gnawty_barrels":false,
     "bonus_barrel_auto_complete":false,
     "open_lobbies":true,
+    "open_levels":false,
     "krool_random":false,
     "krool_phase_count":3,
     "krool_access":true,

--- a/static/presets/coupled_lzr_balanced.json
+++ b/static/presets/coupled_lzr_balanced.json
@@ -40,6 +40,7 @@
     "gnawty_barrels":false,
     "bonus_barrel_auto_complete":false,
     "open_lobbies":true,
+    "open_levels":false,
     "krool_random":false,
     "krool_phase_count":4,
     "krool_access":true,

--- a/static/presets/decoupled_lzr_balanced.json
+++ b/static/presets/decoupled_lzr_balanced.json
@@ -40,6 +40,7 @@
     "gnawty_barrels":false,
     "bonus_barrel_auto_complete":true,
     "open_lobbies":true,
+    "open_levels":false,
     "krool_random":false,
     "krool_phase_count":3,
     "krool_access":true,

--- a/static/presets/go_bananas.json
+++ b/static/presets/go_bananas.json
@@ -33,6 +33,7 @@
     "gnawty_barrels":false,
     "bonus_barrel_auto_complete":false,
     "open_lobbies":false,
+    "open_levels":false,
     "krool_random":false,
     "krool_phase_count":3,
     "krool_access":true,

--- a/static/presets/hell.json
+++ b/static/presets/hell.json
@@ -33,6 +33,7 @@
     "gnawty_barrels":true,
     "bonus_barrel_auto_complete":false,
     "open_lobbies":false,
+    "open_levels":false,
     "krool_random":false,
     "krool_phase_count":5,
     "krool_access":true,

--- a/static/presets/level_order_balanced.json
+++ b/static/presets/level_order_balanced.json
@@ -33,6 +33,7 @@
     "gnawty_barrels":false,
     "bonus_barrel_auto_complete":true,
     "open_lobbies":false,
+    "open_levels":false,
     "krool_random":false,
     "krool_phase_count":3,
     "krool_access":true,

--- a/static/presets/suggested.json
+++ b/static/presets/suggested.json
@@ -32,6 +32,7 @@
     "gnawty_barrels":false,
     "bonus_barrel_auto_complete":false,
     "open_lobbies":false,
+    "open_levels":false,
     "krool_random":false,
     "krool_phase_count":3,
     "krool_access":true,

--- a/static/presets/vanillaesque.json
+++ b/static/presets/vanillaesque.json
@@ -33,6 +33,7 @@
     "gnawty_barrels":false,
     "bonus_barrel_auto_complete":false,
     "open_lobbies":false,
+    "open_levels":false,
     "krool_random":false,
     "krool_phase_count":5,
     "krool_access":true,

--- a/templates/overworld.html.jinja2
+++ b/templates/overworld.html.jinja2
@@ -97,6 +97,19 @@
                         </div>
                     </td>
                 </tr>
+                <tr>
+                    <td>
+                        <div class="form-check form-switch w-75">
+                            <label data-toggle="tooltip" title="Levels will have key elements of them pre-opened. This includes:&#10;*Jungle Japes gun gates that lead to caves and the giant tree area.&#10;*Angry Aztec door that connects the two portions of the level.&#10;*Frantic Factory gate to the right of the entrance, and production room already turned on.&#10;*Gloomy Galleon gates to the Lighthouse and Cannonball areas.&#10;*Fungi Forest gates to the worm and hollow tree areas.&#10;*Crystal Caves igloo pads spawned.">
+                                <input class="form-check-input"
+                                       type="checkbox"
+                                       name="open_levels"
+                                       value="False"/>
+                                Open Levels
+                            </label>
+                        </div>
+                    </td>
+                </tr>
             </table>
         </div>
         <div class="col border">

--- a/templates/overworld.html.jinja2
+++ b/templates/overworld.html.jinja2
@@ -100,7 +100,7 @@
                 <tr>
                     <td>
                         <div class="form-check form-switch w-75">
-                            <label data-toggle="tooltip" title="Levels will have key elements of them pre-opened. This includes:&#10;*Jungle Japes gun gates that lead to caves and the giant tree area.&#10;*Angry Aztec door that connects the two portions of the level.&#10;*Frantic Factory gate to the right of the entrance, and production room already turned on.&#10;*Gloomy Galleon gates to the Lighthouse and Cannonball areas.&#10;*Fungi Forest gates to the worm and hollow tree areas.&#10;*Crystal Caves igloo pads spawned.">
+                            <label data-toggle="tooltip" title="Levels will have key elements of them pre-opened. This includes:&#10;*Jungle Japes coconut gates that lead to caves and feather gate to the giant tree area.&#10;*Angry Aztec door that connects the two portions of the level.&#10;*Frantic Factory gate to the right of the entrance, and production room already turned on.&#10;*Gloomy Galleon gate to the Lighthouse area (Shipyard area open by default).&#10;*Fungi Forest gates to the worm and hollow tree areas.&#10;*Crystal Caves igloo pads spawned.">
                                 <input class="form-check-input"
                                        type="checkbox"
                                        name="open_levels"


### PR DESCRIPTION
Still needs flags to be set in rom when setting is turned on.

Adds an "Open Levels" setting in the GUI and adjusts logic when the setting is enabled according to #421 

Note this does not include the gates in the first cave of Jungle Japes, or the gate to the Cannonball area in Gloomy Galleon.

The one logic this applies to that isn't a transition is the banana in the power hut since it pre-sets main core activated.