### PR TITLE
Training and BFI Move Placement and Logic

### DIFF
--- a/randomizer/CollectibleLogicFiles/AngryAztec.py
+++ b/randomizer/CollectibleLogicFiles/AngryAztec.py
@@ -129,7 +129,7 @@ LogicRegions = {
         Collectible(Collectibles.banana, Kongs.lanky, lambda l: True, None, 6),
         Collectible(Collectibles.bunch, Kongs.lanky, lambda l: lambda l: True, None, 1),  # Warp 1
         Collectible(Collectibles.balloon, Kongs.lanky, lambda l: lambda l: Events.AztecLlamaSpit in l.Events and l.grape and l.swim, None, 2),
-        Collectible(Collectibles.bunch, Kongs.lanky, lambda l: lambda l: l.grape, None, 1),  # Matching game
+        Collectible(Collectibles.bunch, Kongs.lanky, lambda l: lambda l: l.grape and l.vines, None, 1),  # Matching game
 
         Collectible(Collectibles.balloon, Kongs.tiny, lambda l: l.feather, None, 1),
         Collectible(Collectibles.banana, Kongs.tiny, lambda l: True, None, 3),

--- a/randomizer/Enums/Items.py
+++ b/randomizer/Enums/Items.py
@@ -64,6 +64,8 @@ class Items(IntEnum):
     NintendoCoin = auto()
     RarewareCoin = auto()
 
+    Camera = auto()
+    Shockwave = auto()
     CameraAndShockwave = auto()
 
     JungleJapesKey = auto()

--- a/randomizer/Enums/MoveTypes.py
+++ b/randomizer/Enums/MoveTypes.py
@@ -10,3 +10,4 @@ class MoveTypes(IntEnum):
     Guns = auto()
     AmmoBelt = auto()
     Instruments = auto()
+    Flag = auto()

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1038,7 +1038,7 @@ def FillKongsAndMoves(spoiler):
     itemsToPlace = []
     validLocations = {}
     preplacedPriorityMoves = []
-    trainingMoveBlockedLocations = {}
+    trainingMoveBlockedLocations = set({})
 
     # Handle kong rando
     if spoiler.settings.kong_rando:

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -21,7 +21,7 @@ from randomizer.Enums.Transitions import Transitions
 from randomizer.Enums.Types import Types
 from randomizer.Enums.Warps import Warps
 from randomizer.Lists.Item import ItemList, KongFromItem
-from randomizer.Lists.Location import LocationList
+from randomizer.Lists.Location import Location, LocationList
 from randomizer.Lists.MapsAndExits import Maps
 from randomizer.Lists.Minigame import BarrelMetaData, MinigameRequirements
 from randomizer.Lists.ShufflableExit import GetLevelShuffledToIndex, GetShuffledLevelIndex
@@ -719,20 +719,22 @@ def GetItemPrerequisites(spoiler, targetItemId, ownedKongs=[]):
     return requiredMoves
 
 
-def GetValidLocationsForMove(spoiler, move):
+def GetValidLocationsForMove(spoiler, move, blockedLocations={}):
     """Return the valid locations for the given move. Currently only returns shop locations for moves."""
-    validLocations = []
+    validLocations = set({})
     if spoiler.settings.move_rando == "cross_purchase" or move in ItemPool.DonkeyMoves:
-        validLocations.extend(ItemPool.DonkeyMoveLocations.copy())
+        validLocations.update(ItemPool.DonkeyMoveLocations.copy())
     if spoiler.settings.move_rando == "cross_purchase" or move in ItemPool.DiddyMoves:
-        validLocations.extend(ItemPool.DiddyMoveLocations.copy())
+        validLocations.update(ItemPool.DiddyMoveLocations.copy())
     if spoiler.settings.move_rando == "cross_purchase" or move in ItemPool.TinyMoves:
-        validLocations.extend(ItemPool.TinyMoveLocations.copy())
+        validLocations.update(ItemPool.TinyMoveLocations.copy())
     if spoiler.settings.move_rando == "cross_purchase" or move in ItemPool.ChunkyMoves:
-        validLocations.extend(ItemPool.ChunkyMoveLocations.copy())
+        validLocations.update(ItemPool.ChunkyMoveLocations.copy())
     if spoiler.settings.move_rando == "cross_purchase" or move in ItemPool.LankyMoves:
-        validLocations.extend(ItemPool.LankyMoveLocations.copy())
-    return list(validLocations)
+        validLocations.update(ItemPool.LankyMoveLocations.copy())
+    if spoiler.settings.training_barrels == "shuffled":
+        validLocations.update(ItemPool.TrainingBarrelLocations.copy())
+    return list(validLocations - blockedLocations)
 
 
 def PlaceItems(settings, algorithm, itemsToPlace, ownedItems=None, validLocations=None, isPriorityMove=False):
@@ -818,6 +820,24 @@ def ShuffleSharedMoves(spoiler):
 
     # When a shared move is assigned to a shop in any particular level, that shop cannot also hold any kong-specific moves.
     # To avoid conflicts, first determine which level shops will have shared moves then remove these shops from each kong's valid locations list
+    if spoiler.settings.training_barrels != "normal":
+        # First place training moves that are not placed. By this point, only Oranges need to be placed here as the others are important to place even earlier than this
+        trainingMovesUnplaced = PlaceItems(spoiler.settings, "assumed", [Items.Oranges], [x for x in ItemPool.AllItems(spoiler.settings) if x != Items.Oranges], availableSharedShops)
+        if trainingMovesUnplaced > 0:
+            raise Ex.ItemPlacementException("Failed to place Orange training barrel move.")
+    # Next place any fairy moves that need placing, settings dependent
+    if spoiler.settings.shockwave_status == "shuffled":
+        shockwaveCameraUnplaced = PlaceItems(
+            spoiler.settings, "assumed", [Items.CameraAndShockwave], [x for x in ItemPool.AllItems(spoiler.settings) if x != Items.CameraAndShockwave], availableSharedShops
+        )
+        if shockwaveCameraUnplaced > 0:
+            raise Ex.ItemPlacementException("Failed to place Camera and Shockwave combo.")
+    elif spoiler.settings.shockwave_status == "shuffled_decoupled":
+        shockwaveCameraUnplaced = PlaceItems(
+            spoiler.settings, "assumed", [Items.Camera, Items.Shockwave], [x for x in ItemPool.AllItems(spoiler.settings) if x not in (Items.Camera, Items.Shockwave)], availableSharedShops
+        )
+        if shockwaveCameraUnplaced > 0:
+            raise Ex.ItemPlacementException("Failed to place " + str(trainingMovesUnplaced) + " of Camera and Shockwave.")
     importantSharedUnplaced = PlaceItems(
         spoiler.settings, "assumed", ItemPool.ImportantSharedMoves.copy(), [x for x in ItemPool.AllItems(spoiler.settings) if x not in ItemPool.ImportantSharedMoves], availableSharedShops
     )
@@ -1018,6 +1038,7 @@ def FillKongsAndMoves(spoiler):
     itemsToPlace = []
     validLocations = {}
     preplacedPriorityMoves = []
+    trainingMoveBlockedLocations = {}
 
     # Handle kong rando
     if spoiler.settings.kong_rando:
@@ -1039,6 +1060,64 @@ def FillKongsAndMoves(spoiler):
         # Specialized Kong placement function that will never fail to find a beatable combination of Kong unlocks
         PlaceKongs(spoiler, kongItems, [x for x in kongLocations])
 
+    # Once Kongs are placed, the top priority is placing training barrel moves first. These (mostly) need to be very early because they block access to whole levels.
+    if spoiler.settings.shuffle_items == "moves" and spoiler.settings.training_barrels == "shuffled":
+        # First place barrels - needed for most bosses
+        if spoiler.settings.shuffle_loading_zones != "all" and not spoiler.settings.hard_level_progression:
+            # In standard level order, place barrels very early to prevent same-y boss orders
+            needBarrelsByThisLevel = 2
+            BlockAccessToLevel(spoiler.settings, needBarrelsByThisLevel)
+        Reset()
+        possibleMovesBeforeBarrels = ItemPool.AllKongMoves().copy()
+        possibleMovesBeforeBarrels.append(Items.Vines)  # If Aztec is 1, you could be required to get vines and then barrels in Aztec
+        unplacedBarrels = PlaceItems(spoiler.settings, "assumed", [Items.Barrels], ownedItems=possibleMovesBeforeBarrels, validLocations=ItemPool.SharedMoveLocations.copy(), isPriorityMove=True)
+        if unplacedBarrels > 0:
+            raise Ex.ItemPlacementException("Failed to place barrel training somehow.")
+        # Next place vines - needed to beat Aztec and maybe get to upper DK Isle
+        if spoiler.settings.shuffle_loading_zones != "all" and not spoiler.settings.hard_level_progression:
+            needVinesByThisLevel = 2
+            # In a standard level order seed, we need to place vines before Aztec (or else it isn't beatable)
+            for i in range(1, 8):
+                if spoiler.settings.level_order[i] == Levels.AngryAztec:
+                    needVinesByThisLevel = i
+                    break
+            # If we don't have at least Isles warps on, we also need it to access level 2 (and 6)
+            if spoiler.settings.activate_all_bananaports == "off":
+                # The vine level is whatever comes first: Aztec or level 2
+                needVinesByThisLevel = min(2, needVinesByThisLevel)
+            BlockAccessToLevel(spoiler.settings, needVinesByThisLevel)
+        Reset()
+        unplacedVines = PlaceItems(spoiler.settings, "assumed", [Items.Vines], ownedItems=ItemPool.AllKongMoves().copy(), validLocations=ItemPool.SharedMoveLocations.copy(), isPriorityMove=True)
+        if unplacedVines > 0:
+            raise Ex.ItemPlacementException("Failed to place vine training somehow.")
+        # Next place swim - needed to get into level 4
+        if spoiler.settings.shuffle_loading_zones != "all" and not spoiler.settings.hard_level_progression:
+            # In a standard level order seed, we need swim to access level 4 (whatever it is)
+            needSwimByThisLevel = 4
+            BlockAccessToLevel(spoiler.settings, needSwimByThisLevel)
+        else:
+            BlockAccessToLevel(spoiler.settings, 100)
+        Reset()
+        unplacedSwim = PlaceItems(spoiler.settings, "assumed", [Items.Swim], ownedItems=ItemPool.AllKongMoves().copy(), validLocations=ItemPool.SharedMoveLocations.copy(), isPriorityMove=True)
+        if unplacedSwim > 0:
+            raise Ex.ItemPlacementException("Failed to place swimming training somehow.")
+        # If we placed one of these training moves inside BFI, we need to priority place Mini Monkey as well
+        if spoiler.settings.shuffle_loading_zones != "all" and not spoiler.settings.hard_level_progression and LocationList[Locations.CameraAndShockwave].item in (Items.Vines, Items.Swim):
+            # Unblock levels - having training moves placed effectively blocks all levels mini can't be placed in
+            BlockAccessToLevel(spoiler.settings, 100)
+            allItemsButMini = ItemPool.AllKongMoves().copy()
+            allItemsButMini.remove(Items.MiniMonkey)
+            unplacedMini = PlaceItems(spoiler.settings, "assumed", [Items.MiniMonkey], ownedItems=allItemsButMini, validLocations=ItemPool.TinyMoveLocations.copy(), isPriorityMove=True)
+            if unplacedMini > 0:
+                raise Ex.ItemPlacementException("Failed to place Mini Monkey as a dependency for a training move somehow.")
+        # Find out what locations we cannot place moves in now that we took some shops out of the pool
+        trainingMoveShops = []
+        for sharedLocation in ItemPool.SharedMoveLocations:
+            if LocationList[sharedLocation].item is not None:
+                trainingMoveShops.append(sharedLocation)
+        trainingMoveBlockedLocations = ItemPool.GetMoveLocationsToRemove(trainingMoveShops)
+
+    if spoiler.settings.kong_rando:
         # If kongs are our progression, then place moves that unlock those kongs before anything else
         # This logic only matters if the level order is critical to progression (i.e. not loading zone shuffled)
         if spoiler.settings.kongs_for_progression and spoiler.settings.shuffle_loading_zones != "all" and spoiler.settings.move_rando != "start_with":
@@ -1072,14 +1151,14 @@ def FillKongsAndMoves(spoiler):
                     directPrerequisiteMoves = GetItemPrerequisites(spoiler, LocationList[Locations.DiddyKong].item, ownedKongs)
                     for move in directPrerequisiteMoves:
                         if move not in preplacedPriorityMoves:
-                            priorityItemsDict[move] = GetValidLocationsForMove(spoiler, move)
+                            priorityItemsDict[move] = GetValidLocationsForMove(spoiler, move, trainingMoveBlockedLocations)
                 if spoiler.settings.level_order[levelIndex] == Levels.AngryAztec and Locations.TinyKong in locationsLockingKongs and spoiler.settings.tiny_freeing_kong in ownedKongs:
                     locationsLockingKongs.remove(Locations.TinyKong)
                     kongToBeGained = ItemPool.GetKongForItem(LocationList[Locations.TinyKong].item)
                     directPrerequisiteMoves = GetItemPrerequisites(spoiler, LocationList[Locations.TinyKong].item, ownedKongs)
                     for move in directPrerequisiteMoves:
                         if move not in preplacedPriorityMoves:
-                            priorityItemsDict[move] = GetValidLocationsForMove(spoiler, move)
+                            priorityItemsDict[move] = GetValidLocationsForMove(spoiler, move, trainingMoveBlockedLocations)
                 elif (
                     spoiler.settings.level_order[levelIndex] == Levels.AngryAztec
                     and Locations.LankyKong in locationsLockingKongs
@@ -1093,7 +1172,7 @@ def FillKongsAndMoves(spoiler):
                     directPrerequisiteMoves = GetItemPrerequisites(spoiler, LocationList[Locations.LankyKong].item, ownedKongs)
                     for move in directPrerequisiteMoves:
                         if move not in preplacedPriorityMoves:
-                            priorityItemsDict[move] = GetValidLocationsForMove(spoiler, move)
+                            priorityItemsDict[move] = GetValidLocationsForMove(spoiler, move, trainingMoveBlockedLocations)
 
                 # Place the priority items and any items they may depend on
                 while any(priorityItemsDict):
@@ -1132,7 +1211,7 @@ def FillKongsAndMoves(spoiler):
                         for move in dependencyPriorityMoves:
                             # If we haven't placed it already, find the possible locations and prep the dictionary for the next loop
                             if move not in preplacedPriorityMoves:
-                                priorityItemDependencyDict[move] = GetValidLocationsForMove(spoiler, move)
+                                priorityItemDependencyDict[move] = GetValidLocationsForMove(spoiler, move, trainingMoveBlockedLocations)
                     # If we found any dependencies, we have to check for further dependencies
                     priorityItemsDict = priorityItemDependencyDict
                 # Update progression with any newly acquired Kongs
@@ -1169,6 +1248,38 @@ def FillKongsAndMoves(spoiler):
     unplaced = PlaceItems(spoiler.settings, "assumed", itemsToPlace, [], validLocations=validLocations)
     if unplaced > 0:
         raise Ex.ItemPlacementException(str(unplaced) + " unplaced items.")
+
+    # Final touches to item placement, some locations need special treatment
+    if spoiler.settings.shuffle_items == "moves":
+        # If we're shuffling training moves, always put a move in each training barrel
+        if spoiler.settings.training_barrels == "shuffled":
+            emptyTrainingBarrels = [loc for loc in ItemPool.TrainingBarrelLocations if LocationList[loc].item is None]
+            if len(emptyTrainingBarrels) > 0:
+                # Find the list of locations that have a kong move in them
+                kongMoveLocationsList = []
+                for location in ItemPool.DonkeyMoveLocations:
+                    if LocationList[location].item is not None:
+                        kongMoveLocationsList.append(location)
+                for location in ItemPool.DiddyMoveLocations:
+                    if LocationList[location].item is not None:
+                        kongMoveLocationsList.append(location)
+                for location in ItemPool.LankyMoveLocations:
+                    if LocationList[location].item is not None:
+                        kongMoveLocationsList.append(location)
+                for location in ItemPool.TinyMoveLocations:
+                    if LocationList[location].item is not None:
+                        kongMoveLocationsList.append(location)
+                for location in ItemPool.ChunkyMoveLocations:
+                    if LocationList[location].item is not None:
+                        kongMoveLocationsList.append(location)
+                # Worth noting that moving a move to the training barrels will always make it more accessible, and thus doesn't need any additional logic
+                for emptyBarrel in emptyTrainingBarrels:
+                    # Pick a random Kong move to put in the training barrel. This should be both more interesting than a shared move and lead to fewer empty shops.
+                    locationToVacate = random.choice(kongMoveLocationsList)
+                    itemToBeMoved = LocationList[locationToVacate].item
+                    LocationList[emptyBarrel].PlaceItem(itemToBeMoved)
+                    LocationList[locationToVacate].PlaceItem(Items.NoItem)
+                    kongMoveLocationsList.remove(locationToVacate)
 
 
 def FillKongsAndMovesForLevelOrder(spoiler):
@@ -1252,7 +1363,7 @@ def WipeProgressionRequirements(settings: Settings):
         settings.BossBananas[i] = 0
         # Assume starting kong can beat all the bosses for now
         settings.boss_kongs[i] = settings.starting_kong
-        settings.boss_maps[i] = Maps.JapesBoss
+        settings.boss_maps[i] = Maps.CastleBoss
     # Also for now consider any kong can free any other kong, to avoid false failures in fill
     if settings.kong_rando:
         settings.diddy_freeing_kong = Kongs.any
@@ -1287,7 +1398,9 @@ def SetNewProgressionRequirements(settings: Settings):
             ownedMoves[previousLevel] = allMoves
         else:
             accessibleMoves = [
-                LocationList[x].item for x in accessible if LocationList[x].type in (Types.TrainingBarrel, Types.Shop) and LocationList[x].item != Items.NoItem and LocationList[x].item is not None
+                LocationList[x].item
+                for x in accessible
+                if LocationList[x].type in (Types.TrainingBarrel, Types.Shop, Types.Shockwave) and LocationList[x].item != Items.NoItem and LocationList[x].item is not None
             ]
             ownedMoves[previousLevel] = accessibleMoves
     # Cap the B. Locker amounts based on a random fraction of accessible bananas & GBs
@@ -1419,6 +1532,25 @@ def SetNewProgressionRequirementsUnordered(settings: Settings):
     if 6 in openLobbyIndexes and Kongs.donkey not in settings.starting_kong_list and Kongs.chunky not in settings.starting_kong_list:
         openLobbyIndexes.remove(6)
         kongLockedCavesLobby = True  # If we don't have one yet, keep track of that as we progress
+    # We may need training moves for access to some lobbies
+    moveLockedCavesLobby = False
+    moveLockedAztecLobby = False
+    moveLockedGalleonLobby = False
+    if settings.training_barrels != "normal":
+        startingItems = [LocationList[loc].item for loc in ItemPool.TrainingBarrelLocations]
+        # Vines only matter if we don't have Isles warps activated
+        if settings.activate_all_bananaports == "off" and Items.Vines not in startingItems:
+            # Aztec lobby requires vines
+            if 2 in openLobbyIndexes:
+                openLobbyIndexes.remove(2)
+                moveLockedAztecLobby = True
+            # Caves lobby requires vines
+            if 6 in openLobbyIndexes:
+                openLobbyIndexes.remove(6)
+                moveLockedCavesLobby = True
+        # Galleon lobby requires swim
+        if 4 in openLobbyIndexes and Items.Swim not in startingItems:
+            openLobbyIndexes.remove(4)
     # Convert indexes to the shuffled levels
     openLevels = [settings.level_order[index] for index in openLobbyIndexes]
     foundProgressionKeyEvents = []
@@ -1430,8 +1562,13 @@ def SetNewProgressionRequirementsUnordered(settings: Settings):
         # If we have no levels accessible, we need to lower a B. Locker count to make one accessible
         if len(accessibleIncompleteLevels) == 0:
             openUnprogressedLevels = [level for level in openLevels if level not in levelsProgressed]
+            # Galleon isn't beatable without vines or swim, but it could contain those moves so we can't block it from being chosen
+            # Aztec is not progressible if we don't have vines yet
+            if Levels.AngryAztec in openUnprogressedLevels:
+                if Items.Vines not in [LocationList[x].item for x in accessible if LocationList[x].type in (Types.TrainingBarrel, Types.Shop, Types.Shockwave)]:
+                    openUnprogressedLevels.remove(Levels.AngryAztec)
             if len(openUnprogressedLevels) == 0:
-                raise Ex.FillException("Hard level order shuffler failed to progress through levels somehow - SEND THIS TO THE DEVS!")
+                raise Ex.FillException("Hard level order shuffler failed to progress through levels.")
             # Next level chosen randomly (possible room for improvement here?) from accessible levels
             nextLevelToBeat = random.choice(openUnprogressedLevels)
             # If we are allowed to randomize B. Lockers as we please, try to swap a lower random B. Locker value with this level's
@@ -1483,18 +1620,20 @@ def SetNewProgressionRequirementsUnordered(settings: Settings):
             chosenKeyEvent = random.choice(foundProgressionKeyEvents)
             foundProgressionKeyEvents.remove(chosenKeyEvent)
             # Determine what level needs to be completed
+            # Assume levels that could be locked by moves are locked - this will be fixed at the end of this loop
             if chosenKeyEvent == Events.JapesKeyTurnedIn:
-                openLevels.append(settings.level_order[2])
+                moveLockedAztecLobby = True
                 bossCompletedLevel = settings.level_order[1]
             elif chosenKeyEvent == Events.AztecKeyTurnedIn:
                 openLevels.append(settings.level_order[3])
-                openLevels.append(settings.level_order[4])
+                moveLockedGalleonLobby = True
                 bossCompletedLevel = settings.level_order[2]
             elif chosenKeyEvent == Events.GalleonKeyTurnedIn:
                 openLevels.append(settings.level_order[5])
                 bossCompletedLevel = settings.level_order[4]
             elif chosenKeyEvent == Events.ForestKeyTurnedIn:
                 kongLockedCavesLobby = True
+                moveLockedCavesLobby = True
                 openLevels.append(settings.level_order[7])
                 bossCompletedLevel = settings.level_order[5]
             availableCBs = sum(LogicVariables.ColoredBananas[bossCompletedLevel])
@@ -1510,20 +1649,42 @@ def SetNewProgressionRequirementsUnordered(settings: Settings):
                 ownedMoves[bossCompletedLevel] = allMoves
             else:
                 accessibleMoves = [
-                    LocationList[x].item for x in accessible if LocationList[x].type in (Types.TrainingBarrel, Types.Shop) and LocationList[x].item != Items.NoItem and LocationList[x].item is not None
+                    LocationList[x].item
+                    for x in accessible
+                    if LocationList[x].type in (Types.TrainingBarrel, Types.Shop, Types.Shockwave) and LocationList[x].item != Items.NoItem and LocationList[x].item is not None
                 ]
                 ownedMoves[bossCompletedLevel] = accessibleMoves
 
-        # Check Caves Lobby entrance accessibility. This is independent all other checks because it's not the key that unlocks the kongs, it's the level itself.
+        # Check for new Lobby entrance accessibility. This is independent all other checks because it's not the key that unlocks the lobby, it's the contents of the level itself.
+        # See if we got a kong that gives Caves Lobby access
         if kongLockedCavesLobby:
             ownedKongsByThisLevel = LogicVariables.GetKongs()
             if (
                 Kongs.donkey in ownedKongsByThisLevel
                 or Kongs.chunky in ownedKongsByThisLevel
-                or (Kongs.tiny in ownedKongsByThisLevel and Items.PonyTailTwirl in [LocationList[x].item for x in accessible if LocationList[x].type == Types.Shop])
+                or (
+                    Kongs.tiny in ownedKongsByThisLevel
+                    and Items.PonyTailTwirl in [LocationList[x].item for x in accessible if LocationList[x].type in (Types.TrainingBarrel, Types.Shop, Types.Shockwave)]
+                )
             ):
                 kongLockedCavesLobby = False
-                openLevels.append(settings.level_order[6])
+                if not moveLockedCavesLobby:  # Might still be move locked
+                    openLevels.append(settings.level_order[6])
+        # See if we got vines or access to upper isles
+        if moveLockedAztecLobby or moveLockedCavesLobby:
+            if settings.activate_all_bananaports != "off" or Items.Vines in [LocationList[x].item for x in accessible if LocationList[x].type in (Types.TrainingBarrel, Types.Shop, Types.Shockwave)]:
+                if moveLockedAztecLobby:
+                    moveLockedAztecLobby = False
+                    openLevels.append(settings.level_order[2])
+                if moveLockedCavesLobby:
+                    moveLockedCavesLobby = False
+                    if not kongLockedCavesLobby:
+                        openLevels.append(settings.level_order[6])
+        # See if we got swim for Galleon Lobby entrance
+        if moveLockedGalleonLobby:
+            if Items.Swim in [LocationList[x].item for x in accessible if LocationList[x].type in (Types.TrainingBarrel, Types.Shop, Types.Shockwave)]:
+                moveLockedGalleonLobby = False
+                openLevels.append(settings.level_order[4])
 
     # We still need to set T&S for some levels, but we'll have access to every level by this point
     for level in range(len(settings.BossBananas)):

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -37,6 +37,10 @@ def PlaceConstants(settings):
             shuffledLocations.extend(TinyMoveLocations)
             shuffledLocations.extend(ChunkyMoveLocations)
             shuffledLocations.extend(SharedMoveLocations)
+            if settings.training_barrels == "shuffled":
+                shuffledLocations.extend(TrainingBarrelLocations)
+            if settings.shockwave_status != "vanilla":
+                shuffledLocations.append(Locations.CameraAndShockwave)
         if settings.kong_rando:
             shuffledLocations.append(Locations.DiddyKong)
             shuffledLocations.append(Locations.LankyKong)
@@ -54,7 +58,7 @@ def PlaceConstants(settings):
         # All locations NOT shuffled will place their default item here
         for location in locations:
             LocationList[location].PlaceDefaultItem()
-    if settings.training_barrels == "normal" or settings.training_barrels == "startwith":
+    if settings.training_barrels == "normal":
         LocationList[Locations.IslesVinesTrainingBarrel].PlaceConstantItem(Items.Vines)
         LocationList[Locations.IslesSwimTrainingBarrel].PlaceConstantItem(Items.Swim)
         LocationList[Locations.IslesOrangesTrainingBarrel].PlaceConstantItem(Items.Oranges)
@@ -100,7 +104,7 @@ def PlaceConstants(settings):
         LocationList[Locations.MusicUpgrade1].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.ThirdMelon].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.MusicUpgrade2].PlaceConstantItem(Items.NoItem)
