### PR TITLE
hint move location edge cases

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1285,6 +1285,15 @@ def SetNewProgressionRequirements(settings: Settings):
         min(settings.blocker_6, max(1, round(random.uniform(BLOCKER_MIN, BLOCKER_MAX) * goldenBananaTotals[5]))),
         settings.blocker_7,  # Last B. Locker shouldn't be affected
     ]
+    # Prevent scenario where B. Lockers randomize to not-always-increasing values
+    if settings.randomize_blocker_required_amounts:
+        for i in range(1, 7):
+            # If this level is more expensive than the next level, swap the B. Lockers
+            # This will never break logic - if you could get into a more expensive level 3, you could get into an equally expensive level 4
+            if settings.EntryGBs[i] > settings.EntryGBs[i + 1]:
+                temp = settings.EntryGBs[i]
+                settings.EntryGBs[i] = settings.EntryGBs[i + 1]
+                settings.EntryGBs[i + 1] = temp
     settings.BossBananas = [
         min(settings.troff_0, sum(coloredBananaCounts[0]), round(settings.troff_0 / (settings.troff_max * settings.troff_weight_0) * sum(coloredBananaCounts[0]))),
         min(settings.troff_1, sum(coloredBananaCounts[1]), round(settings.troff_1 / (settings.troff_max * settings.troff_weight_1) * sum(coloredBananaCounts[1]))),

--- a/randomizer/ShuffleExits.py
+++ b/randomizer/ShuffleExits.py
@@ -197,7 +197,7 @@ def ShuffleExits(settings: Settings):
         if settings.kongs_for_progression:
             ShuffleLevelOrderWithRestrictions(settings)
         else:
-            ShuffleLevelExits()
+            ShuffleLevelExits(settings)
     elif settings.shuffle_loading_zones == "all":
         frontpool = []
         backpool = []
@@ -255,7 +255,7 @@ def UpdateLevelProgression(settings: Settings):
     settings.BossBananas = newBossBananas
 
 
-def ShuffleLevelExits(newLevelOrder: dict = None):
+def ShuffleLevelExits(settings: Settings, newLevelOrder: dict = None):
     """Shuffle level exits according to new level order if provided, otherwise shuffle randomly."""
     frontpool = LobbyEntrancePool.copy()
     backpool = LobbyEntrancePool.copy()
@@ -265,6 +265,26 @@ def ShuffleLevelExits(newLevelOrder: dict = None):
             backpool[index - 1] = LobbyEntrancePool[level]
     else:
         random.shuffle(frontpool)
+
+    # Initialize reference variables
+    lobby_entrance_map = {
+        Transitions.IslesMainToJapesLobby: Levels.JungleJapes,
+        Transitions.IslesMainToAztecLobby: Levels.AngryAztec,
+        Transitions.IslesMainToFactoryLobby: Levels.FranticFactory,
+        Transitions.IslesMainToGalleonLobby: Levels.GloomyGalleon,
+        Transitions.IslesMainToForestLobby: Levels.FungiForest,
+        Transitions.IslesMainToCavesLobby: Levels.CrystalCaves,
+        Transitions.IslesMainToCastleLobby: Levels.CreepyCastle,
+    }
+    shuffledLevelOrder = {
+        1: None,
+        2: None,
+        3: None,
+        4: None,
+        5: None,
+        6: None,
+        7: None,
+    }
 
     # For each back exit, select a random valid front entrance to attach to it
     # Assuming there are no inherently invalid level orders, but if there are, validation will check after this
@@ -282,7 +302,9 @@ def ShuffleLevelExits(newLevelOrder: dict = None):
         backReverse = ShufflableExits[backExit.back.reverse]
         backReverse.shuffled = True
         backReverse.shuffledId = frontExit.back.reverse
-        # print("Assigned " + ShufflableExits[backExit.back.reverse].name + " --> " + ShufflableExits[frontExit.back.reverse].name)
+
+        shuffledLevelOrder[lobby_entrance_map[frontId] + 1] = lobby_entrance_map[backId]
+    settings.level_order = shuffledLevelOrder
 
 
 def ShuffleLevelOrderWithRestrictions(settings: Settings):
@@ -293,8 +315,7 @@ def ShuffleLevelOrderWithRestrictions(settings: Settings):
         newLevelOrder = ShuffleLevelOrderForMultipleStartingKongs(settings)
     if None in newLevelOrder.values():
         raise Ex.EntrancePlacementException("Invalid level order with fewer than the 7 required main levels.")
-    settings.level_order = newLevelOrder
-    ShuffleLevelExits(newLevelOrder)
+    ShuffleLevelExits(settings, newLevelOrder)
 
 
 def ShuffleLevelOrderForOneStartingKong(settings):


### PR DESCRIPTION
Another rework to hint move locations, this time to better cover 5 kong starts and potential ties in B. Lockers.
Fixes some bugs:
- Changes how hints are skipped when no more locations are available to avoid a bad reference bug
- Prevent B. Lockers from being out of order in standard level order rando. This usually manifested as a level 4 being cheaper than a level 3.