### PR TITLE
Genericize Kong Dependencies

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -708,6 +708,22 @@ def GetItemPrerequisites(spoiler, targetItemId, ownedKongs=[]):
     return requiredMoves
 
 
+def GetValidLocationsForMove(spoiler, move):
+    """Return the valid locations for the given move. Currently only returns shop locations for moves."""
+    validLocations = []
+    if spoiler.settings.move_rando == "on_cross_purchase" or move in ItemPool.DonkeyMoves:
+        validLocations.extend(ItemPool.DonkeyMoveLocations.copy())
+    if spoiler.settings.move_rando == "on_cross_purchase" or move in ItemPool.DiddyMoves:
+        validLocations.extend(ItemPool.DiddyMoveLocations.copy())
+    if spoiler.settings.move_rando == "on_cross_purchase" or move in ItemPool.TinyMoves:
+        validLocations.extend(ItemPool.TinyMoveLocations.copy())
+    if spoiler.settings.move_rando == "on_cross_purchase" or move in ItemPool.ChunkyMoves:
+        validLocations.extend(ItemPool.ChunkyMoveLocations.copy())
+    if spoiler.settings.move_rando == "on_cross_purchase" or move in ItemPool.LankyMoves:
+        validLocations.extend(ItemPool.LankyMoveLocations.copy())
+    return list(validLocations)
+
+
 def PlaceItems(settings, algorithm, itemsToPlace, ownedItems=None, validLocations=None, isPriorityMove=False):
     """Places items using given algorithm."""
     if ownedItems is None:
@@ -859,90 +875,6 @@ def GeneratePlaythrough(spoiler):
     spoiler.UpdateWoth(LocationList, WothLocations)
 
 
