### PR TITLE
Hard Level Progression

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -941,6 +941,9 @@ def PlaceKongs(spoiler, kongItems, kongLocations):
     # Vanilla levels can be treated as if the level shuffler randomly placed all the levels in the same order
     elif spoiler.settings.shuffle_loading_zones in ("levels", "none"):
         latestLogicallyAllowedLevel = len(ownedKongs) + 1
+        # Logically we can always enter any level on hard level progression
+        if spoiler.settings.hard_level_progression:
+            latestLogicallyAllowedLevel = 7
         logicallyAccessibleKongLocations = GetLogicallyAccessibleKongLocations(spoiler, kongLocations, ownedKongs, latestLogicallyAllowedLevel)
         while len(ownedKongs) != 5:
             # If there aren't any accessible Kong locations, then the level order shuffler has a bug (this shouldn't happen)
@@ -966,8 +969,9 @@ def PlaceKongs(spoiler, kongItems, kongLocations):
             kongLocations.remove(progressionLocation)
             # Pick a Kong to unlock from the locked Kongs
             kongToBeFreed = random.choice(kongItems)
-            # With this kong, we can progress one level further
-            latestLogicallyAllowedLevel += 1
+            # With this kong, we can progress one level further (if we care about this logic)
+            if not spoiler.settings.hard_level_progression:
+                latestLogicallyAllowedLevel += 1
             # If this Kong must unlock more locked Kong locations, we have to be more careful
             # The second condition here because we don't need to worry about the last placed Kong
             if len(logicallyAccessibleKongLocations) == 0 and len(kongItems) > 1:
@@ -1039,12 +1043,18 @@ def FillKongsAndMoves(spoiler):
             locationsLockingKongs = [location for location in kongLocations]
             ownedKongs = [kong for kong in spoiler.settings.starting_kong_list]
             latestLogicallyAllowedLevel = spoiler.settings.starting_kongs_count + 1
+            # Logically we can always enter any level on hard level progression
+            if spoiler.settings.hard_level_progression:
+                latestLogicallyAllowedLevel = 100
             levelIndex = 1
             checkedAllLogicallyAvailableLevels = False
             # Loop until we've logically unlocked all the kongs
             # It may take multiple loops through available levels before we unlock all kongs
             while len(ownedKongs) != 5:
                 latestLogicallyAllowedLevel = len(ownedKongs) + 1
+                # Logically we can always enter any level on hard level progression
+                if spoiler.settings.hard_level_progression:
+                    latestLogicallyAllowedLevel = 100
                 priorityItemsDict = {}
                 kongToBeGained = None
                 # For each level that has a locked kong, identify the items needed to unlock them
@@ -1134,7 +1144,11 @@ def FillKongsAndMoves(spoiler):
                     elif levelIndex == latestLogicallyAllowedLevel:
                         checkedAllLogicallyAvailableLevels = True
                     # Wrap back to level 1 if we hit the end - it's logically possible we've now unlocked a kong that frees an earlier kong
-                    levelIndex = (levelIndex % latestLogicallyAllowedLevel) + 1
+                    if spoiler.settings.hard_level_progression:
+                        levelIndex = (levelIndex % 7) + 1
+                        checkedAllLogicallyAvailableLevels = levelIndex == 1
+                    else:
+                        levelIndex = (levelIndex % latestLogicallyAllowedLevel) + 1
                 # Undo any level blocking that may have been performed
                 BlockAccessToLevel(spoiler.settings, 100)
 
@@ -1182,7 +1196,10 @@ def FillKongsAndMovesForLevelOrder(spoiler):
             # Fill the kongs and the moves
             FillKongsAndMoves(spoiler)
             # Update progression requirements based on what is now accessible after all shuffles are done
-            SetNewProgressionRequirements(spoiler.settings)
+            if spoiler.settings.hard_level_progression:
+                SetNewProgressionRequirementsUnordered(spoiler.settings)
+            else:
+                SetNewProgressionRequirements(spoiler.settings)
             # Once progression requirements updated, no longer assume we need kongs freed for level progression
             spoiler.settings.kongs_for_progression = False
             # Check if game is beatable
@@ -1295,6 +1312,201 @@ def SetNewProgressionRequirements(settings: Settings):
     ShuffleBossesBasedOnOwnedItems(settings, ownedKongs, ownedMoves)
 
 
