### PR TITLE
Fill Unity Refactor

### DIFF
--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -451,7 +451,7 @@ class LogicVarHolder:
         if location.item is not None and location.item is not Items.NoItem:
             price = GetPriceOfMoveItem(location.item, self.settings, self.Slam, self.AmmoBelts, self.InstUpgrades)
             if price is None:  # This probably shouldn't happen but I think it's harmless
-                return  # I think I solved this, deleting this safety measure if I don't see it for a while
+                return  # TODO: solve this
             # print("BuyShopItem for location: " + location.name)
             # print("Item: " + ItemList[location.item].name + " has Price: " + str(price))
             # If shared move, take the price from all kongs EVEN IF THEY AREN'T FREED YET

--- a/randomizer/LogicFiles/CrystalCaves.py
+++ b/randomizer/LogicFiles/CrystalCaves.py
@@ -92,7 +92,7 @@ LogicRegions = {
     ),
 
     Regions.FrozenCastle: Region("Frozen Castle", Levels.CrystalCaves, False, None, [
-        LocationLogic(Locations.CavesLankyCastle, lambda l: l.Slam and (l.islanky or l.free_trade_items)),
+        LocationLogic(Locations.CavesLankyCastle, lambda l: l.Slam and (l.islanky or l.settings.free_trade_items)),
     ], [], [
         TransitionFront(Regions.CrystalCavesMain, lambda l: True, Transitions.CavesCastleToMain),
     ]),

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -84,7 +84,7 @@ LogicRegions = {
 
     Regions.BananaFairyRoom: Region("Banana Fairy Room", Levels.DKIsles, False, None, [
         LocationLogic(Locations.CameraAndShockwave, lambda l: True),
-        LocationLogic(Locations.RarewareBanana, lambda l: l.BananaFairies >= 20 and (l.istiny or l.free_trade_items)),
+        LocationLogic(Locations.RarewareBanana, lambda l: l.BananaFairies >= 20 and (l.istiny or l.settings.free_trade_items)),
     ], [], [
         TransitionFront(Regions.IslesMain, lambda l: True, Transitions.IslesFairyToMain),
     ]),

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -32,7 +32,7 @@ LogicRegions = {
     ]),
 
     Regions.ForestMinecarts: Region("Forest Minecarts", Levels.FungiForest, False, None, [
-        LocationLogic(Locations.ForestChunkyMinecarts, lambda l: l.ischunky or l.free_trade_items),
+        LocationLogic(Locations.ForestChunkyMinecarts, lambda l: l.ischunky or l.settings.free_trade_items),
     ], [], [
         TransitionFront(Regions.FungiForestStart, lambda l: True),
     ], Transitions.ForestMainToCarts

--- a/randomizer/ShuffleItems.py
+++ b/randomizer/ShuffleItems.py
@@ -37,14 +37,6 @@ class LocationSelection:
 
 def ShuffleItems(spoiler: Spoiler):
     """Shuffle items into assortment."""
-    spoiler.shuffled_item_types = (
-        Types.Banana,
-        Types.Blueprint,
-        Types.Coin,
-        Types.Key,
-        Types.Crown,
-        Types.Medal,
-    )
     successful_gen = False
     gen_counter = 5
     while not successful_gen and gen_counter > 0:
@@ -52,7 +44,7 @@ def ShuffleItems(spoiler: Spoiler):
         location_data = []
         for location_enum in LocationList:
             item_location = LocationList[location_enum]
-            if item_location.default_mapid_data is not None and item_location.type in spoiler.shuffled_item_types:
+            if item_location.default_mapid_data is not None and item_location.type in spoiler.settings.shuffled_location_types:
                 # Can be shuffled
                 placement_info = {}
                 is_reward = False

--- a/randomizer/ShuffleKasplats.py
+++ b/randomizer/ShuffleKasplats.py
@@ -191,17 +191,17 @@ def ShuffleKasplats(LogicVariables):
 
 def KasplatShuffle(spoiler, LogicVariables):
     """Facilitate the shuffling of kasplat types."""
-    if LogicVariables.settings.kasplat_rando:
+    if spoiler.settings.kasplat_rando:
         retries = 0
         while True:
             try:
                 # Shuffle kasplats
-                if LogicVariables.settings.kasplat_location_rando:
+                if spoiler.settings.kasplat_location_rando:
                     ShuffleKasplatsAndLocations(spoiler, LogicVariables)
                 else:
                     ShuffleKasplats(LogicVariables)
                 # Verify world by assuring all locations are still reachable
-                if not Fill.VerifyWorld(LogicVariables.settings):
+                if not Fill.VerifyWorld(spoiler.settings):
                     raise Ex.KasplatPlacementException
                 return
             except Ex.KasplatPlacementException:
@@ -211,7 +211,7 @@ def KasplatShuffle(spoiler, LogicVariables):
                 retries += 1
                 js.postMessage("Kasplat placement failed. Retrying. Tries: " + str(retries))
                 # We've added logic in kasplat location rando, now we need to remove it
-                if LogicVariables.settings.kasplat_location_rando:
+                if spoiler.settings.kasplat_location_rando:
                     ResetShuffledKasplatLocations()
 
 


### PR DESCRIPTION
Adds `settings.shuffled_location_types` to the settings which enables a proper refactor of Fill. Now we're not beholden to checking specific presets like "phase1". 

This PR refactors the fill methods to unify the logic they flow through. Now all code flows go through `Fill()` and can selectively fill items depending on the shuffled location types. This is the precursor to a customizable item pool shuffling.