-def GetKongUnlockingMovesAndValidLocations(spoiler, location, ownedKongs=[]):
-    """Given the settings and a locked Kong's location, determine the moves needed to unlock them in preparation for PlaceItems. Note that `ownedKongs` is only needed for Locations.LankyKong."""
-    kongUnlockingItemsDict = {}
-    if location == Locations.DiddyKong:
-        # We need the Diddy freeing Kong's gun
-        gun = Items.Coconut
-        validLocations = ItemPool.DonkeyMoveLocations.copy()
-        if spoiler.settings.diddy_freeing_kong == Kongs.diddy:
-            gun = Items.Peanut
-            validLocations = ItemPool.DiddyMoveLocations.copy()
-        elif spoiler.settings.diddy_freeing_kong == Kongs.lanky:
-            gun = Items.Grape
-            validLocations = ItemPool.LankyMoveLocations.copy()
-        elif spoiler.settings.diddy_freeing_kong == Kongs.tiny:
-            gun = Items.Feather
-            validLocations = ItemPool.TinyMoveLocations.copy()
-        elif spoiler.settings.diddy_freeing_kong == Kongs.chunky:
-            gun = Items.Pineapple
-            validLocations = ItemPool.ChunkyMoveLocations.copy()
-        kongUnlockingItemsDict[gun] = validLocations
-    elif location == Locations.LankyKong:
-        # We always need the guitar to get to the Llama Temple - make extra double triple sure it doesn't lock itself
-        kongUnlockingItemsDict[Items.Guitar] = ItemPool.DiddyMoveLocations.copy()
-        kongUnlockingItemsDict[Items.Guitar].remove(Locations.DiddyAztecGun)
-        kongUnlockingItemsDict[Items.Guitar].remove(Locations.RocketbarrelBoost)
-        # We also need a different Kong's gun to get into the Llama Temple
-        llamaTempleOpeningKong = random.choice([kong for kong in ownedKongs if kong in (Kongs.donkey, Kongs.lanky, Kongs.tiny)])
-        llamaTempleOpeningGun = Items.Coconut
-        llamaTempleOpeningGunLocations = ItemPool.DonkeyMoveLocations
-        if llamaTempleOpeningKong == Kongs.lanky:
-            llamaTempleOpeningGun = Items.Grape
-            llamaTempleOpeningGunLocations = ItemPool.LankyMoveLocations
-        elif llamaTempleOpeningKong == Kongs.tiny:
-            llamaTempleOpeningGun = Items.Feather
-            llamaTempleOpeningGunLocations = ItemPool.TinyMoveLocations
-        kongUnlockingItemsDict[llamaTempleOpeningGun] = llamaTempleOpeningGunLocations
-        # We need the gun and instrument of the Lanky freeing Kong
-        gun = Items.Coconut
-        instrument = Items.Bongos
-        validLocations = ItemPool.DonkeyMoveLocations
-        if spoiler.settings.lanky_freeing_kong == Kongs.diddy:
-            gun = Items.Peanut
-            instrument = Items.Guitar
-            validLocations = ItemPool.DiddyMoveLocations
-        elif spoiler.settings.lanky_freeing_kong == Kongs.lanky:
-            gun = Items.Grape
-            instrument = Items.Trombone
-            validLocations = ItemPool.LankyMoveLocations
-        elif spoiler.settings.lanky_freeing_kong == Kongs.tiny:
-            gun = Items.Feather
-            instrument = Items.Saxophone
-            validLocations = ItemPool.TinyMoveLocations
-        elif spoiler.settings.lanky_freeing_kong == Kongs.chunky:
-            gun = Items.Pineapple
-            instrument = Items.Triangle
-            validLocations = ItemPool.ChunkyMoveLocations
-        kongUnlockingItemsDict[gun] = validLocations
-        kongUnlockingItemsDict[instrument] = validLocations
-    elif location == Locations.TinyKong:
-        # We need Peanut & Charge or Pineapple & Punch to open Tiny's cage
-        gun = Items.Peanut
-        move = Items.ChimpyCharge
-        validLocations = ItemPool.DiddyMoveLocations
-        if spoiler.settings.tiny_freeing_kong == Kongs.chunky:
-            gun = Items.Pineapple
-            move = Items.PrimatePunch
-            validLocations = ItemPool.ChunkyMoveLocations
-        kongUnlockingItemsDict[gun] = validLocations
-        kongUnlockingItemsDict[move] = validLocations
-    # Locations.ChunkyKong has no prerequisites yet
-
-    # If cross Kong purchases are enabled, then expand the valid item location lists
-    if spoiler.settings.move_rando == "on_cross_purchase":
-        allKongMoveLocations = ItemPool.DonkeyMoveLocations.copy()
-        allKongMoveLocations.update(ItemPool.DiddyMoveLocations.copy())
-        allKongMoveLocations.update(ItemPool.LankyMoveLocations.copy())
-        allKongMoveLocations.update(ItemPool.TinyMoveLocations.copy())
-        allKongMoveLocations.update(ItemPool.ChunkyMoveLocations.copy())
-        allKongMoveLocations = list(allKongMoveLocations)
-        for item in kongUnlockingItemsDict:
-            kongUnlockingItemsDict[item] = allKongMoveLocations
-    return kongUnlockingItemsDict
-
-
 def GetLogicallyAccessibleKongLocations(spoiler, kongLocations, ownedKongs, latestLevel):
     """Find the logically accessible Kong Locations given the current state of Kong unlocking."""
     logicallyAccessibleKongLocations = []