-    if settings.unlock_fairy_shockwave:
+    if settings.unlock_fairy_shockwave and settings.shockwave_status == "vanilla":
         LocationList[Locations.CameraAndShockwave].PlaceConstantItem(Items.NoItem)
 
 
@@ -119,6 +123,13 @@ def AllItems(settings):
         allItems.extend(TinyMoves)
         allItems.extend(ChunkyMoves)
         allItems.extend(ImportantSharedMoves)
+        if settings.training_barrels == "shuffled":
+            allItems.extend(TrainingBarrelAbilities().copy())
+        if settings.shockwave_status == "shuffled":
+            allItems.append(Items.CameraAndShockwave)
+        elif settings.shockwave_status == "shuffled_decoupled":
+            allItems.append(Items.Camera)
+            allItems.append(Items.Shockwave)
     if settings.kong_rando:
         allItems.extend(Kongs(settings))
     return allItems
@@ -291,7 +302,11 @@ def Upgrades(settings):
                 ]
             )
     if not settings.unlock_fairy_shockwave:
-        upgrades.append(Items.CameraAndShockwave)
+        if settings.shockwave_status == "vanilla" or settings.shockwave_status == "shuffled":
+            upgrades.append(Items.CameraAndShockwave)
+        else:
+            upgrades.append(Items.Camera)
+            upgrades.append(Items.Shockwave)
 
     return upgrades
 
