### PR TITLE
Add Available GB Count to each sphere

### DIFF
--- a/randomizer/Lists/Item.py
+++ b/randomizer/Lists/Item.py
@@ -137,7 +137,7 @@ ItemList = {
     Items.HelmTiny2: Item("Helm Tiny Barrel 2", False, Types.Constant),
     Items.HelmChunky1: Item("Helm Chunky Barrel 1", False, Types.Constant),
     Items.HelmChunky2: Item("Helm Chunky Barrel 2", False, Types.Constant),
-    Items.GoldenBanana: Item("Golden Banana", False, Types.Banana),
+    Items.GoldenBanana: Item("Golden Banana", True, Types.Banana),
     Items.BananaFairy: Item("Banana Fairy", False, Types.Fairy),
     Items.BananaMedal: Item("Banana Medal", False, Types.Medal),
     Items.BattleCrown: Item("Battle Crown", False, Types.Crown),

--- a/randomizer/LogicClasses.py
+++ b/randomizer/LogicClasses.py
@@ -188,7 +188,7 @@ class TransitionFront:
 
 
 class Sphere:
-    """A randomizer concept often used in spoiler logs. 
+    """A randomizer concept often used in spoiler logs.
     
     A 'sphere' is a collection of locations and items that are accessible 
     or obtainable with only the items available from earlier, smaller spheres.
@@ -198,5 +198,6 @@ class Sphere:
     """
     
     def __init__(self):
+        """Initialize with given parameters."""
         self.availableGBs = 0
         self.locations = []

--- a/randomizer/LogicClasses.py
+++ b/randomizer/LogicClasses.py
@@ -185,3 +185,18 @@ class TransitionFront:
         self.exitShuffleId = exitShuffleId  # Planning to remove this
         self.time = time
         self.assumed = assumed  # Indicates this is an assumed exit attached to the root
+
+
+class Sphere:
+    """A randomizer concept often used in spoiler logs. 
+    
+    A 'sphere' is a collection of locations and items that are accessible 
+    or obtainable with only the items available from earlier, smaller spheres.
+    Sphere 0 items are what you start with in a seed, sphere 1 items can be 
+    obtained with those items, sphere 2 items can be obtained with sphere 0 
+    and sphere 1 items, and so on.
+    """
+    
+    def __init__(self):
+        self.availableGBs = 0
+        self.locations = []

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -331,8 +331,10 @@ class Spoiler:
         i = 0
         for sphere in playthroughLocations:
             newSphere = {}
-            for locationId in sphere:
-                location = locations[locationId]
+            newSphere["Available GBs"] = sphere.availableGBs
+            sphereLocations = list(map(lambda l: locations[l], sphere.locations))
+            sphereLocations.sort(key=lambda l: l.type == Types.Banana)
+            for location in sphereLocations:
                 newSphere[location.name] = ItemList[location.item].name
             self.playthrough[i] = newSphere
             i += 1


### PR DESCRIPTION
This adds the logically available GB count to each sphere. It does this by adding GBs as a playthrough location, but does not actually add it to the playthrough. 
I refactored Spheres as a logic class. In the future this could maybe track additional helpful info about spheres like maybe blueprints or coin counts.

It is possible to add the exact expected GBs to the playthrough, but as-is this adds several minutes to `ParePlaythrough()` to get rid of the excess, settings dependent. We could probably speed up the culling of GB locations but I didn't look into yet.

My python's a little rusty, so that bit in `Spoiler.py` could probably be more python-y somehow?