### PR TITLE
created new region for bp on caves spire

### DIFF
--- a/randomizer/Enums/Regions.py
+++ b/randomizer/Enums/Regions.py
@@ -135,6 +135,7 @@ class Regions(IntEnum):
     CavesBlueprintCave = auto()
     CavesBonusCave = auto()
     CavesBlueprintPillar = auto()
+    CavesBananaportSpire = auto()
     BoulderCave = auto()
     CavesLankyRace = auto()
     FrozenCastle = auto()

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1120,7 +1120,7 @@ def FillKongsAndMoves(spoiler):
                             if location in ItemPool.ForestFunkyMoveLocations:
                                 # There's no way a kong locked behind Forest Funky can be your second kong
                                 # This _should_ be covered by the ownedItems=OwnedKongMoves preventing you from having the guns to get to it, which in turn prevents access to that shop unless you have both Chunky and Tiny
-                                if len(ownedKongs == 1):
+                                if len(ownedKongs) == 1:
                                     raise Ex.ItemPlacementException("Fungi Funky logic issue - SEND THIS TO A DEV!")
                                 if Items.Feather not in preplacedPriorityMoves:
                                     featherLocations = ItemPool.TinyMoveLocations.copy()

--- a/randomizer/Lists/Warps.py
+++ b/randomizer/Lists/Warps.py
@@ -90,7 +90,7 @@ BananaportVanilla = {
     Warps.CavesWaterfall: BananaportData(name="Crystal Caves: Near Waterfall", map_id=Maps.CrystalCaves, region_id=Regions.CabinArea, obj_id_vanilla=0x36, vanilla_warp=1),
     Warps.CavesNearIglooTag: BananaportData(name="Crystal Caves: Near Igloo Tag", map_id=Maps.CrystalCaves, region_id=Regions.IglooArea, obj_id_vanilla=0x57, vanilla_warp=2),
     Warps.CavesBonusRoom: BananaportData(name="Crystal Caves: Inside Bonus Room", map_id=Maps.CrystalCaves, region_id=Regions.CavesBonusCave, obj_id_vanilla=0x56, locked=True, vanilla_warp=2),
-    Warps.CavesThinPillar: BananaportData(name="Crystal Caves: On the Thin Pillar", map_id=Maps.CrystalCaves, region_id=Regions.CrystalCavesMain, obj_id_vanilla=0x6B, vanilla_warp=3),
+    Warps.CavesThinPillar: BananaportData(name="Crystal Caves: On the Thin Pillar", map_id=Maps.CrystalCaves, region_id=Regions.CavesBananaportSpire, obj_id_vanilla=0x6B, vanilla_warp=3),
     Warps.CavesBlueprintRoom: BananaportData(
         name="Crystal Caves: Inside Blueprint Room", map_id=Maps.CrystalCaves, region_id=Regions.CavesBlueprintCave, obj_id_vanilla=0x6A, locked=True, vanilla_warp=3
     ),

--- a/randomizer/LogicFiles/CrystalCaves.py
+++ b/randomizer/LogicFiles/CrystalCaves.py
@@ -62,7 +62,7 @@ LogicRegions = {
         TransitionFront(Regions.CrystalCavesMain, lambda l: True)
     ]),
 
-    Regions.CavesBananaportSpire: Region("Caves Bananaport Spire",Levels.CrystalCaves, False, None, [], [], [
+    Regions.CavesBananaportSpire: Region("Caves Bananaport Spire", Levels.CrystalCaves, False, None, [], [], [
         TransitionFront(Regions.CrystalCavesMain, lambda l: True)
     ]),
 

--- a/randomizer/LogicFiles/CrystalCaves.py
+++ b/randomizer/LogicFiles/CrystalCaves.py
@@ -31,6 +31,7 @@ LogicRegions = {
         TransitionFront(Regions.CavesBlueprintCave, lambda l: l.mini and l.twirl and l.tiny),
         TransitionFront(Regions.CavesBonusCave, lambda l: l.mini and l.tiny),
         TransitionFront(Regions.CavesBlueprintPillar, lambda l: l.jetpack and l.diddy),
+        TransitionFront(Regions.CavesBananaportSpire, lambda l: l.jetpack and l.diddy),
         TransitionFront(Regions.BoulderCave, lambda l: l.punch),
         TransitionFront(Regions.CavesLankyRace, lambda l: l.superSlam and l.balloon and l.islanky, Transitions.CavesMainToRace),
         TransitionFront(Regions.FrozenCastle, lambda l: l.superSlam and l.islanky, Transitions.CavesMainToCastle),
@@ -58,6 +59,10 @@ LogicRegions = {
     Regions.CavesBlueprintPillar: Region("Caves Blueprint Pillar", Levels.CrystalCaves, False, None, [
         LocationLogic(Locations.CavesKasplatPillar, lambda l: True),
     ], [], [
+        TransitionFront(Regions.CrystalCavesMain, lambda l: True)
+    ]),
+
+    Regions.CavesBananaportSpire: Region("Caves Bananaport Spire",Levels.CrystalCaves, False, None, [], [], [
         TransitionFront(Regions.CrystalCavesMain, lambda l: True)
     ]),
 


### PR DESCRIPTION
Creates a new Region for the bananaport on the Caves spire. In shuffled + activated warps, this warp could be the only access to some colored bananas or GBs, which could be extremely annoying to get if T&S or B. Locker rolls high. Giving it its own region effectively locks the warp behind jetpack.