@@ -557,6 +572,12 @@ def GetKongMoveOccupiedShops():
     return list(set(occupiedShops))
 
 
+TrainingBarrelLocations = {
+    Locations.IslesSwimTrainingBarrel,
+    Locations.IslesVinesTrainingBarrel,
+    Locations.IslesBarrelsTrainingBarrel,
+    Locations.IslesOrangesTrainingBarrel,
+}
 DonkeyMoveLocations = {
     Locations.BaboonBlast,
     Locations.StrongKong,
@@ -644,6 +665,7 @@ TinyMoveLocations = {
     Locations.TinyCavesInstrument,
     Locations.TinyCastleInstrument,
     Locations.TinyIslesPotion,
+    Locations.CameraAndShockwave,
 }
 ChunkyMoveLocations = {
     Locations.HunkyChunky,
@@ -688,6 +710,11 @@ SharedMoveLocations = {
     Locations.SharedGalleonPotion,
     Locations.SharedGalleonGun,
     Locations.SharedCavesPotion,
+    Locations.IslesSwimTrainingBarrel,
+    Locations.IslesVinesTrainingBarrel,
+    Locations.IslesBarrelsTrainingBarrel,
+    Locations.IslesOrangesTrainingBarrel,
+    Locations.CameraAndShockwave,
 }
 DonkeyMoves = [Items.Coconut, Items.Bongos, Items.BaboonBlast, Items.StrongKong, Items.GorillaGrab]
 DiddyMoves = [Items.Peanut, Items.Guitar, Items.ChimpyCharge, Items.RocketbarrelBoost, Items.SimianSpring]

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -104,7 +104,7 @@ def PlaceConstants(settings):
         LocationList[Locations.MusicUpgrade1].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.ThirdMelon].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.MusicUpgrade2].PlaceConstantItem(Items.NoItem)
