### PR TITLE
Activated cross-map warp logic

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -7,6 +7,7 @@ import randomizer.ItemPool as ItemPool
 import randomizer.Lists.Exceptions as Ex
 import randomizer.Logic as Logic
 import randomizer.ShuffleExits as ShuffleExits
+import randomizer.LogicFiles.DKIsles as IslesLogic
 from randomizer.CompileHints import compileHints
 from randomizer.Enums.Events import Events
 from randomizer.Enums.Items import Items
@@ -1827,6 +1828,7 @@ def ShuffleMisc(spoiler):
     if spoiler.settings.shuffle_shops:
         ShuffleShopLocations(spoiler)
     if spoiler.settings.activate_all_bananaports in ["all", "isles"]:
+        # In simpler bananaport shuffling, we can rely on the map id and warp number to find pairs
         if spoiler.settings.bananaport_rando in ("in_level", "off"):
             warpMapIds = set([BananaportVanilla[warp].map_id for warp in Warps])
             for map_id in warpMapIds:
@@ -1842,3 +1844,10 @@ def ShuffleMisc(spoiler):
                         warpRegion = Logic.Regions[warpData.region_id]
                         bananaportExit = TransitionFront(pairedWarpData.region_id, lambda l: True)
                         warpRegion.exits.append(bananaportExit)
+        # In complex cross-map shuffling, we have to rely on saved destination regions to generate transitions
+        else:
+            for warp in BananaportVanilla.values():
+                warpRegion = Logic.Regions[warp.region_id]
+                if spoiler.settings.activate_all_bananaports != "isles" or (warp.region_id in IslesLogic.LogicRegions.keys() and warp.destination_region_id in IslesLogic.LogicRegions.keys()):
+                    bananaportExit = TransitionFront(warp.destination_region_id, lambda l: True)
+                    warpRegion.exits.append(bananaportExit)

--- a/randomizer/Lists/Warps.py
+++ b/randomizer/Lists/Warps.py
@@ -14,6 +14,7 @@ class BananaportData:
         self.name = name
         self.map_id = map_id
         self.region_id = region_id
+        self.destination_region_id = None
         self.obj_id_vanilla = obj_id_vanilla
         self.locked = locked
         self.vanilla_warp = vanilla_warp
@@ -30,12 +31,6 @@ class BananaportData:
     def setNewWarp(self, new_warp):
         """Set new warp type."""
         self.new_warp = new_warp
-
-    def setWarpCrossMap(self, index, warp_type):
-        """Set new warp properties for Cross-Map."""
-        self.tied_index = index
-        self.cross_map_placed = True
-        self.new_warp = warp_type
 
 
 BananaportVanilla = {

--- a/randomizer/ShuffleWarps.py
+++ b/randomizer/ShuffleWarps.py
@@ -46,11 +46,11 @@ def ShuffleWarps(bananaport_replacements, human_ports):
         bananaport_replacements.append({"containing_map": warp_map, "pads": pad_list.copy()})
 
 
-def getNameFromSwapIndex(index):
+def getWarpFromSwapIndex(index):
     """Acquire warp name from index."""
-    for warp_name in BananaportVanilla.values():
-        if warp_name.swap_index == index:
-            return warp_name.name
+    for warp in BananaportVanilla.values():
+        if warp.swap_index == index:
+            return warp
 
 
 def ShuffleWarpsCrossMap(bananaport_replacements, human_ports, is_coupled):
@@ -84,8 +84,10 @@ def ShuffleWarpsCrossMap(bananaport_replacements, human_ports, is_coupled):
                 if warp_check.swap_index == selected_index:
                     warp_check.cross_map_placed = True
             warp.new_warp = warp_type_index
-            human_ports[warp.name] = getNameFromSwapIndex(selected_index)
+            destination_warp = getWarpFromSwapIndex(selected_index)
+            human_ports[warp.name] = destination_warp.name
             bananaport_replacements[warp.swap_index] = [selected_index, warp_type_index]
+            warp.destination_region_id = destination_warp.region_id
             selected_lst = [selected_index]
             if selected_index in selected_warp_list:
                 print(f"Selected {selected_index} which is a duplicate")
@@ -97,8 +99,10 @@ def ShuffleWarpsCrossMap(bananaport_replacements, human_ports, is_coupled):
                         warp_check.tied_index = warp.swap_index
                         selected_lst.append(warp.swap_index)
                         warp_check.new_warp = warp_type_index
-                        human_ports[warp_check.name] = getNameFromSwapIndex(warp.swap_index)
+                        destination_warp = getWarpFromSwapIndex(warp.swap_index)
+                        human_ports[warp_check.name] = destination_warp.name
                         bananaport_replacements[warp_check.swap_index] = [warp.swap_index, warp_type_index]
+                        warp.destination_region_id = destination_warp.region_id
                         if warp.swap_index in selected_warp_list:
                             print(f"Selected {warp.swap_index} which is a duplicate")
                         selected_warp_list.append(warp.swap_index)


### PR DESCRIPTION
Adds transitions for activated cross-map warps. Does take into consideration having only Isles warps active