+def SetNewProgressionRequirementsUnordered(settings: Settings):
+    """Set level progression requirements based on a random path of accessible levels."""
+    ownedKongs = {}
+    ownedMoves = {}
+    allMoves = ItemPool.DonkeyMoves.copy()
+    allMoves.extend(ItemPool.DiddyMoves)
+    allMoves.extend(ItemPool.LankyMoves)
+    allMoves.extend(ItemPool.TinyMoves)
+    allMoves.extend(ItemPool.ChunkyMoves)
+    allMoves.extend(ItemPool.ImportantSharedMoves)
+    KeyEvents = [
+        Events.JapesKeyTurnedIn,
+        Events.AztecKeyTurnedIn,
+        Events.FactoryKeyTurnedIn,
+        Events.GalleonKeyTurnedIn,
+        Events.ForestKeyTurnedIn,
+        Events.CavesKeyTurnedIn,
+        Events.CastleKeyTurnedIn,
+        Events.HelmKeyTurnedIn,
+    ]
+
+    # Before doing anything else, determine how many GBs we can access without entering any levels
+    # This is very likely to be 1, but depending on the settings there are decent odds more are available
+    BlockAccessToLevel(settings, 0)
+    Reset()
+    accessible = GetAccessibleLocations(settings, [])
+    runningGBTotal = LogicVariables.GoldenBananas
+    minimumBLockerGBs = 1
+
+    # Reset B. Lockers and T&S to initial values
+    settings.EntryGBs = [
+        settings.blocker_0,
+        settings.blocker_1,
+        settings.blocker_2,
+        settings.blocker_3,
+        settings.blocker_4,
+        settings.blocker_5,
+        settings.blocker_6,
+        settings.blocker_7,
+    ]
+    settings.BossBananas = [
+        settings.troff_0,
+        settings.troff_1,
+        settings.troff_2,
+        settings.troff_3,
+        settings.troff_4,
+        settings.troff_5,
+        settings.troff_6,
+    ]
+    # We also need to remember T&S values in an array as we'll overwrite the settings value in the process of determining location availability
+    initialTNS = [
+        settings.troff_0,
+        settings.troff_1,
+        settings.troff_2,
+        settings.troff_3,
+        settings.troff_4,
+        settings.troff_5,
+        settings.troff_6,
+    ]
+
+    levelsProgressed = []
+    # Keep track of what lobbies are accessible, starting with an array of indexes
+    openLobbyIndexes = [1, 2, 3, 4, 5, 6, 7]
+    if not settings.open_lobbies:
+        for key in settings.krool_keys_required:
+            if key == Events.JapesKeyTurnedIn:
+                openLobbyIndexes.remove(2)
+            elif key == Events.AztecKeyTurnedIn:
+                openLobbyIndexes.remove(3)
+                openLobbyIndexes.remove(4)
+            elif key == Events.GalleonKeyTurnedIn:
+                openLobbyIndexes.remove(5)
+            elif key == Events.ForestKeyTurnedIn:
+                openLobbyIndexes.remove(6)
+                openLobbyIndexes.remove(7)
+    # We need a kong who can enter the Caves Lobby logically
+    kongLockedCavesLobby = False
+    if 5 in openLobbyIndexes and Kongs.donkey not in settings.starting_kong_list and Kongs.chunky not in settings.starting_kong_list:
+        openLobbyIndexes.remove(5)
+        kongLockedCavesLobby = True  # If we don't have one yet, keep track of that as we progress
+    # Convert indexes to the shuffled levels
+    openLevels = [settings.level_order[index] for index in openLobbyIndexes]
+    foundProgressionKeyEvents = []
+
+    # Until we've completed every level...
+    while len(levelsProgressed) < 7:
+        # Pick a random accessible B. Locker
+        accessibleIncompleteLevels = [level for level in openLevels if level not in levelsProgressed and settings.EntryGBs[level] <= runningGBTotal]
+        # If we have no levels accessible, we need to lower a B. Locker count to make one accessible
+        if len(accessibleIncompleteLevels) == 0:
+            asdf = [level for level in openLevels if level not in levelsProgressed]
+            if len(asdf) == 0:
+                print("wtf")
+            # Next level chosen randomly (possible room for improvement here?) from accessible levels
+            nextLevelToBeat = random.choice([level for level in openLevels if level not in levelsProgressed])
+            # If we are allowed to randomize B. Lockers as we please, try to swap a lower random B. Locker value with this level's
+            if settings.randomize_blocker_required_amounts:
+                # Find the lowest GB B. Locker
+                incompleteLevelWithLowestBLocker = 0
+                for level in range(1, len(settings.EntryGBs)):
+                    if level not in levelsProgressed and settings.EntryGBs[level] < settings.EntryGBs[incompleteLevelWithLowestBLocker]:
+                        incompleteLevelWithLowestBLocker = level
+                # Swap B. Locker values with the randomly chosen accessible level
+                temp = settings.EntryGBs[incompleteLevelWithLowestBLocker]
+                settings.EntryGBs[incompleteLevelWithLowestBLocker] = settings.EntryGBs[nextLevelToBeat]
+                settings.EntryGBs[nextLevelToBeat] = temp
+            # If the level still isn't accessible, we have to truncate the required amount
+            if settings.EntryGBs[nextLevelToBeat] > runningGBTotal:
+                # Each B. Locker must be greater than the previous one and at least half of the available GBs
+                settings.EntryGBs[nextLevelToBeat] = random.randint(max(minimumBLockerGBs, round(runningGBTotal * 0.5)), runningGBTotal)
+            accessibleIncompleteLevels = [nextLevelToBeat]
+        else:
+            nextLevelToBeat = random.choice(accessibleIncompleteLevels)
+        minimumBLockerGBs = settings.EntryGBs[nextLevelToBeat]  # This B. Locker is now the minimum for the next one
+        levelsProgressed.append(nextLevelToBeat)
+
+        # Determine if we found a level progression key
+        if not settings.open_lobbies:
+            lobbyIndex = -1
+            for key in settings.level_order.keys():
+                if settings.level_order[key] == nextLevelToBeat:
+                    lobbyIndex = key - 1
+                    break
+            foundKeyEvent = KeyEvents[lobbyIndex]
+            # If we need this key to open new lobbies, it's a progression key
+            if foundKeyEvent in settings.krool_keys_required and foundKeyEvent not in [Events.FactoryKeyTurnedIn, Events.CavesKeyTurnedIn, Events.CastleKeyTurnedIn]:
+                foundProgressionKeyEvents.append(foundKeyEvent)
+
+        # Determine the Kong, GB, and Move accessibility from this level
+        # Block the ability to complete the boss of every level we could complete but haven't yet (including this one)
+        # This allows logic to get moves from any other accessible level to beat this one
+        BlockCompletionOfLevelSet(settings, accessibleIncompleteLevels)
+        Reset()
+        accessible = GetAccessibleLocations(settings, [])
+        runningGBTotal = LogicVariables.GoldenBananas
+
+        # If we've progressed through all open levels, then we need to pick a progression key we've found to acquire and set that level's Troff n Scoff
+        if len(openLevels) == len(levelsProgressed) and any(foundProgressionKeyEvents):
+            chosenKeyEvent = random.choice(foundProgressionKeyEvents)
+            foundProgressionKeyEvents.remove(chosenKeyEvent)
+            # Determine what level needs to be completed
+            if chosenKeyEvent == Events.JapesKeyTurnedIn:
+                openLevels.append(settings.level_order[2])
+                bossCompletedLevel = settings.level_order[1]
+            elif chosenKeyEvent == Events.AztecKeyTurnedIn:
+                openLevels.append(settings.level_order[3])
+                openLevels.append(settings.level_order[4])
+                bossCompletedLevel = settings.level_order[2]
+            elif chosenKeyEvent == Events.GalleonKeyTurnedIn:
+                openLevels.append(settings.level_order[5])
+                bossCompletedLevel = settings.level_order[4]
+            elif chosenKeyEvent == Events.ForestKeyTurnedIn:
+                kongLockedCavesLobby = True
+                openLevels.append(settings.level_order[7])
+                bossCompletedLevel = settings.level_order[5]
+            availableCBs = sum(LogicVariables.ColoredBananas[bossCompletedLevel])
+            # If we don't have enough CBs to beat the boss per the settings-determined value
+            if availableCBs < initialTNS[bossCompletedLevel]:
+                # Reduce the requirement to an amount guaranteed to be available, currently somewhere between half and all of accessible CBs
+                reducedColoredBananaRequirement = random.randint(round(availableCBs * 0.5), availableCBs)
+                settings.BossBananas[bossCompletedLevel] = reducedColoredBananaRequirement
+            else:
+                settings.BossBananas[bossCompletedLevel] = initialTNS[bossCompletedLevel]
+            ownedKongs[bossCompletedLevel] = LogicVariables.GetKongs()
+            if settings.unlock_all_moves:
+                ownedMoves[bossCompletedLevel] = allMoves
+            else:
+                accessibleMoves = [LocationList[x].item for x in accessible if LocationList[x].type == Types.Shop and LocationList[x].item != Items.NoItem and LocationList[x].item is not None]
+                ownedMoves[bossCompletedLevel] = accessibleMoves
+
+        # Check Caves Lobby entrance accessibility. This is independent of both:
+        # 1. The open levels setting
+        # 2. Whether or not the key opens more lobbies (because it's not the key that unlocks the kongs, it's the level itself)
+        if kongLockedCavesLobby:
+            ownedKongsByThisLevel = LogicVariables.GetKongs()
+            if (
+                Kongs.donkey in ownedKongsByThisLevel
+                or Kongs.chunky in ownedKongsByThisLevel
+                or (Kongs.tiny in ownedKongsByThisLevel and Items.PonyTailTwirl in [LocationList[x].item for x in accessible if LocationList[x].type == Types.Shop])
+            ):
+                kongLockedCavesLobby = False
+                openLevels.append(settings.level_order[6])
+
+    # We still need to set T&S for some levels, but we'll have access to every level by this point
+    for level in range(len(settings.BossBananas)):
+        # This means that the level hasn't been unset from completion blocking
+        if settings.BossBananas[level] == 1000:
+            # We should have access to everything by this point
+            ownedKongs[level] = LogicVariables.GetKongs()
+            ownedMoves[level] = allMoves
+            settings.BossBananas[level] = initialTNS[level]
+    # Place boss locations based on kongs and moves found for each level
+    ShuffleBossesBasedOnOwnedItems(settings, ownedKongs, ownedMoves)
+
+
 def BlockAccessToLevel(settings: Settings, level):
     """Assume the level index passed in is the furthest level you have access to in the level order."""
     for i in range(0, 7):