-    if settings.unlock_fairy_shockwave and settings.shockwave_status == "vanilla":
+    if settings.unlock_fairy_shockwave:
         LocationList[Locations.CameraAndShockwave].PlaceConstantItem(Items.NoItem)
 
 
@@ -125,11 +125,11 @@ def AllItems(settings):
         allItems.extend(ImportantSharedMoves)
         if settings.training_barrels == "shuffled":
             allItems.extend(TrainingBarrelAbilities().copy())
-        if settings.shockwave_status == "shuffled":
-            allItems.append(Items.CameraAndShockwave)
-        elif settings.shockwave_status == "shuffled_decoupled":
+        if settings.shockwave_status == "shuffled_decoupled":
             allItems.append(Items.Camera)
             allItems.append(Items.Shockwave)
+        else:
+            allItems.append(Items.CameraAndShockwave)
     if settings.kong_rando:
         allItems.extend(Kongs(settings))
     return allItems

--- a/randomizer/Lists/Item.py
+++ b/randomizer/Lists/Item.py
@@ -20,6 +20,9 @@ class Item:
             self.kong = data[0]
             self.movetype = data[1]
             self.index = data[2]
+        if type in (Types.TrainingBarrel, Types.Shockwave):
+            self.movetype = data[0]
+            self.flag = data[1]
 
 
 def ItemFromKong(kong):
