### PR TITLE
prevent psychotically difficulty seeds unless requested

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1425,7 +1425,7 @@ def SetNewProgressionRequirementsUnordered(settings: Settings):
     # Until we've completed every level...
     while len(levelsProgressed) < 7:
         # Pick a random accessible B. Locker
-        accessibleIncompleteLevels = [level for level in openLevels if level not in levelsProgressed and settings.EntryGBs[level] <= runningGBTotal]
+        accessibleIncompleteLevels = [level for level in openLevels if level not in levelsProgressed and settings.EntryGBs[level] <= round(runningGBTotal * BLOCKER_MAX)]
         # If we have no levels accessible, we need to lower a B. Locker count to make one accessible
         if len(accessibleIncompleteLevels) == 0:
             openUnprogressedLevels = [level for level in openLevels if level not in levelsProgressed]
@@ -1445,7 +1445,7 @@ def SetNewProgressionRequirementsUnordered(settings: Settings):
                 settings.EntryGBs[incompleteLevelWithLowestBLocker] = settings.EntryGBs[nextLevelToBeat]
                 settings.EntryGBs[nextLevelToBeat] = temp
             # If the level still isn't accessible, we have to truncate the required amount
-            if settings.EntryGBs[nextLevelToBeat] > runningGBTotal:
+            if settings.EntryGBs[nextLevelToBeat] > round(runningGBTotal * BLOCKER_MAX):
                 # Each B. Locker must be greater than the previous one and at least a specified percentage of availalbe GBs
                 settings.EntryGBs[nextLevelToBeat] = random.randint(max(minimumBLockerGBs, round(runningGBTotal * BLOCKER_MIN)), round(runningGBTotal * BLOCKER_MAX))
             accessibleIncompleteLevels = [nextLevelToBeat]

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -404,7 +404,9 @@ class Spoiler:
                 "Creepy Castle": [],
             }
             for group in self.cb_placements:
-                humanspoiler["Colored Banana Locations"][level_dict[group["level"]]].append(NameFromKong(group["kong"]) + human_cb_type_map[group["type"]] + ": " + Maps(group["map"]).name + " - " + group["name"])
+                humanspoiler["Colored Banana Locations"][level_dict[group["level"]]].append(
+                    NameFromKong(group["kong"]) + human_cb_type_map[group["type"]] + ": " + Maps(group["map"]).name + " - " + group["name"]
+                )
 
         return json.dumps(humanspoiler, indent=4)
 

--- a/templates/difficulty.html.jinja2
+++ b/templates/difficulty.html.jinja2
@@ -169,35 +169,38 @@
                     </label>
                 </div>
                 <div class="form-check form-switch item-switch">
-                    <label data-toggle="tooltip" title="Only relevant in Level Order shuffle. Generally increase the values randomly rolled by B. Lockers, making them closer to the total number of available GBs."
-                            style="text-align: left;">
+                    <label data-toggle="tooltip"
+                           title="Only relevant in Level Order shuffle. Generally increase the values randomly rolled by B. Lockers, making them closer to the total number of available GBs."
+                           style="text-align: left;">
                         <input class="form-check-input"
-                                type="checkbox"
-                                name="hard_blockers"
-                                id="hard_blockers"
-                                value="True"/>
+                               type="checkbox"
+                               name="hard_blockers"
+                               id="hard_blockers"
+                               value="True"/>
                         Hard B. Lockers
                     </label>
                 </div>
                 <div class="form-check form-switch item-switch">
-                    <label data-toggle="tooltip" title="Increase the minimum values rollable by Troff n Scoff."
-                            style="text-align: left;">
+                    <label data-toggle="tooltip"
+                           title="Increase the minimum values rollable by Troff n Scoff."
+                           style="text-align: left;">
                         <input class="form-check-input"
-                                type="checkbox"
-                                name="hard_troff_n_scoff"
-                                id="hard_troff_n_scoff"
-                                value="True"/>
+                               type="checkbox"
+                               name="hard_troff_n_scoff"
+                               id="hard_troff_n_scoff"
+                               value="True"/>
                         Hard Troff N' Scoff
                     </label>
                 </div>
                 <div class="form-check form-switch item-switch">
-                    <label data-toggle="tooltip" title="EXPERIMENTAL: Level Order randomizer only. Shuffles levels without regard for key acquisition order or steady Kong progression. May have wildly varying and expensive B. Lockers locking Kongs deep into seeds. Likely to have high cost Troff n Scoffs that require returning to levels later."
-                            style="text-align: left;">
+                    <label data-toggle="tooltip"
+                           title="EXPERIMENTAL: Level Order randomizer only. Shuffles levels without regard for key acquisition order or steady Kong progression. May have wildly varying and expensive B. Lockers locking Kongs deep into seeds. Likely to have high cost Troff n Scoffs that require returning to levels later."
+                           style="text-align: left;">
                         <input class="form-check-input"
-                                type="checkbox"
-                                name="hard_level_progression"
-                                id="hard_level_progression"
-                                value="True"/>
+                               type="checkbox"
+                               name="hard_level_progression"
+                               id="hard_level_progression"
+                               value="True"/>
                         Hard Level Progression
                     </label>
                 </div>

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -184,12 +184,13 @@
                     </label>
                 </div>
                 <div class="form-check form-switch item-switch">
-                    <label data-toggle="tooltip" title="Shuffle the locations of colored bananas within each Level.">
+                    <label data-toggle="tooltip"
+                           title="Shuffle the locations of colored bananas within each Level.">
                         <input class="form-check-input"
-                                type="checkbox"
-                                name="cb_rando"
-                                id="cb_rando"
-                                value="True"/>
+                               type="checkbox"
+                               name="cb_rando"
+                               id="cb_rando"
+                               value="True"/>
                         Shuffle Colored Banana Locations
                     </label>
                 </div>


### PR DESCRIPTION
Sometimes on hard level progression seed gen it wouldn't reduce B. Lockers when the value was above the settings-specified percentage of maximum available GBs, leading to insanely hard seeds without Hard B. Lockers active.