### PR TITLE
Diddy fast RD fix

### DIFF
--- a/base-hack/src/misc/object_instance_script_changes.c
+++ b/base-hack/src/misc/object_instance_script_changes.c
@@ -626,7 +626,12 @@ int change_object_scripts(behaviour_data* behaviour_pointer, int id, int index, 
 						}
 					}
 				} else if (index == 2) {
-					disableDiddyRDDoors();
+					if (Rando.fast_gbs) {
+						disableDiddyRDDoors();
+					}
+					else {
+						setScriptRunState(behaviour_pointer, 2, 0);
+					}
         		}
 			} else if (param2 == FACTORY_DARTBOARD) {
 				if (index < 6) {


### PR DESCRIPTION
This fixes an error where the script was not checking if the ```fast_gbs``` setting was on before disabling all the doors. This has been tested and verified to work with the setting both on and off.