### PR TITLE
fixed kasplat location logic and other minor fixes

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1,4 +1,5 @@
 """Module used to distribute items randomly."""
+import json
 import random
 
 import js
@@ -1001,7 +1002,7 @@ def PlaceKongs(spoiler, kongItems, kongLocations):
         while len(ownedKongs) != 5:
             # If there aren't any accessible Kong locations, then the level order shuffler has a bug (this shouldn't happen)
             if not any(logicallyAccessibleKongLocations):
-                raise Ex.EntrancePlacementException("Levels shuffled in a way that makes Kong unlocks impossible. SEND THIS TO THE DEVS!")
+                raise Ex.EntrancePlacementException("Levels shuffled in a way that makes Kong unlocks impossible. SEND THIS TO THE DEVS!" + json.dumps(spoiler.settings) + "SEND THIS TO THE DEVS!")
             # Begin by finding the currently accessible Kong locations
             # Randomly pick an accessible location
             progressionLocation = random.choice(logicallyAccessibleKongLocations)
@@ -1037,6 +1038,8 @@ def PlaceKongs(spoiler, kongItems, kongLocations):
                         newlyAccessibleKongLocations = GetLogicallyAccessibleKongLocations(spoiler, kongLocations, tempOwnedKongs, latestLogicallyAllowedLevel)
                         if any(newlyAccessibleKongLocations):
                             progressionKongItems.append(kongItem)
+                    if len(progressionKongItems) == 0:
+                        raise Ex.FillException("Kongs placed in a way that is impossible to unlock everyone. SEND THIS TO THE DEVS!" + json.dumps(spoiler.settings) + "SEND THIS TO THE DEVS!")
                     # Pick a random Kong from the Kongs that guarantee progression
                     kongToBeFreed = random.choice(progressionKongItems)
             # Now that we have a combination guaranteed to not break the seed or logic, lock it in

--- a/randomizer/Lists/KasplatLocations.py
+++ b/randomizer/Lists/KasplatLocations.py
@@ -10,12 +10,11 @@ from randomizer.Enums.Kongs import Kongs
 class KasplatLocation:
     """Class which stores name and logic for a kasplat location."""
 
-    def __init__(self, *, name="No Location", map_id=0, kong_lst=[], logic=0, coords=[0, 0, 0], xmin=0, xmax=0, zmin=0, zmax=0, region, additional_logic=None, vanilla=False):
+    def __init__(self, *, name="No Location", map_id=0, kong_lst=[], coords=[0, 0, 0], xmin=0, xmax=0, zmin=0, zmax=0, region, additional_logic=None, vanilla=False):
         """Initialize with given parameters."""
         self.name = name
         self.map = map_id
         self.kong_lst = kong_lst
-        self.logic = logic
         self.coords = coords
         self.bounds = [xmin, xmax, zmin, zmax]
         self.selected = False

--- a/randomizer/LogicFiles/CrystalCaves.py
+++ b/randomizer/LogicFiles/CrystalCaves.py
@@ -56,7 +56,7 @@ LogicRegions = {
     ]),
 
     Regions.CavesBonusCave: Region("Caves Bonus Cave", Levels.CrystalCaves, False, None, [
-        LocationLogic(Locations.CavesTinyCaveBarrel, lambda l: True, MinigameType.BonusBarrel),
+        LocationLogic(Locations.CavesTinyCaveBarrel, lambda l: l.istiny, MinigameType.BonusBarrel),
     ], [], [
         TransitionFront(Regions.CrystalCavesMain, lambda l: l.mini and l.istiny)
     ]),

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -235,7 +235,7 @@ LogicRegions = {
         LocationLogic(Locations.ForestTinyBeanstalk, lambda l: Events.Bean in l.Events and l.saxophone and l.mini and l.tiny),
         LocationLogic(Locations.ForestChunkyApple, lambda l: l.hunkyChunky and l.chunky),
     ], [], [
-        TransitionFront(Regions.FungiForestStart, lambda l: True),
+        TransitionFront(Regions.FungiForestStart, lambda l: Events.WormGatesOpened in l.Events),
         TransitionFront(Regions.FunkyForest, lambda l: True),
         TransitionFront(Regions.ForestBossLobby, lambda l: True, time=Time.Night),
     ]),

--- a/randomizer/ShuffleKasplats.py
+++ b/randomizer/ShuffleKasplats.py
@@ -112,6 +112,7 @@ def ShuffleKasplatsAndLocations(spoiler, LogicVariables):
             kasplat.setKasplat(state=False)
         # Fill kasplats kong by kong
         kongs = GetKongs()
+        random.shuffle(kongs)
         for idx, kong in enumerate(kongs):
             available_for_kong = []
             # Pick a random unselected kasplat from available ones for this kong
@@ -132,7 +133,7 @@ def ShuffleKasplatsAndLocations(spoiler, LogicVariables):
                     Logic.LocationList[location_id] = location
                     # Insert the Location into the Region
                     kasplatRegion = Logic.Regions[kasplat.region_id]
-                    kasplatRegion.locations.append(LocationLogic(location_id, lambda l: kasplat.additional_logic(l)))
+                    kasplatRegion.locations.append(LocationLogic(location_id, kasplat.additional_logic))
                     # Update logic variables for remainder of the Fill
                     LogicVariables.kasplat_map[location_id] = kong
                     spoiler.shuffled_kasplat_map[kasplat.name] = idx


### PR DESCRIPTION
Fixed major issue where kasplat logic was incorrect. Either too many kasplats would be available or not enough kasplats would be available logically.

The minor fixes:
- That Tiny barrel in Caves is now marked correctly as a Tiny barrel.
- Fixed logic for getting from the worm area to main (they're not one-way gates). This shouldn't change anything, as you could have just deathwarped anyway.
- Shuffling the kongs before picking kasplat locations *should* increase location diversity.