@@ -1308,6 +1520,14 @@ def BlockAccessToLevel(settings: Settings, level):
             settings.BossBananas[i] = 0
     # Update values based on actual level progression
     ShuffleExits.UpdateLevelProgression(settings)
+
+
+def BlockCompletionOfLevelSet(settings: Settings, lockedLevels):
+    """Prevent acquiring the keys of the levels provided."""
+    for i in range(0, 7):
+        if i in lockedLevels:
+            # This level is incompletable
+            settings.BossBananas[i] = 1000
 
 
 def Generate_Spoiler(spoiler):

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -484,7 +484,7 @@ class LogicVarHolder:
 
     def HasEnoughKongs(self, level, forPreviousLevel=False):
         """Check if kongs are required for progression, do we have enough to reach the given level."""
-        if self.settings.kongs_for_progression and level != Levels.HideoutHelm:
+        if self.settings.kongs_for_progression and level != Levels.HideoutHelm and not self.settings.hard_level_progression:
             # Figure out where this level fits in the progression
             levelIndex = GetShuffledLevelIndex(level)
             if forPreviousLevel:

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -84,7 +84,7 @@ class Settings:
         self.troff_weight_4 = 0.8
         self.troff_weight_5 = 0.9
         self.troff_weight_6 = 1.0
