### PR TITLE
No Logic Item Placement Fixes

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -433,6 +433,7 @@ def RandomFill(itemsToPlace, validLocations):
         random.shuffle(itemEmpty)
         locationId = itemEmpty.pop()
         LocationList[locationId].PlaceItem(item)
+        empty.remove(locationId)
     return 0
 
 
@@ -917,8 +918,9 @@ def PlaceKongs(spoiler, kongItems, kongLocations):
     """For these settings, Kongs to place, and locations to place them in, place the Kongs in such a way the generation will never error here."""
     ownedKongs = [kong for kong in spoiler.settings.starting_kong_list]
     # In entrance randomizer, it's too complicated to quickly determine kong accessibility.
-    # Instead, we place Kongs in a specific order to guarantee we'll at least have an eligible freer
-    if spoiler.settings.shuffle_loading_zones == "all":
+    # Instead, we place Kongs in a specific order to guarantee we'll at least have an eligible freer.
+    # To be at least somewhat nice to no logic users, we also use this section here so kongs don't lock each other.
+    if spoiler.settings.shuffle_loading_zones == "all" or spoiler.settings.no_logic:
         random.shuffle(kongItems)
         if Locations.ChunkyKong in kongLocations:
             kongItemToBeFreed = kongItems.pop()
@@ -941,7 +943,7 @@ def PlaceKongs(spoiler, kongItems, kongLocations):
             kongItemToBeFreed = kongItems.pop()
             LocationList[Locations.TinyKong].PlaceItem(kongItemToBeFreed)
             eligibleFreers = list(set(ownedKongs).intersection([Kongs.diddy, Kongs.chunky]))
-            spoiler.settings.tiny_freeing_kong = random.choice(ownedKongs)
+            spoiler.settings.tiny_freeing_kong = random.choice(eligibleFreers)
             ownedKongs.append(ItemPool.GetKongForItem(kongItemToBeFreed))
     # In level order shuffling, we need to be very particular about who we unlock and in what order so as to guarantee completion
     # Vanilla levels can be treated as if the level shuffler randomly placed all the levels in the same order

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -405,7 +405,7 @@ class Settings:
                 self.kong_locations.remove(Locations.ChunkyKong)
 
         # Kongs needed for level progression
-        if self.starting_kongs_count < 5 and (self.shuffle_loading_zones == "levels" or self.shuffle_loading_zones == "none"):
+        if self.starting_kongs_count < 5 and (self.shuffle_loading_zones == "levels" or self.shuffle_loading_zones == "none") and not self.no_logic:
             self.kongs_for_progression = True
 
         # Move Location Rando


### PR DESCRIPTION
Fixes an issue where some items wouldn't be placed in No Logic seeds. 
This PR also gives the ability for No Logic seeds to unlock Kongs, guaranteeing they won't lock each other.
It also fixes an issue where a non-diddy/chunky Kong could be assigned to unlock Tiny in entrance shuffle modes.