@@ -77,10 +80,10 @@ ItemList = {
     Items.Lanky: Item("Lanky", True, Types.Kong),
     Items.Tiny: Item("Tiny", True, Types.Kong),
     Items.Chunky: Item("Chunky", True, Types.Kong),
-    Items.Vines: Item("Vines", True, Types.TrainingBarrel),
-    Items.Swim: Item("Swim", True, Types.TrainingBarrel),
-    Items.Oranges: Item("Oranges", True, Types.TrainingBarrel),
-    Items.Barrels: Item("Barrels", True, Types.TrainingBarrel),
+    Items.Vines: Item("Vines", True, Types.TrainingBarrel, [MoveTypes.Flag, "vine"]),
+    Items.Swim: Item("Swim", True, Types.TrainingBarrel, [MoveTypes.Flag, "dive"]),
+    Items.Oranges: Item("Oranges", True, Types.TrainingBarrel, [MoveTypes.Flag, "orange"]),
+    Items.Barrels: Item("Barrels", True, Types.TrainingBarrel, [MoveTypes.Flag, "barrel"]),
     Items.ProgressiveSlam: Item("Progressive Slam", True, Types.Shop, [Kongs.any, MoveTypes.Slam, 2]),
     Items.ProgressiveDonkeyPotion: Item("Progressive Donkey Potion", True, Types.Shop, [Kongs.donkey, MoveTypes.Moves, 1]),
     Items.BaboonBlast: Item("Baboon Blast", True, Types.Shop, [Kongs.donkey, MoveTypes.Moves, 1]),
@@ -118,7 +121,9 @@ ItemList = {
     Items.ProgressiveInstrumentUpgrade: Item("Progressive Instrument Upgrade", False, Types.Shop, [Kongs.any, MoveTypes.Instruments, 2]),
     Items.NintendoCoin: Item("Nintendo Coin", True, Types.Coin),
     Items.RarewareCoin: Item("Rareware Coin", True, Types.Coin),
-    Items.CameraAndShockwave: Item("Camera and Shockwave", True, Types.Shockwave),
+    Items.Camera: Item("Fairy Camera", True, Types.Shockwave, [MoveTypes.Flag, "camera"]),
+    Items.Shockwave: Item("Shockwave", True, Types.Shockwave, [MoveTypes.Flag, "shockwave"]),
+    Items.CameraAndShockwave: Item("Camera and Shockwave", True, Types.Shockwave, [MoveTypes.Flag, "camera_shockwave"]),
     Items.JungleJapesKey: Item("Jungle Japes Key", True, Types.Key),
     Items.AngryAztecKey: Item("Angry Aztec Key", True, Types.Key),
     Items.FranticFactoryKey: Item("Frantic Factory Key", True, Types.Key),

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -55,10 +55,10 @@ class LogicVarHolder:
         self.chunky = Kongs.chunky in self.settings.starting_kong_list
 
         # Right now assuming start with training barrels
-        self.vines = True  # self.settings.training_barrels == "startwith"
-        self.swim = True  # self.settings.training_barrels == "startwith"
-        self.oranges = True  # self.settings.training_barrels == "startwith"
-        self.barrels = True  # self.settings.training_barrels == "startwith"
+        self.vines = self.settings.training_barrels == "normal"
+        self.swim = self.settings.training_barrels == "normal"
+        self.oranges = self.settings.training_barrels == "normal"
+        self.barrels = self.settings.training_barrels == "normal"
 
         self.progDonkey = 3 if self.settings.unlock_all_moves else 0
         self.blast = self.settings.unlock_all_moves
@@ -258,8 +258,8 @@ class LogicVarHolder:
         self.BananaMedals = sum(1 for x in ownedItems if x == Items.BananaMedal)
         self.BattleCrowns = sum(1 for x in ownedItems if x == Items.BattleCrown)
 
-        self.camera = self.camera or Items.CameraAndShockwave in ownedItems
-        self.shockwave = self.shockwave or Items.CameraAndShockwave in ownedItems
+        self.camera = self.camera or Items.CameraAndShockwave in ownedItems or Items.Camera in ownedItems
+        self.shockwave = self.shockwave or Items.CameraAndShockwave in ownedItems or Items.Shockwave in ownedItems
 
         self.scope = self.scope or Items.SniperSight in ownedItems
         self.homing = self.homing or Items.HomingAmmo in ownedItems

--- a/randomizer/Patching/PriceRando.py
+++ b/randomizer/Patching/PriceRando.py
@@ -9,6 +9,8 @@ def randomize_prices(spoiler: Spoiler):
     if spoiler.settings.random_prices != "vanilla" or spoiler.settings.shuffle_items != "none":
         varspaceOffset = spoiler.settings.rom_data
         pricesOffset = 0x035
+        tbarrelPricesOffset = 0x0A8
+        fairyPricesOffset = 0x0AC
         ROM().seek(varspaceOffset + pricesOffset)
         # /* 0x035 */ char price_rando_on; // 0 = Price Randomizer off, 1 = On
         if spoiler.settings.random_prices != "vanilla":
@@ -56,3 +58,18 @@ def randomize_prices(spoiler: Spoiler):
         ROM().write(spoiler.settings.prices[Items.ProgressiveInstrumentUpgrade][0])
         ROM().write(spoiler.settings.prices[Items.ProgressiveInstrumentUpgrade][1])
         ROM().write(spoiler.settings.prices[Items.ProgressiveInstrumentUpgrade][2])
+
+        # /* 0x0A8 */ unsigned char tbarrel_prices[4]; // Array of training barrel move prices in this order: Swim, Oranges, Barrels, Vines
+        ROM().seek(varspaceOffset + tbarrelPricesOffset)
+        ROM().write(spoiler.settings.prices[Items.Swim])
+        ROM().write(spoiler.settings.prices[Items.Oranges])
+        ROM().write(spoiler.settings.prices[Items.Barrels])
+        ROM().write(spoiler.settings.prices[Items.Vines])
+
+        # /* 0x0A8 */ unsigned char fairy_prices[2]; // Array of training barrel move prices in this order: Swim, Oranges, Barrels, Vines
+        ROM().seek(varspaceOffset + fairyPricesOffset)
+        if spoiler.settings.shockwave_status == "shuffled_decoupled":
+            ROM().write(spoiler.settings.prices[Items.Camera])
+            ROM().write(spoiler.settings.prices[Items.Shockwave])
+        else:
+            ROM().write(spoiler.settings.prices[Items.CameraAndShockwave])

--- a/randomizer/Prices.py
+++ b/randomizer/Prices.py
@@ -1,5 +1,6 @@
 """Functions and data for setting and calculating prices."""
 
+from math import ceil
 import random
 
 from randomizer.Enums.Items import Items
@@ -17,10 +18,19 @@ from randomizer.ItemPool import (
     SharedMoveLocations,
     TinyMoveLocations,
     TinyMoves,
+    TrainingBarrelAbilities,
+    TrainingBarrelLocations,
 )
 from randomizer.Lists.Location import LocationList
 
 VanillaPrices = {
+    Items.Vines: 0,
+    Items.Swim: 0,
+    Items.Barrels: 0,
+    Items.Oranges: 0,
+    Items.Camera: 0,
+    Items.Shockwave: 0,
+    Items.CameraAndShockwave: 0,
     Items.BaboonBlast: 3,
     Items.StrongKong: 5,
     Items.GorillaGrab: 7,
@@ -95,6 +105,9 @@ def RandomizePrices(weight):
                 prices[item].append(GenerateRandomPrice(weight, avg, stddev, upperLimit))
         else:
             prices[item] = GenerateRandomPrice(weight, avg, stddev, upperLimit)
+            # Make training barrel moves cheaper because they'll be early and are super important
+            if item in TrainingBarrelAbilities():
+                prices[item] = ceil(prices[item] * 0.5)
     return prices
 
 
@@ -262,6 +275,9 @@ def EveryKongCanBuy(location, logic):
 
 def CanBuy(location, logic):
     """Check if an appropriate kong can logically purchase this location."""
+    # If it's in a location that doesn't care about prices, it's free!
+    if location in TrainingBarrelLocations or location == Locations.CameraAndShockwave:
+        return True
     # Either have the setting that any kong can buy any move or it's a shared location so any kong can anyway
     if location in SharedMoveLocations:
         return AnyKongCanBuy(location, logic)

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -56,12 +56,6 @@ class Settings:
         # In hard level progression we go through levels in a random order, so we set every level's troff min weight to the largest weight
         if self.hard_level_progression:
             self.troff_min = [self.troff_min[-1] for x in self.troff_min]
-        # Always start with training barrels currently
-        # training_barrels: str
-        # normal
-        # shuffled
-        # startwith
-        self.training_barrels = "startwith"
 
         # currently just set to moves by move_rando
         # shuffle_items: str
@@ -255,6 +249,18 @@ class Settings:
 
         # decoupled_loading_zones: bool
         self.decoupled_loading_zones = False
+
+        # Always start with training barrels currently
+        # training_barrels: str
+        # normal
+        # shuffled
+        self.training_barrels = "normal"
+
+        # The status of camera & shockwave: str
+        # vanilla - both located at Banana Fairy Isle
+        # shuffled - located in a random valid location
+        # shuffled_decoupled - camera and shockwave are separate upgrades and can be anywhere
+        self.shockwave_status = "vanilla"
 
         #  Music
         self.music_bgm = "default"

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -232,6 +232,22 @@
                     </select>
                 </div>
                 <div class="item-select">
+                    <p class="select-title">Training Barrels</p>
+                    <select name="training_barrels"
+                            id="training_barrels"
+                            class="form-select"
+                            aria-label="Randomization type"
+                            data-toggle="tooltip"
+                            title="Determines if and how training barrel moves are randomized.&#10;-Vanilla: Training barrel moves are learned from the training barrels.&#10;-Shuffle: Training barrel moves are shuffled with other moves.">
+                        <option id="training_barrels_normal" value="normal">
+                            Vanilla
+                        </option>
+                        <option id="training_barrels_shuffled" value="shuffled">
+                            Shuffle
+                        </option>
+                    </select>
+                </div>
+                <div class="item-select">
                     <p class="select-title">Random Shop Prices</p>
                     <select name="random_prices"
                             id="random_prices"
@@ -256,6 +272,25 @@
                         </option>
                         <option id="extreme_price_option" value="extreme">
                             Extreme
+                        </option>
+                    </select>
+                </div>
+                <div class="item-select">
+                    <p class="select-title">Banana Fairy Isle</p>
+                    <select name="shockwave_status"
+                            id="shockwave_status"
+                            class="form-select"
+                            aria-label="Randomization type"
+                            data-toggle="tooltip"
+                            title="Determines how Banana Fairy Isle is handled.&#10;-Vanilla: Shockwave and Camera are given at BFI.&#10;-Shuffle: Camera and Shockwave are shuffled with other moves and BFI can hold a shared or Tiny move.&#10;-Shuffle Separately: Same as Shuffle but Camera and Shockwave are separate upgrades.">
+                        <option id="shockwave_status_vanilla" value="vanilla">
+                            Vanilla
+                        </option>
+                        <option id="shockwave_status_shuffled" value="shuffled">
+                            Shuffle
+                        </option>
+                        <option id="shockwave_status_shuffled_decoupled" value="shuffled_decoupled">
+                            Shuffle Separately
                         </option>
                     </select>
                 </div>


### PR DESCRIPTION
Adds logic for placing training barrel moves. Note these rules only apply to non-hard LO settings:
- You must have vines before Aztec or level 2 if you don't have Isles warps active
- You must have swim before level 4
- You must have barrels before level 2 to promote boss diversity
Hard mode ignores all this logic but does keep in mind lobby accessibility when generating progression.

Writing them to the ROM is in, but probably loaded with bugs. Proceed with caution.