### PR TITLE
Orange Logic

### DIFF
--- a/randomizer/Lists/KasplatLocations.py
+++ b/randomizer/Lists/KasplatLocations.py
@@ -142,7 +142,7 @@ KasplatLocationList = {
             zmin=1650,
             zmax=1800,
             region=Regions.JungleJapesMain,
-            additional_logic=lambda l: l.swim,
+            additional_logic=lambda l: l.swim and (l.oranges or l.HasGun(Kongs.any)),
         ),
         KasplatLocation(
             name="Japes Kasplat: In the water near Rambi Wall",
@@ -154,7 +154,7 @@ KasplatLocationList = {
             zmin=2700,
             zmax=2900,
             region=Regions.BeyondRambiGate,
-            additional_logic=lambda l: l.swim,
+            additional_logic=lambda l: l.swim and (l.oranges or l.HasGun(Kongs.any)),
         ),
         KasplatLocation(
             name="Japes Kasplat: Near Cranky's",
@@ -932,7 +932,7 @@ KasplatLocationList = {
             zmin=540,
             zmax=630,
             region=Regions.GiantMushroomArea,
-            additional_logic=lambda l: l.swim,
+            additional_logic=lambda l: l.swim and (l.oranges or l.HasGun(Kongs.any)),
         ),
         KasplatLocation(
             name="Forest Kasplat: At the very top of the Giant Mushroom",
@@ -1314,7 +1314,7 @@ KasplatLocationList = {
             zmin=150,
             zmax=300,
             region=Regions.CreepyCastleMain,
-            additional_logic=lambda l: l.swim,
+            additional_logic=lambda l: l.swim and (l.oranges or l.HasGun(Kongs.any)),
         ),
         KasplatLocation(
             name="Castle Kasplat: Near Cranky's Hut",
@@ -1622,7 +1622,7 @@ KasplatLocationList = {
             zmin=1091,
             zmax=1137,
             region=Regions.IslesMain,
-            additional_logic=lambda l: l.swim,
+            additional_logic=lambda l: l.swim and (l.oranges or l.HasGun(Kongs.any)),
         ),
     ],
 }

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -339,16 +339,17 @@ class LogicVarHolder:
         """Check if logic currently is currently the specified kong and owns a gun for them."""
         if kong == Kongs.donkey:
             return self.coconut and self.isdonkey
-        if kong == Kongs.diddy:
+        elif kong == Kongs.diddy:
             return self.peanut and self.isdiddy
-        if kong == Kongs.lanky:
+        elif kong == Kongs.lanky:
             return self.grape and self.islanky
-        if kong == Kongs.tiny:
+        elif kong == Kongs.tiny:
             return self.feather and self.istiny
-        if kong == Kongs.chunky:
+        elif kong == Kongs.chunky:
             return self.pineapple and self.ischunky
-        if kong == Kongs.any:
+        elif kong == Kongs.any:
             return (self.coconut and self.isdonkey) or (self.peanut and self.isdiddy) or (self.grape and self.islanky) or (self.feather and self.istiny) or (self.pineapple and self.ischunky)
+        return False
 
     def HasInstrument(self, kong):
         """Check if logic currently is currently the specified kong and owns an instrument for them."""

--- a/randomizer/LogicFiles/CrystalCaves.py
+++ b/randomizer/LogicFiles/CrystalCaves.py
@@ -177,14 +177,14 @@ LogicRegions = {
     Regions.DiddyLowerCabin: Region("Diddy Lower Cabin", Levels.CrystalCaves, False, -1, [
         # You're supposed to use the jetpack to get up the platforms,
         # but you can just backflip onto them
-        LocationLogic(Locations.CavesDiddy5DoorCabinLower, lambda l: l.isdiddy),
+        LocationLogic(Locations.CavesDiddy5DoorCabinLower, lambda l: l.isdiddy and l.oranges),
     ], [], [
         TransitionFront(Regions.CabinArea, lambda l: True, Transitions.CavesDiddyLowerToCabin),
     ]),
 
     Regions.DiddyUpperCabin: Region("Diddy Upper Cabin", Levels.CrystalCaves, False, -1, [
-        LocationLogic(Locations.CavesDiddy5DoorCabinUpper, lambda l: (l.guitar or l.shockwave) and l.spring and l.jetpack and l.isdiddy),
-        LocationLogic(Locations.CavesBananaFairyCabin, lambda l: l.camera and (l.guitar or l.shockwave) and l.spring and l.jetpack and l.isdiddy),
+        LocationLogic(Locations.CavesDiddy5DoorCabinUpper, lambda l: (l.guitar or l.shockwave) and l.spring and l.jetpack and l.isdiddy and l.oranges),
+        LocationLogic(Locations.CavesBananaFairyCabin, lambda l: l.camera and (l.guitar or l.shockwave) and l.spring and l.jetpack and l.isdiddy and l.oranges),
     ], [], [
         TransitionFront(Regions.CabinArea, lambda l: True, Transitions.CavesDiddyUpperToCabin),
     ]),
@@ -196,7 +196,7 @@ LogicRegions = {
     ]),
 
     Regions.TinyCabin: Region("Tiny Cabin", Levels.CrystalCaves, False, None, [
-        LocationLogic(Locations.CavesTiny5DoorCabin, lambda l: l.istiny),
+        LocationLogic(Locations.CavesTiny5DoorCabin, lambda l: l.istiny and l.oranges),
     ], [], [
         TransitionFront(Regions.CabinArea, lambda l: True, Transitions.CavesTinyToCabin),
     ]),

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -133,7 +133,7 @@ LogicRegions = {
         LocationLogic(Locations.IslesTinyGalleonLobby, lambda l: l.chunky and l.superSlam and l.mini and l.twirl and l.tiny),
         LocationLogic(Locations.IslesKasplatGalleonLobby, lambda l: not l.settings.kasplat_location_rando),
     ], [], [
-        TransitionFront(Regions.IslesMain, lambda l: True, Transitions.IslesGalleonLobbyToMain),
+        TransitionFront(Regions.IslesMain, lambda l: l.swim, Transitions.IslesGalleonLobbyToMain),
         TransitionFront(Regions.GloomyGalleonStart, lambda l: l.IsLevelEnterable(Levels.GloomyGalleon), Transitions.IslesToGalleon),
     ]),
 

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -142,9 +142,9 @@ LogicRegions = {
     ]),
 
     Regions.Anthill: Region("Anthill", Levels.FungiForest, False, -1, [
-        LocationLogic(Locations.ForestTinyAnthill, lambda l: l.istiny),
+        LocationLogic(Locations.ForestTinyAnthill, lambda l: l.istiny and l.oranges),
     ], [
-        Event(Events.Bean, lambda l: l.istiny),
+        Event(Events.Bean, lambda l: l.istiny and l.oranges),
     ], [
         TransitionFront(Regions.HollowTreeArea, lambda l: True, Transitions.ForestAnthillToTree),
     ]),

--- a/randomizer/LogicFiles/JungleJapes.py
+++ b/randomizer/LogicFiles/JungleJapes.py
@@ -86,7 +86,7 @@ LogicRegions = {
     ]),
 
     Regions.TinyHive: Region("Tiny Hive", Levels.JungleJapes, False, -1, [
-        LocationLogic(Locations.JapesTinyBeehive, lambda l: l.Slam and l.istiny),
+        LocationLogic(Locations.JapesTinyBeehive, lambda l: l.Slam and l.istiny and l.oranges),
     ], [], [
         TransitionFront(Regions.JapesBeyondFeatherGate, lambda l: True, Transitions.JapesTinyHiveToMain),
     ]),


### PR DESCRIPTION
Adds orange requirement for hard-required cabins + anthill and also shellhive.

Also fixed galleon lobby -> isles entrance logic.