-        if self.level_randomization in ("loadingzone", "loadingzonesdecoupled"):
+        if self.level_randomization in ("loadingzone", "loadingzonesdecoupled") or self.hard_level_progression:
             self.troff_weight_0 = 1
             self.troff_weight_1 = 1
             self.troff_weight_2 = 1
@@ -108,10 +108,11 @@ class Settings:
         if self.randomize_blocker_required_amounts:
             randomlist = random.sample(range(1, self.blocker_max), 7)
             b_lockers = randomlist
-            b_lockers.append(1)
-            if self.shuffle_loading_zones == "all":
+            if self.shuffle_loading_zones == "all" or self.hard_level_progression:
+                b_lockers.append(random.randint(1, self.blocker_max))
                 random.shuffle(b_lockers)
             else:
+                b_lockers.append(1)
                 b_lockers.sort()
             self.blocker_0 = b_lockers[0]
             self.blocker_1 = b_lockers[1]
@@ -267,6 +268,7 @@ class Settings:
         self.enemy_rando = False
         self.crown_enemy_rando = "off"
         self.enemy_speed_rando = False
+        self.hard_level_progression = False
 
     def shuffle_prices(self):
         """Price randomization. Reuseable if we need to reshuffle prices."""

--- a/randomizer/ShuffleBosses.py
+++ b/randomizer/ShuffleBosses.py
@@ -163,7 +163,7 @@ def ShuffleBossesBasedOnOwnedItems(settings, ownedKongs: dict, ownedMoves: dict)
         if len(newBossMaps) < 7:
             raise FillException("Invalid boss order with fewer than the 7 required main levels.")
     except Exception as ex:
-        if "index out of range" in ex.args[0]:
+        if isinstance(ex.args[0], str) and "index out of range" in ex.args[0]:
             raise BossOutOfLocationsException("No valid locations to place " + bossTryingToBePlaced)
         raise FillException(ex)
 

--- a/randomizer/ShuffleExits.py
+++ b/randomizer/ShuffleExits.py
@@ -286,7 +286,9 @@ def ShuffleLevelExits(newLevelOrder: dict = None):
 
 def ShuffleLevelOrderWithRestrictions(settings: Settings):
     """Determine level order given starting kong and the need to find more kongs along the way."""
-    if settings.starting_kongs_count == 1:
+    if settings.hard_level_progression:
+        newLevelOrder = ShuffleLevelOrderUnrestricted(settings)
+    elif settings.starting_kongs_count == 1:
         newLevelOrder = ShuffleLevelOrderForOneStartingKong(settings)
     else:
         newLevelOrder = ShuffleLevelOrderForMultipleStartingKongs(settings)
@@ -294,6 +296,24 @@ def ShuffleLevelOrderWithRestrictions(settings: Settings):
         raise Ex.EntrancePlacementException("Invalid level order with fewer than the 7 required main levels.")
     settings.level_order = newLevelOrder
     ShuffleLevelExits(newLevelOrder)
+
+
+def ShuffleLevelOrderUnrestricted(settings):
+    """Shuffle the level order without Kong placement restrictions."""
+    newLevelOrder = {
+        1: None,
+        2: None,
+        3: None,
+        4: None,
+        5: None,
+        6: None,
+        7: None,
+    }
+    allLevels = [Levels.JungleJapes, Levels.AngryAztec, Levels.FranticFactory, Levels.GloomyGalleon, Levels.FungiForest, Levels.CrystalCaves, Levels.CreepyCastle]
+    random.shuffle(allLevels)
+    for i in range(len(allLevels)):
+        newLevelOrder[i + 1] = allLevels[i]
+    return newLevelOrder
 
 
 def ShuffleLevelOrderForOneStartingKong(settings):

--- a/static/presets/2dos_special.json
+++ b/static/presets/2dos_special.json
@@ -36,6 +36,7 @@
     "hard_bosses":true,
     "perma_death":false,
     "disable_tag_barrels":true,
+    "hard_level_progression":false,
     "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":true,
     "gnawty_barrels":false,

--- a/static/presets/cfox_luck.json
+++ b/static/presets/cfox_luck.json
@@ -30,6 +30,7 @@
     "hard_bosses":true,
     "perma_death":false,
     "disable_tag_barrels":true,
+    "hard_level_progression":false,
     "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":true,
     "gnawty_barrels":false,

--- a/static/presets/coupled_lzr_balanced.json
+++ b/static/presets/coupled_lzr_balanced.json
@@ -36,6 +36,7 @@
     "hard_bosses":false,
     "perma_death":false,
     "disable_tag_barrels":false,
+    "hard_level_progression":false,
     "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":true,
     "gnawty_barrels":false,

--- a/static/presets/decoupled_lzr_balanced.json
+++ b/static/presets/decoupled_lzr_balanced.json
@@ -36,6 +36,7 @@
     "hard_bosses":false,
     "perma_death":false,
     "disable_tag_barrels":false,
