### PR TITLE
Adjust shop scales

### DIFF
--- a/randomizer/Patching/ShopRandomizer.py
+++ b/randomizer/Patching/ShopRandomizer.py
@@ -86,23 +86,23 @@ def ApplyShopRandomizer(spoiler: Spoiler):
                             search_model = 0x124
                             search_lz = Maps.Candy
                             search_rot = 0
-                            search_scale = 1
+                            search_scale = 0.95
                         else:
                             new_model = 0x124
                             new_lz = Maps.Candy
                             new_rot = 0
-                            new_scale = 1
+                            new_scale = 0.95
                     elif x == Regions.FunkyGeneric:
                         if x_i == 0:
                             search_model = 0x7A
                             search_lz = Maps.Funky
                             search_rot = 90
-                            search_scale = 1.1
+                            search_scale = 1.045
                         else:
                             new_model = 0x7A
                             new_lz = Maps.Funky
                             new_rot = 90
-                            new_scale = 1.1
+                            new_scale = 1.045
                     elif x == Regions.Snide:
                         if x_i == 0:
                             search_model = 0x79


### PR DESCRIPTION
Fixes the following
> MadagascarDave — Today at 4:10 AM
> so I had a shop shuffle problem in caves. Candy shop at Cranky spot. I could get through the door with Tiny and Diddy but Chunky and DK wouldn't go in. I ended up going in with the smaller kong and switching just as I entered to progress, but I know quick swap isn't supposed to be logic