### PR TITLE
Removing vine logic

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1161,7 +1161,7 @@ def FillKongsAndMoves(spoiler):
                         # debuginfo[item] = location
 
                         # Find what items are needed to get this item
-                        dependencyPriorityMoves = GetItemPrerequisites(spoiler, item, ownedKongs, location)
+                        dependencyPriorityMoves = GetItemPrerequisites(spoiler, item, ownedKongs)
                         # If there are any...
                         for move in dependencyPriorityMoves:
                             # If we haven't placed it already, find the possible locations and prep the dictionary for the next loop

--- a/randomizer/Lists/KasplatLocations.py
+++ b/randomizer/Lists/KasplatLocations.py
@@ -176,6 +176,7 @@ KasplatLocationList = {
             zmin=2295,
             zmax=2380,
             region=Regions.JungleJapesMain,
+            additional_logic=lambda l: l.vines
         ),
         KasplatLocation(
             name="Japes Kasplat: Inside the Mountain", map_id=Maps.JapesMountain, kong_lst=[Kongs.diddy], coords=[551, 101, 1192], xmin=525, xmax=576, zmin=1078, zmax=1236, region=Regions.Mine

--- a/randomizer/Lists/KasplatLocations.py
+++ b/randomizer/Lists/KasplatLocations.py
@@ -176,7 +176,7 @@ KasplatLocationList = {
             zmin=2295,
             zmax=2380,
             region=Regions.JungleJapesMain,
-            additional_logic=lambda l: l.vines
+            additional_logic=lambda l: l.vines,
         ),
         KasplatLocation(
             name="Japes Kasplat: Inside the Mountain", map_id=Maps.JapesMountain, kong_lst=[Kongs.diddy], coords=[551, 101, 1192], xmin=525, xmax=576, zmin=1078, zmax=1236, region=Regions.Mine

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -46,7 +46,7 @@ LogicRegions = {
         TransitionFront(Regions.BananaFairyRoom, lambda l: l.mini and l.istiny, Transitions.IslesMainToFairy),
         TransitionFront(Regions.JungleJapesLobby, lambda l: l.settings.open_lobbies or Events.KLumsyTalkedTo in l.Events, Transitions.IslesMainToJapesLobby),
         TransitionFront(Regions.CrocodileIsleBeyondLift, lambda l: l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events),
-        TransitionFront(Regions.IslesMainUpper, lambda l: l.vines and (l.donkey or l.diddy or l.chunky)),  # Lanky and Tiny are bad on vines
+        TransitionFront(Regions.IslesMainUpper, lambda l: l.vines),
         TransitionFront(Regions.GloomyGalleonLobby, lambda l: l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events, Transitions.IslesMainToGalleonLobby),
         TransitionFront(Regions.CabinIsle, lambda l: l.settings.open_lobbies or Events.GalleonKeyTurnedIn in l.Events),
         TransitionFront(Regions.CreepyCastleLobby, lambda l: l.settings.open_lobbies or Events.ForestKeyTurnedIn in l.Events, Transitions.IslesMainToCastleLobby),

--- a/randomizer/LogicFiles/JungleJapes.py
+++ b/randomizer/LogicFiles/JungleJapes.py
@@ -43,7 +43,7 @@ LogicRegions = {
         TransitionFront(Regions.JapesCatacomb, lambda l: l.Slam and l.chunkyAccess, Transitions.JapesMainToCatacomb),
         TransitionFront(Regions.FunkyJapes, lambda l: True),
         TransitionFront(Regions.Snide, lambda l: True),
-        TransitionFront(Regions.JapesBossLobby, lambda l: l.vines and (l.donkey or l.diddy or l.chunky)),  # Lanky and Tiny have a rough time with the vines and falling from top is not intuitive
+        TransitionFront(Regions.JapesBossLobby, lambda l: l.vines),  # Falling from top is not intuitive
         TransitionFront(Regions.JapesBaboonBlast, lambda l: l.blast and l.isdonkey)  # , Transitions.JapesMainToBBlast)
     ]),
 


### PR DESCRIPTION
This PR removes the unnecessary kong checks on some vine-locked areas like upper Isles. This should cut down on seed generation failure when your starting Kongs don't have access to level 2.