### PR TITLE
Minecart exit loop fix

### DIFF
--- a/randomizer/ShuffleExits.py
+++ b/randomizer/ShuffleExits.py
@@ -139,6 +139,12 @@ def ShuffleExitsInPool(settings, frontpool, backpool):
             origins = [x for x in origins if ShufflableExits[ShufflableExits[x].back.reverse].category is not None]
             # Also validate the entry & region kongs overlap in reverse direction
             origins = [x for x in origins if ShufflableExits[backExit.back.reverse].entryKongs.issuperset(ShufflableExits[ShufflableExits[x].back.reverse].regionKongs)]
+        elif settings.decoupled_loading_zones and backExit.back.regionId in [Regions.JapesMinecarts, Regions.ForestMinecarts]:
+            # In decoupled, we still have to prevent one-way minecart exits from leading to the minecarts themselves
+            if Transitions.JapesCartsToMain in origins:
+                origins.remove(Transitions.JapesCartsToMain)
+            if Transitions.ForestCartsToMain in origins:
+                origins.remove(Transitions.ForestCartsToMain)
         if len(origins) == 0:
             print("Failed to connect to " + backExit.name + ", found no suitable origins!")
             raise Ex.EntranceOutOfDestinations

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -8,6 +8,7 @@
                         <input class="form-check-input"
                                 type="checkbox"
                                 name="no_logic"
+                                id="no_logic"
                                 value="True"/>
                         No Logic
                     </label>
@@ -208,7 +209,7 @@
                             class="form-select"
                             aria-label="Randomization type"
                             data-toggle="tooltip"
-                            title="All prices in shops are randomized to a random number.&#10;-Vanilla: Same cost as base game.&#10;-Free: All moves are free.&#10;-Low: Moves cost 1-4 coins most of the time. (Avg: 2.5)&#10;-Medium: Moves cost 1-8 coins most of the time. (Avg: 4.5)&#10;-High: Moves cost 1-12 coins most of the time. (Avg: 6.5)&#10;-Extreme: Moves cost 10+ coins most of the time. (Avg: 11!)&#10;WARNING: High Prices restricts move placements quite a bit and therefore Seeds have a hard time generating, Extreme even more so. Might take a few tries to generate a seed!">
+                            title="All prices in shops are randomized to a random number.&#10;-Vanilla: Same cost as base game.&#10;-Free: All moves are free.&#10;-Low: Moves cost 1-4 coins most of the time. (Avg: 2.5)&#10;-Medium: Moves cost 1-8 coins most of the time. (Avg: 4.5)&#10;-High: Moves cost 1-12 coins most of the time. (Avg: 6.5)&#10;-Extreme: Moves cost 10+ coins most of the time. (Avg: 11, starting Shockwave required!)&#10;WARNING: High Prices restricts move placements quite a bit and therefore Seeds have a hard time generating, Extreme even more so. Might take a few tries to generate a seed!">
                         <option selected value="vanilla">
                             Vanilla
                         </option>

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -453,11 +453,17 @@ def disable_rw(evt):
 def toggle_extreme_prices_option(event):
     """Determine the visibility of the extreme prices option."""
     unlocked_shockwave = document.getElementById("unlock_fairy_shockwave").checked
+    no_logic = document.getElementById("no_logic").checked
     option = document.getElementById("extreme_price_option")
-    if unlocked_shockwave:
+    if unlocked_shockwave or no_logic:
         option.removeAttribute("disabled")
     else:
         option.setAttribute("disabled", "disabled")
         price_option = document.getElementById("random_prices")
         if price_option.value == "extreme":
             price_option.value = "high"
+
+@bind("change", "no_logic")
+def toggle_no_logic(event):
+    """Toggle settings based on the presence of logic."""
+    toggle_extreme_prices_option(event)

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -463,6 +463,7 @@ def toggle_extreme_prices_option(event):
         if price_option.value == "extreme":
             price_option.value = "high"
 
+
 @bind("change", "no_logic")
 def toggle_no_logic(event):
     """Toggle settings based on the presence of logic."""


### PR DESCRIPTION
I think this prevents the issue found in #484 
I suspect there's an underlying issue here, as attempts to loop the Castle minecart failed correctly. In any case this fix should prevent Japes or Forest minecarts from looping themselves and making seeds un-101%-able

Also adds extreme price option with no logic.