### PR TITLE
Fix vanilla boss shuffles and LO kong pools

### DIFF
--- a/randomizer/ShuffleBosses.py
+++ b/randomizer/ShuffleBosses.py
@@ -3,7 +3,7 @@ import random
 from array import array
 from randomizer.Enums.Items import Items
 from randomizer.Enums.Kongs import Kongs
-from randomizer.Lists.Exceptions import BossOutOfLocationsException, FillException
+from randomizer.Lists.Exceptions import BossOutOfLocationsException, FillException, ItemPlacementException
 from randomizer.Lists.MapsAndExits import Maps
 
 BossMapList = [Maps.JapesBoss, Maps.AztecBoss, Maps.FactoryBoss, Maps.GalleonBoss, Maps.FungiBoss, Maps.CavesBoss, Maps.CastleBoss]
@@ -58,7 +58,7 @@ def SelectRandomKongForBoss(boss_map: Maps, hard_bosses: bool):
     elif boss_map == Maps.FungiBoss:
         possibleKongs = [Kongs.chunky]
     elif boss_map == Maps.CavesBoss:
-        possibleKongs = [Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.chunky]
+        possibleKongs = [Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky]
     elif boss_map == Maps.CastleBoss:
         possibleKongs = [Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky]
     return random.choice(possibleKongs)
@@ -99,6 +99,8 @@ def ShuffleBossesBasedOnOwnedItems(settings, ownedKongs: dict, ownedMoves: dict)
         # First place dogadon 2 (most restrictive)
         bossTryingToBePlaced = "Dogadon 2"
         forestBossOptions = [x for x in bossLevelOptions if Kongs.chunky in ownedKongs[x] and Items.HunkyChunky in ownedMoves[x]]
+        if not settings.kong_rando and not settings.boss_location_rando and 4 not in forestBossOptions:
+            raise ItemPlacementException("Items not placed to allow vanilla Dogadon 2.")
         forestBossIndex = random.choice(forestBossOptions)
         forestBossKong = Kongs.chunky
         bossLevelOptions.remove(forestBossIndex)
@@ -118,24 +120,14 @@ def ShuffleBossesBasedOnOwnedItems(settings, ownedKongs: dict, ownedMoves: dict)
             factoryBossIndex = random.choice(factoryBossOptions)
             factoryBossKong = Kongs.tiny
         bossLevelOptions.remove(factoryBossIndex)
-        # Then place Pufftoss (next most restrictive)
-        bossTryingToBePlaced = "Pufftoss"
-        galleonBossOptions = [x for x in bossLevelOptions if Kongs.diddy in ownedKongs[x] or Kongs.lanky in ownedKongs[x] or Kongs.tiny in ownedKongs[x] or Kongs.chunky in ownedKongs[x]]
-        galleonBossIndex = random.choice(galleonBossOptions)
-        galleonBossKongOptions = set(ownedKongs[galleonBossIndex]).intersection({Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky})
-        galleonBossKong = random.choice(list(galleonBossKongOptions))
-        bossLevelOptions.remove(galleonBossIndex)
-        # Then place Armydillo 2
-        bossTryingToBePlaced = "Armydillo 2"
-        cavesBossOptions = [x for x in bossLevelOptions if Kongs.donkey in ownedKongs[x] or Kongs.diddy in ownedKongs[x] or Kongs.lanky in ownedKongs[x] or Kongs.chunky in ownedKongs[x]]
-        cavesBossIndex = random.choice(cavesBossOptions)
-        cavesBossKongOptions = set(ownedKongs[cavesBossIndex]).intersection({Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.chunky})
-        cavesBossKong = random.choice(list(cavesBossKongOptions))
-        bossLevelOptions.remove(cavesBossIndex)
         # Place the rest randomly
         bossTryingToBePlaced = "the easy bosses to place (if this breaks here something REALLY strange happened)"
         remainingBosses = list(bossLevelOptions)
         random.shuffle(remainingBosses)
+        galleonBossIndex = remainingBosses.pop()
+        galleonBossKong = random.choice(ownedKongs[galleonBossIndex])
+        cavesBossIndex = remainingBosses.pop()
+        cavesBossKong = random.choice(ownedKongs[cavesBossIndex])
         japesBossIndex = remainingBosses.pop()
         japesBossKong = random.choice(ownedKongs[japesBossIndex])
         aztecBossIndex = remainingBosses.pop()
@@ -175,6 +167,18 @@ def ShuffleBossesBasedOnOwnedItems(settings, ownedKongs: dict, ownedMoves: dict)
             raise BossOutOfLocationsException("No valid locations to place " + bossTryingToBePlaced)
         raise FillException(ex)
 
-    settings.boss_maps = newBossMaps
-    settings.boss_kongs = newBossKongs
-    settings.kutout_kongs = ShuffleKutoutKongs(settings.boss_maps, settings.boss_kongs, True)
+    # Only apply this shuffle if the settings permit it
+    # If kongs are random we have to shuffle bosses and locations or else we might break logic
+    if settings.kong_rando or settings.boss_location_rando:
+        settings.boss_maps = newBossMaps
+    else:
+        settings.boss_maps = BossMapList.copy()
+    if settings.kong_rando or settings.boss_kong_rando:
+        # If we shuffle kongs but not locations, we must forcibly sort the array with the known valid kongs
+        if not settings.boss_location_rando:
+            settings.boss_kongs = [japesBossKong, aztecBossKong, factoryBossKong, galleonBossKong, forestBossKong, cavesBossKong, castleBossKong]
+        else:
+            settings.boss_kongs = newBossKongs
+    else:
+        settings.boss_kongs = ShuffleBossKongs(settings)
+    settings.kutout_kongs = ShuffleKutoutKongs(settings.boss_maps, settings.boss_kongs, settings.boss_kong_rando)


### PR DESCRIPTION
Two parts:
- Adding Kongs to level order rando boss pools - Tiny to Dillo 2 and DK to Pufftoss
- Fixing vanilla-esque boss shuffling options ( #540 ). Most of these won't be relevant to the average user as Kong rando must be off and Level Order rando requires Kong rando to be on.