### PR TITLE
Add Individual GBs to the Spoiler

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -88,8 +88,7 @@ def GetAccessibleLocations(settings, ownedItems, searchType=SearchMode.GetReacha
                         break
                     if location.item == Items.GoldenBanana:
                         sphere.availableGBs += 1
-                    else:
-                        sphere.locations.append(locationId)
+                    sphere.locations.append(locationId)
                 # If we're checking beatability, just want to know if we have access to the banana hoard
                 if searchType == SearchMode.CheckBeatable and location.item == Items.BananaHoard:
                     return True
@@ -344,11 +343,20 @@ def Reset():
 def ParePlaythrough(settings, PlaythroughLocations):
     """Pare playthrough down to only the essential elements."""
     locationsToAddBack = []
+    mostExpensiveBLocker = max([settings.blocker_0, settings.blocker_1, settings.blocker_2, settings.blocker_3, settings.blocker_4, settings.blocker_5, settings.blocker_6, settings.blocker_7])
     # Check every location in the list of spheres.
     for i in range(len(PlaythroughLocations) - 2, -1, -1):
         sphere = PlaythroughLocations[i]
+        # If there are more available GBs than the most expensive B. Locker needs, none of them are logically required
+        # If there are fewer available GBs than the most expensive B. Locker requires, all of them are logically required
+        if sphere.availableGBs > mostExpensiveBLocker:
+            sphere.locations = [l for l in sphere.locations if LocationList[l].item != Items.GoldenBanana]
+            continue
         for locationId in sphere.locations.copy():
             location = LocationList[locationId]
+            # All GBs that make it here are logically required
+            if location.item == Items.GoldenBanana:
+                continue
             # Copy out item from location
             item = location.item
             location.item = None

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -350,7 +350,7 @@ def ParePlaythrough(settings, PlaythroughLocations):
         # If there are more available GBs than the most expensive B. Locker needs, none of them are logically required
         # If there are fewer available GBs than the most expensive B. Locker requires, all of them are logically required
         if sphere.availableGBs > mostExpensiveBLocker:
-            sphere.locations = [l for l in sphere.locations if LocationList[l].item != Items.GoldenBanana]
+            sphere.locations = [locationId for locationId in sphere.locations if LocationList[locationId].item != Items.GoldenBanana]
             continue
         for locationId in sphere.locations.copy():
             location = LocationList[locationId]


### PR DESCRIPTION
An addition to having the available GB count on the sphere, this update also adds the "logically required" GBs to the spoiler. I skipped this in the original commit because it added a ton of time to paring the playthrough. With some tricks, we can cut down on that dramatically. 

A "logically required" GB is any GB that can be obtained in a sphere with a smaller available GB count than the largest B Locker requirement (usually Helm, but some maniacs might not make it that). This concept lets us very quickly cull GBs that aren't required.

Where these changes work best is early in level order randomizer seeds where the logic can sometimes require you to get every GB available. Knowing that you needed all 5 GBs isn't very helpful, but being given the locations in the spoiler can be very educational.