### PR TITLE
Hint distro tweak

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -125,6 +125,10 @@ hint_list = [
     Hint(hint="Why do they call it oven when you of in the cold food of out hot eat the food?", important=False, base=True),
     Hint(hint="Wanna become famous? Buy followers, coconuts and donks at DK64Randomizer (DK64Randomizer . com)!", important=False, base=True),
     Hint(hint="What you gonna do, SpikeVegeta?", important=False, base=True),
+    Hint(hint="You don't care? Just give it to me? Okay, here it is.", important=False, base=True),
+    Hint(hint="Rumor has it this game was developed in a cave with only a box of scraps!", important=False, base=True),
+    Hint(hint="If you backflip right before Chunky punches K. Rool, you must go into first person camera to face him before the punch.", important=False, base=True),
+    Hint(hint="The barrier to Hideout Helm can be cleared by obtaining 801 Golden Bananas. It can also be cleared with fewer than that.", important=False, base=True),
 ]
 
 kong_list = ["Donkey", "Diddy", "Lanky", "Tiny", "Chunky"]

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -275,9 +275,9 @@ kong_placement_levels = [
 hint_distribution = {
     HintType.Joke: 1,
     HintType.KRoolOrder: 2,
-    HintType.HelmOrder: 3,  # must have one on the path
+    HintType.HelmOrder: 2,  # must have one on the path
     HintType.FullShop: 8,
-    HintType.MoveLocation: 8,  # must be placed before you can buy the move
+    HintType.MoveLocation: 7,  # must be placed before you can buy the move
     HintType.DirtPatch: 0,
     HintType.BLocker: 3,  # must be placed on the path and before the level they hint
     HintType.TroffNScoff: 0,


### PR DESCRIPTION
Based on feedback, a very light touch to the hint distribution.

It sounds like putting a hint "on the path" is making them appear very often, so we don't need as many helm order hints.

Pulling one off move locations. This is intended to increase the variance a little bit, as it will be redistributed randomly among the possible hints.

Also added a few more joke hints.