### PR TITLE
Add slams to woth

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -412,6 +412,9 @@ def PareWoth(settings, PlaythroughLocations):
         locationId = WothLocations[i]
         location = LocationList[locationId]
         item = location.item
+        # ParePlaythrough already removes unnecessary slams. Any slams that get here are required.
+        if item == Items.ProgressiveSlam:
+            continue
         location.item = None
         # Check if game is still beatable
         Reset()


### PR DESCRIPTION
In the current flow `ParePlaythrough` pares one slam and then `PareWoth` pares the other, so no slams make it to the way of the hoard in the spoiler log (unless one is locked by the other - unfathomably rare) despite one of them being definitely required.