### PR TITLE
Add no logic toggle

### DIFF
--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -205,6 +205,9 @@ class Settings:
         # damage multiplier
         self.damage_amount = "default"
 
+        # no_logic: bool
+        self.no_logic = False
+
         # shuffle_loading_zones: str
         # none
         # levels

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -63,7 +63,8 @@ class Spoiler:
         # Settings data
         settings = OrderedDict()
         settings["seed"] = self.settings.seed_id
-        settings["algorithm"] = self.settings.algorithm
+        # settings["algorithm"] = self.settings.algorithm # Don't need this for now, probably
+        settings["no_logic"] = self.settings.no_logic
         settings["move_rando"] = self.settings.move_rando
         settings["shuffle_loading_zones"] = self.settings.shuffle_loading_zones
         settings["decoupled_loading_zones"] = self.settings.decoupled_loading_zones
@@ -296,7 +297,7 @@ class Spoiler:
                     move_level = ItemList[location.item].index - 1
                     move_kong = ItemList[location.item].kong
                     for kong_index in kong_indices:
-                        print(f"Shop {shop_index}, Kong {kong_index}, Level {level_index} | Move: {move_type} lvl {move_level} for kong {move_kong}")
+                        # print(f"Shop {shop_index}, Kong {kong_index}, Level {level_index} | Move: {move_type} lvl {move_level} for kong {move_kong}")
                         if move_type == 1 or move_type == 3 or (move_type == 2 and move_level > 0) or (move_type == 4 and move_level > 0):
                             move_kong = kong_index
                         data = (move_type << 5) | (move_level << 3) | move_kong

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -6,6 +6,19 @@
                 <tr>
                     <td>
                         <div class="form-check form-switch w-75">
+                            <label data-toggle="tooltip" title="If this is checked, then locations and entrances will be shuffled without logic.&#10;WARNING: This can lead to unbeatable seeds, or seeds that require a high level of glitch knowledge to complete.">
+                                <input class="form-check-input"
+                                       type="checkbox"
+                                       name="no_logic"
+                                       value="False"/>
+                                No Logic
+                            </label>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div class="form-check form-switch w-75">
                             <label data-toggle="tooltip" title="All normal enemies that spawn in the world are randomized.">
                                 <input class="form-check-input"
                                        type="checkbox"


### PR DESCRIPTION
Implements #516 

Adds a "No Logic" toggle at the top of global settings, cfox may want to move this elsewhere but that place made sense to me. The tooltips warns the user that it can lead to unbeatable seeds.

Adding no logic required changing only a couple things:
* Telling both world verification functions to always return true if it's on (World is always valid!)
* Tell the PlaceItems function to always use random fill if it's on

This also necessitated changing RandomFill to handle whenever validLocations is a dictionary since it hadn't been upgraded for that yet.