@@ -956,7 +888,8 @@ def GetLogicallyAccessibleKongLocations(spoiler, kongLocations, ownedKongs, late
         if (
             spoiler.settings.level_order[level] == Levels.AngryAztec
             and Locations.LankyKong in kongLocations
-            and (Kongs.diddy in ownedKongs or spoiler.settings.open_levels)  # Must be able to open Guitar door
+            # Must be able to bypass Guitar door - the active bananaports condition is in case your only Llama Temple access is through the quicksand cave
+            and (Kongs.diddy in ownedKongs or spoiler.settings.open_levels or (Kongs.donkey in ownedKongs and spoiler.settings.activate_all_bananaports == "all"))
             and (Kongs.donkey in ownedKongs or Kongs.lanky in ownedKongs or Kongs.tiny in ownedKongs)
         ):  # Must be able to open Llama Temple
             logicallyAccessibleKongLocations.append(Locations.LankyKong)
@@ -1109,30 +1042,35 @@ def FillKongsAndMoves(spoiler):
                 if spoiler.settings.level_order[levelIndex] == Levels.FranticFactory and Locations.ChunkyKong in locationsLockingKongs and spoiler.settings.chunky_freeing_kong in ownedKongs:
                     locationsLockingKongs.remove(Locations.ChunkyKong)
                     kongToBeGained = ItemPool.GetKongForItem(LocationList[Locations.ChunkyKong].item)
+                    # No prerequisites for Chunky's Cage (yet)
                 if spoiler.settings.level_order[levelIndex] == Levels.JungleJapes and Locations.DiddyKong in locationsLockingKongs and spoiler.settings.diddy_freeing_kong in ownedKongs:
                     locationsLockingKongs.remove(Locations.DiddyKong)
-                    priorityItemsDict = GetKongUnlockingMovesAndValidLocations(spoiler, Locations.DiddyKong)
-                    for alreadyPriorityPlacedMove in preplacedPriorityMoves:
-                        priorityItemsDict.pop(alreadyPriorityPlacedMove, None)
                     kongToBeGained = ItemPool.GetKongForItem(LocationList[Locations.DiddyKong].item)
+                    directPrerequisiteMoves = GetItemPrerequisites(spoiler, LocationList[Locations.DiddyKong].item, ownedKongs)
+                    for move in directPrerequisiteMoves:
+                        if move not in preplacedPriorityMoves:
+                            priorityItemsDict[move] = GetValidLocationsForMove(spoiler, move)
                 if spoiler.settings.level_order[levelIndex] == Levels.AngryAztec and Locations.TinyKong in locationsLockingKongs and spoiler.settings.tiny_freeing_kong in ownedKongs:
                     locationsLockingKongs.remove(Locations.TinyKong)
-                    priorityItemsDict = GetKongUnlockingMovesAndValidLocations(spoiler, Locations.TinyKong)
-                    for alreadyPriorityPlacedMove in preplacedPriorityMoves:
-                        priorityItemsDict.pop(alreadyPriorityPlacedMove, None)
                     kongToBeGained = ItemPool.GetKongForItem(LocationList[Locations.TinyKong].item)
+                    directPrerequisiteMoves = GetItemPrerequisites(spoiler, LocationList[Locations.TinyKong].item, ownedKongs)
+                    for move in directPrerequisiteMoves:
+                        if move not in preplacedPriorityMoves:
+                            priorityItemsDict[move] = GetValidLocationsForMove(spoiler, move)
                 elif (
                     spoiler.settings.level_order[levelIndex] == Levels.AngryAztec
                     and Locations.LankyKong in locationsLockingKongs
                     and spoiler.settings.lanky_freeing_kong in ownedKongs
-                    and (Kongs.diddy in ownedKongs or spoiler.settings.open_levels)
+                    # Must be able to bypass Guitar door - the active bananaports condition is in case your only Llama Temple access is through the quicksand cave
+                    and (Kongs.diddy in ownedKongs or spoiler.settings.open_levels or (Kongs.donkey in ownedKongs and spoiler.settings.activate_all_bananaports == "all"))
                     and (Kongs.donkey in ownedKongs or Kongs.lanky in ownedKongs or Kongs.tiny in ownedKongs)
                 ):
                     locationsLockingKongs.remove(Locations.LankyKong)
-                    priorityItemsDict = GetKongUnlockingMovesAndValidLocations(spoiler, Locations.LankyKong, ownedKongs)
-                    for alreadyPriorityPlacedMove in preplacedPriorityMoves:
-                        priorityItemsDict.pop(alreadyPriorityPlacedMove, None)
                     kongToBeGained = ItemPool.GetKongForItem(LocationList[Locations.LankyKong].item)
+                    directPrerequisiteMoves = GetItemPrerequisites(spoiler, LocationList[Locations.LankyKong].item, ownedKongs)
+                    for move in directPrerequisiteMoves:
+                        if move not in preplacedPriorityMoves:
+                            priorityItemsDict[move] = GetValidLocationsForMove(spoiler, move)
 
                 # Place the priority items and any items they may depend on
                 while any(priorityItemsDict):
@@ -1171,18 +1109,7 @@ def FillKongsAndMoves(spoiler):
                         for move in dependencyPriorityMoves:
                             # If we haven't placed it already, find the possible locations and prep the dictionary for the next loop
                             if move not in preplacedPriorityMoves:
-                                priorityLocations = []
-                                if spoiler.settings.move_rando == "on_cross_purchase" or move in ItemPool.DonkeyMoves:
-                                    priorityLocations.extend(ItemPool.DonkeyMoveLocations.copy())
-                                if spoiler.settings.move_rando == "on_cross_purchase" or move in ItemPool.DiddyMoves:
-                                    priorityLocations.extend(ItemPool.DiddyMoveLocations.copy())
-                                if spoiler.settings.move_rando == "on_cross_purchase" or move in ItemPool.TinyMoves:
-                                    priorityLocations.extend(ItemPool.TinyMoveLocations.copy())
-                                if spoiler.settings.move_rando == "on_cross_purchase" or move in ItemPool.ChunkyMoves:
-                                    priorityLocations.extend(ItemPool.ChunkyMoveLocations.copy())
-                                if spoiler.settings.move_rando == "on_cross_purchase" or move in ItemPool.LankyMoves:
-                                    priorityLocations.extend(ItemPool.LankyMoveLocations.copy())
-                                priorityItemDependencyDict[move] = list(priorityLocations)
+                                priorityItemDependencyDict[move] = GetValidLocationsForMove(spoiler, move)
                     # If we found any dependencies, we have to check for further dependencies
                     priorityItemsDict = priorityItemDependencyDict
                 # Update progression with any newly acquired Kongs
@@ -1198,8 +1125,8 @@ def FillKongsAndMoves(spoiler):
                         checkedAllLogicallyAvailableLevels = True
                     # Wrap back to level 1 if we hit the end - it's logically possible we've now unlocked a kong that frees an earlier kong
                     levelIndex = (levelIndex % latestLogicallyAllowedLevel) + 1
-            # Undo any level blocking that may have been performed
-            BlockAccessToLevel(spoiler.settings, 100)
+                # Undo any level blocking that may have been performed
+                BlockAccessToLevel(spoiler.settings, 100)
 
     # Handle shared moves before other moves in move rando
     if spoiler.settings.shuffle_items == "moves":
@@ -1234,11 +1161,11 @@ def FillKongsAndMovesForLevelOrder(spoiler):
     #   7. Fungi
     # ALGORITHM START
     # print("Starting Kongs: " + str([kong.name + " " for kong in spoiler.settings.starting_kong_list]))
-    # Need to place constants to update boss key items after shuffling levels
-    ItemPool.PlaceConstants(spoiler.settings)
     retries = 0
     while True:
         try:
+            # Need to place constants to update boss key items after shuffling levels
+            ItemPool.PlaceConstants(spoiler.settings)
             # Assume we can progress through the levels so long as we have enough kongs
             WipeProgressionRequirements(spoiler.settings)
             spoiler.settings.kongs_for_progression = True

--- a/randomizer/Lists/Warps.py
+++ b/randomizer/Lists/Warps.py
@@ -42,8 +42,10 @@ BananaportVanilla = {
     Warps.AztecCranky: BananaportData(name="Angry Aztec: Outside Cranky's", map_id=Maps.AngryAztec, region_id=Regions.AngryAztecMain, obj_id_vanilla=0x95, vanilla_warp=2),
     Warps.AztecTotemNearRight: BananaportData(name="Angry Aztec: Near Llama Temple", map_id=Maps.AngryAztec, region_id=Regions.AngryAztecMain, obj_id_vanilla=0x73, vanilla_warp=3),
     Warps.AztecFunky: BananaportData(name="Angry Aztec: Outside Funky's", map_id=Maps.AngryAztec, region_id=Regions.AngryAztecMain, obj_id_vanilla=0xB1, vanilla_warp=3),
-    Warps.AztecNearSnide: BananaportData(name="Angry Aztec: Near Snide's", map_id=Maps.AngryAztec, region_id=Regions.AngryAztecMain, obj_id_vanilla=0x82, vanilla_warp=4),
-    Warps.AztecSnoopTunnel: BananaportData(name="Angry Aztec: Sandy Tunnel", map_id=Maps.AngryAztec, region_id=Regions.AztecDonkeyQuicksandCave, obj_id_vanilla=0x87, vanilla_warp=4),
+    # Locked until the warp shuffler is fixed
+    Warps.AztecNearSnide: BananaportData(name="Angry Aztec: Near Snide's", map_id=Maps.AngryAztec, region_id=Regions.AngryAztecMain, obj_id_vanilla=0x82, locked=True, vanilla_warp=4),
+    # Locked until the warp shuffler is fixed
+    Warps.AztecSnoopTunnel: BananaportData(name="Angry Aztec: Sandy Tunnel", map_id=Maps.AngryAztec, region_id=Regions.AztecDonkeyQuicksandCave, obj_id_vanilla=0x87, locked=True, vanilla_warp=4),
     Warps.LlamaNearLeft: BananaportData(name="Llama Temple: Near the Bongo Pad", map_id=Maps.AztecLlamaTemple, region_id=Regions.LlamaTemple, obj_id_vanilla=0x58, vanilla_warp=0),
     Warps.LlamaMatchingGame: BananaportData(name="Llama Temple: Outside Matching Game", map_id=Maps.AztecLlamaTemple, region_id=Regions.LlamaTemple, obj_id_vanilla=0x4E, vanilla_warp=0),
     Warps.LlamaNearRight: BananaportData(name="Llama Temple: Near the Trombone Pad", map_id=Maps.AztecLlamaTemple, region_id=Regions.LlamaTemple, obj_id_vanilla=0x9A, vanilla_warp=1),
@@ -68,7 +70,10 @@ BananaportVanilla = {
     Warps.GalleonNear2DS: BananaportData(name="Gloomy Galleon: Near 2-Door Ship", map_id=Maps.GloomyGalleon, region_id=Regions.Shipyard, obj_id_vanilla=0x6C, locked=True, vanilla_warp=1),
     Warps.GalleonNearCranky: BananaportData(name="Gloomy Galleon: Near Cranky's", map_id=Maps.GloomyGalleon, region_id=Regions.GloomyGalleonStart, obj_id_vanilla=0x60, vanilla_warp=2),
     Warps.GalleonSnides: BananaportData(name="Gloomy Galleon: Outside Snide's", map_id=Maps.GloomyGalleon, region_id=Regions.LighthouseArea, obj_id_vanilla=0x66, vanilla_warp=2),
-    Warps.GalleonGoldTower: BananaportData(name="Gloomy Galleon: On a Gold Tower", map_id=Maps.GloomyGalleon, region_id=Regions.TreasureRoomDiddyGoldTower, obj_id_vanilla=0x55, vanilla_warp=3),
+    # Locked until the warp shuffler is fixed
+    Warps.GalleonGoldTower: BananaportData(
+        name="Gloomy Galleon: On a Gold Tower", map_id=Maps.GloomyGalleon, region_id=Regions.TreasureRoomDiddyGoldTower, obj_id_vanilla=0x55, locked=True, vanilla_warp=3
+    ),
     Warps.GalleonNearSeal: BananaportData(name="Gloomy Galleon: Near Seal Race", map_id=Maps.GloomyGalleon, region_id=Regions.Shipyard, obj_id_vanilla=0x56, locked=True, vanilla_warp=3),
     Warps.GalleonNearRocketbarrel: BananaportData(
         name="Gloomy Galleon: Near Lighthouse Rocketbarrel", map_id=Maps.GloomyGalleon, region_id=Regions.LighthouseArea, obj_id_vanilla=0x16, vanilla_warp=4
@@ -77,11 +82,13 @@ BananaportVanilla = {
     Warps.FungiClock1: BananaportData(name="Fungi Forest: Clock (1)", map_id=Maps.FungiForest, region_id=Regions.FungiForestStart, obj_id_vanilla=0x36, vanilla_warp=0),
     Warps.FungiMill: BananaportData(name="Fungi Forest: Mill", map_id=Maps.FungiForest, region_id=Regions.MillArea, obj_id_vanilla=0x35, vanilla_warp=0),
     Warps.FungiClock2: BananaportData(name="Fungi Forest: Clock (2)", map_id=Maps.FungiForest, region_id=Regions.FungiForestStart, obj_id_vanilla=0x49, vanilla_warp=1),
-    Warps.FungiFunky: BananaportData(name="Fungi Forest: Outside Funky's", map_id=Maps.FungiForest, region_id=Regions.WormArea, obj_id_vanilla=0x4A, vanilla_warp=1),
+    # Locked until the warp shuffler is fixed
+    Warps.FungiFunky: BananaportData(name="Fungi Forest: Outside Funky's", map_id=Maps.FungiForest, region_id=Regions.WormArea, obj_id_vanilla=0x4A, locked=True, vanilla_warp=1),
     Warps.FungiClock3: BananaportData(name="Fungi Forest: Clock (3)", map_id=Maps.FungiForest, region_id=Regions.FungiForestStart, obj_id_vanilla=0x4B, vanilla_warp=2),
     Warps.FungiMushEntrance: BananaportData(name="Fungi Forest: Giant Mushroom Lowest Entrance", map_id=Maps.FungiForest, region_id=Regions.GiantMushroomArea, obj_id_vanilla=0x4E, vanilla_warp=2),
     Warps.FungiClock4: BananaportData(name="Fungi Forest: Clock (4)", map_id=Maps.FungiForest, region_id=Regions.FungiForestStart, obj_id_vanilla=0x4F, vanilla_warp=3),
-    Warps.FungiOwlTree: BananaportData(name="Fungi Forest: Owl Tree", map_id=Maps.FungiForest, region_id=Regions.HollowTreeArea, obj_id_vanilla=0x51, vanilla_warp=3),
+    # Locked until the warp shuffler is fixed
+    Warps.FungiOwlTree: BananaportData(name="Fungi Forest: Owl Tree", map_id=Maps.FungiForest, region_id=Regions.HollowTreeArea, obj_id_vanilla=0x51, locked=True, vanilla_warp=3),
     Warps.FungiTopMush: BananaportData(name="Fungi Forest: Giant Mushroom (Top)", map_id=Maps.FungiForest, region_id=Regions.MushroomUpperExterior, obj_id_vanilla=0x56, vanilla_warp=4),
     Warps.FungiLowMush: BananaportData(name="Fungi Forest: Giant Mushroom (Bottom)", map_id=Maps.FungiForest, region_id=Regions.GiantMushroomArea, obj_id_vanilla=0x55, vanilla_warp=4),
     Warps.CavesNearLeft: BananaportData(name="Crystal Caves: Near Left", map_id=Maps.CrystalCaves, region_id=Regions.CrystalCavesMain, obj_id_vanilla=0x22, vanilla_warp=0),

--- a/randomizer/LogicFiles/CrystalCaves.py
+++ b/randomizer/LogicFiles/CrystalCaves.py
@@ -108,6 +108,7 @@ LogicRegions = {
         TransitionFront(Regions.LankyIgloo, lambda l: (l.settings.high_req or l.jetpack) and l.trombone and l.islanky, Transitions.CavesIglooToLanky),
         TransitionFront(Regions.TinyIgloo, lambda l: (l.settings.high_req or l.jetpack) and l.saxophone and l.istiny, Transitions.CavesIglooToTiny),
         TransitionFront(Regions.ChunkyIgloo, lambda l: (l.settings.high_req or l.jetpack) and l.triangle and l.ischunky, Transitions.CavesIglooToChunky),
+        TransitionFront(Regions.CavesBossLobby, lambda l: True),
     ]),
 
     Regions.GiantKosha: Region("Giant Kosha", Levels.CrystalCaves, False, -1, [], [

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -445,10 +445,14 @@ class Settings:
         for i in range(0, self.starting_kongs_count - 1):
             kongLocation = random.choice(kongCageLocations)
             kongCageLocations.remove(kongLocation)
+
+        # The following cases do not apply if you could bypass the Guitar door without Diddy
+        bypass_guitar_door = self.open_levels or self.activate_all_bananaports == "all"
         # In case both Diddy and Chunky need to be freed but only Aztec locations are available
         # This would be impossible, as one of them must free the Tiny location and Diddy is needed for the Lanky location
         if (
-            self.starting_kongs_count == 3
+            not bypass_guitar_door
+            and self.starting_kongs_count == 3
             and Kongs.diddy not in self.starting_kong_list
             and Kongs.chunky not in self.starting_kong_list
             and Locations.TinyKong in kongCageLocations
@@ -457,8 +461,8 @@ class Settings:
             # Move a random location to a non-Aztec location
             kongCageLocations.pop()
             kongCageLocations.append(random.choice(Locations.DiddyKong, Locations.ChunkyKong))
-        # In case diddy is the only kong to free, he can't be in the llama temple since it's behind guitar door
-        if self.starting_kongs_count == 4 and Kongs.diddy not in self.starting_kong_list and Locations.LankyKong in kongCageLocations:
+        # In case Diddy is the only kong to free, he can't be in the Llama Temple since it's behind the Guitar door
+        if not bypass_guitar_door and self.starting_kongs_count == 4 and Kongs.diddy not in self.starting_kong_list and Locations.LankyKong in kongCageLocations:
             # Move diddy kong from llama temple to another cage randomly chosen
             kongCageLocations.remove(Locations.LankyKong)
             kongCageLocations.append(random.choice(Locations.DiddyKong, Locations.TinyKong, Locations.ChunkyKong))

--- a/randomizer/ShuffleExits.py
+++ b/randomizer/ShuffleExits.py
@@ -410,28 +410,27 @@ def ShuffleLevelOrderForMultipleStartingKongs(settings: Settings):
             if kongsAssumed < 5 and level > kongsAssumed + 1:
                 break
             if kongsOwned == settings.starting_kongs_count:
-                # If reached aztec without freeing anyone yet, diddy and/or chunky are needed
-                if newLevelOrder[level] == Levels.AngryAztec:
-                    # If a kong is in Tiny Temple, either Diddy or Chunky can make progress
-                    if Locations.TinyKong in settings.kong_locations:
+                # If reached Aztec without freeing anyone yet, specific combinations of kongs are needed to open those cages (if they have any occupants)
+                if newLevelOrder[level] == Levels.AngryAztec and (Locations.TinyKong in settings.kong_locations or Locations.LankyKong in settings.kong_locations):
+                    # Assume we can free any locked kongs here
+                    tinyAccessible = Locations.TinyKong in settings.kong_locations
+                    lankyAccessible = Locations.LankyKong in settings.kong_locations
+                    # If a kong is in Tiny Temple, either Diddy or Chunky can free them
+                    if tinyAccessible:
                         if Kongs.diddy not in settings.starting_kong_list and Kongs.chunky not in settings.starting_kong_list:
-                            break
-                    # If no kong in Tiny Temple but a kong is in Llama temple, need Diddy to open guitar door
-                    # You also need one of Donkey, Lanky, or Tiny to open the Llama temple
-                    elif Locations.LankyKong in settings.kong_locations:
-                        if Kongs.diddy not in settings.starting_kong_list or (
+                            tinyAccessible = False
+                    # If a kong is in Llama temple, need to be able to get past the guitar door and one of Donkey, Lanky, or Tiny to open the Llama temple
+                    if lankyAccessible:
+                        guitarDoorAccess = (
+                            Kongs.diddy in settings.starting_kong_list or settings.open_levels or (Kongs.donkey in settings.starting_kong_list and settings.activate_all_bananaports == "all")
+                        )
+                        if not guitarDoorAccess or (
                             Kongs.donkey not in settings.starting_kong_list and Kongs.lanky not in settings.starting_kong_list and Kongs.tiny not in settings.starting_kong_list
                         ):
-                            break
-                # If reached Japes without freeing anyone yet, Only Donkey, Diddy, and Chunky logically have access to T&S portal in Japes
-                elif (
-                    newLevelOrder[level] == Levels.JungleJapes
-                    and kongsInLevels[Levels.JungleJapes] == 0  # This restriction only matters if there's no one to free in Japes
-                    and Kongs.donkey not in settings.starting_kong_list
-                    and Kongs.diddy not in settings.starting_kong_list
-                    and Kongs.chunky not in settings.starting_kong_list
-                ):
-                    break
+                            lankyAccessible = False
+                    # If we can unlock one kong then we can unlock both, so if we can't reach either then we can't assume we can unlock any kong from here
+                    if not tinyAccessible and not lankyAccessible:
+                        break
             levelsReachable.append(level)
             # Check if a level has been assigned here
             if newLevelOrder[level] is not None:

--- a/randomizer/ShuffleWarps.py
+++ b/randomizer/ShuffleWarps.py
@@ -36,9 +36,10 @@ def ShuffleWarps(bananaport_replacements, human_ports):
         pad_list = []
         pad_temp_list = [[], [], [], [], []]
         for warp in BananaportVanilla.values():
-            if warp.map_id == warp_map and not warp.locked:
-                pad_temp_list[warp.new_warp].append(warp.obj_id_vanilla)
+            if warp.map_id == warp_map:
                 human_ports[warp.name] = "Warp " + str(warp.new_warp + 1)
+                if not warp.locked:
+                    pad_temp_list[warp.new_warp].append(warp.obj_id_vanilla)
         for warp_index in range(len(pad_temp_list)):
             if len(pad_temp_list[warp_index]) > 0:
                 pad_list.append({"warp_index": warp_index, "warp_ids": pad_temp_list[warp_index].copy()})

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -213,8 +213,9 @@ class Spoiler:
             humanspoiler["Shuffled Kasplats"] = self.human_kasplats
         if self.settings.random_patches:
             humanspoiler["Shuffled Dirt Patches"] = self.human_patches
-        # if self.settings.bananaport_rando:
-        #     humanspoiler["Bananaports"] = self.human_warp_locations
+        # Deactivated until the shuffler is fixed
+        # if self.settings.bananaport_rando and self.settings.activate_all_bananaports == "all":
+        #     humanspoiler["Activated Bananaports"] = self.human_warp_locations
         if len(self.hint_list) > 0:
             humanspoiler["Wrinkly Hints"] = self.hint_list
         if self.settings.shuffle_shops:


### PR DESCRIPTION
The main thrust of this PR is to convert Kong item placement to using the GetItemPrerequisites method I made the other day for move placement. Now the fill can dynamically assess what moves are needing priority placement, going so far as to even be able to place Diddy in the Llama temple in some settings. The idea behind this was to create more flexibility in how items are placed, eventually leading up to placing Kongs on moves someday. This is the first step in that process.

The last major issue is the bananaports shuffle not being correctly written to the ROM, and this PR locks a couple warps to ensure that all seeds are beatable until we resolve that issue.

Other smaller issues resolved:
- Adding logical access to the Caves boss from the T&S we placed (should save some false fill fails)
- Properly re-placing constant items on fill retries (which should be way more dangerous to fills and I'm surprised nobody has said anything about it - either my other changes introduced this bug and it's not a real bug or we just don't fail enough for this to be a problem?)