+    "hard_level_progression":false,
     "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":false,
     "gnawty_barrels":false,

--- a/static/presets/default.json
+++ b/static/presets/default.json
@@ -94,6 +94,7 @@
   "hard_bosses": false,
   "perma_death": false,
   "disable_tag_barrels": false,
+  "hard_level_progression":false,
   "disable_shop_hints": false,
   "fps_display": false,
   "random_music": false,

--- a/static/presets/hell.json
+++ b/static/presets/hell.json
@@ -29,6 +29,7 @@
     "hard_bosses":true,
     "perma_death":false,
     "disable_tag_barrels":true,
+    "hard_level_progression":false,
     "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":false,
     "gnawty_barrels":true,

--- a/static/presets/season1.json
+++ b/static/presets/season1.json
@@ -30,6 +30,7 @@
     "hard_bosses":false,
     "perma_death":false,
     "disable_tag_barrels":false,
+    "hard_level_progression":false,
     "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":true,
     "gnawty_barrels":false,

--- a/static/presets/suggested.json
+++ b/static/presets/suggested.json
@@ -30,6 +30,7 @@
     "hard_bosses":false,
     "perma_death":false,
     "disable_tag_barrels":false,
+    "hard_level_progression":false,
     "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":true,
     "gnawty_barrels":false,

--- a/templates/difficulty.html.jinja2
+++ b/templates/difficulty.html.jinja2
@@ -165,6 +165,18 @@
                         Tag Barrels Disabled
                     </label>
                 </div>
+                <div class="form-check form-switch item-switch">
+                    <label data-toggle="tooltip" title="EXPERIMENTAL: Level Order randomizer only. Shuffles levels without regard for key acquisition order or steady Kong progression. May have wildly varying and expensive B. Lockers locking Kongs deep into seeds. Likely to have high cost Troff n Scoffs that require returning to levels later."
+                            style="text-align: left;">
+                        <input class="form-check-input"
+                                type="checkbox"
+                                name="hard_level_progression"
+                                id="hard_level_progression"
+                                value="True"/>
+                        Hard Level Progression
+                    </label>
+                </div>
+                <div class=spacer></div>
             </div>
             <div class = "flex-container">
                 <div class="item-select">

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -195,6 +195,7 @@ def update_boss_required(evt):
     boss_kong = document.getElementById("boss_kong_rando")
     kong_rando = document.getElementById("kong_rando")
     moves = document.getElementById("move_off")
+    hard_level_progression = document.getElementById("hard_level_progression")
     if level.value == "level_order":
         boss_location.setAttribute("disabled", "disabled")
         boss_location.checked = True
@@ -205,6 +206,7 @@ def update_boss_required(evt):
         if moves.selected is True:
             document.getElementById("move_on").selected = True
         moves.setAttribute("disabled", "disabled")
+        hard_level_progression.removeAttribute("disabled")
     elif level.value == "vanilla" and kong_rando.checked:
         boss_location.setAttribute("disabled", "disabled")
         boss_location.checked = True
@@ -212,12 +214,16 @@ def update_boss_required(evt):
         boss_kong.checked = True
         kong_rando.removeAttribute("disabled")
         moves.removeAttribute("disabled")
+        hard_level_progression.setAttribute("disabled", "disabled")
+        hard_level_progression.checked = False
     else:
         try:
             boss_kong.removeAttribute("disabled")
             boss_location.removeAttribute("disabled")
             kong_rando.removeAttribute("disabled")
             moves.removeAttribute("disabled")
+            hard_level_progression.setAttribute("disabled", "disabled")
+            hard_level_progression.checked = False
         except Exception:
             pass
 


### PR DESCRIPTION
Adds a "hard level progression" option that removes the two main restrictions of the existing level order randomizer:
- The logic no longer cares about collecting keys in order
- The logic no longer cares about how many Kongs you have ever

This means that you may have to return to levels later to beat the bosses because future levels have moves or Kongs you need to get more CBs or beat the boss itself. GB requirements for B. Lockers may vary wildly, burying Kongs deep into seeds.

It needs playtesting to fine-tune some of the guesses I made when adjusting B. Lockers and Troff n Scoffs.