### PR TITLE
Last major item shuffler fixes

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1767,6 +1767,8 @@ def Generate_Spoiler(spoiler):
         compileHints(spoiler)
     Reset()
     ShuffleExits.Reset()
+    spoiler.createJson()
+    js.postMessage("Patching ROM...")
     return spoiler
 
 

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -29,6 +29,8 @@ def PlaceConstants(settings):
                 dest = ShufflableExits[level.TransitionTo].shuffledId
                 shuffledTo = [x for x in LevelInfoList.values() if x.TransitionTo == dest][0]
                 LocationList[shuffledTo.KeyLocation].PlaceConstantItem(level.KeyItem)
+        # The key in Helm is always Key 8 in these settings
+        LocationList[Locations.HelmKey].PlaceConstantItem(Items.HideoutHelmKey)
     # Settings-dependent locations
     # Determine what types of locations are being shuffled
     typesOfItemsShuffled = []
@@ -234,26 +236,7 @@ def MedalAssumedItems():
 
 def Keys(settings):
     """Return all key items."""
-    keys = []
-    for event in settings.krool_keys_required:
-        if event == Events.JapesKeyTurnedIn:
-            keys.append(Items.JungleJapesKey)
-        elif event == Events.AztecKeyTurnedIn:
-            keys.append(Items.AngryAztecKey)
-        elif event == Events.FactoryKeyTurnedIn:
-            keys.append(Items.FranticFactoryKey)
-        elif event == Events.GalleonKeyTurnedIn:
-            keys.append(Items.GloomyGalleonKey)
-        elif event == Events.ForestKeyTurnedIn:
-            keys.append(Items.FungiForestKey)
-        elif event == Events.CavesKeyTurnedIn:
-            keys.append(Items.CrystalCavesKey)
-        elif event == Events.CastleKeyTurnedIn:
-            keys.append(Items.CreepyCastleKey)
-        elif event == Events.HelmKeyTurnedIn:
-            keys.append(Items.HideoutHelmKey)
-    keys.sort()
-    return keys
+    return [Items.JungleJapesKey, Items.AngryAztecKey, Items.FranticFactoryKey, Items.GloomyGalleonKey, Items.FungiForestKey, Items.CrystalCavesKey, Items.CreepyCastleKey, Items.HideoutHelmKey]
 
 
 def Kongs(settings):

--- a/randomizer/Lists/Item.py
+++ b/randomizer/Lists/Item.py
@@ -17,12 +17,15 @@ class Item:
         self.playthrough = playthrough
         self.type = type
         self.kong = kong
+        self.rando_flag = None
         if type == Types.Shop:
             self.movetype = data[0]
             self.index = data[1]
         if type in (Types.TrainingBarrel, Types.Shockwave):
             self.movetype = data[0]
             self.flag = data[1]
+        if type == Types.Key:
+            self.rando_flag = data[0]
 
 
 def ItemFromKong(kong):
@@ -122,16 +125,16 @@ ItemList = {
     Items.Camera: Item("Fairy Camera", True, Types.Shockwave, Kongs.any, [MoveTypes.Flag, "camera"]),
     Items.Shockwave: Item("Shockwave", True, Types.Shockwave, Kongs.any, [MoveTypes.Flag, "shockwave"]),
     Items.CameraAndShockwave: Item("Camera and Shockwave", True, Types.Shockwave, Kongs.any, [MoveTypes.Flag, "camera_shockwave"]),
-    Items.NintendoCoin: Item("Nintendo Coin", True, Types.Coin, Kongs.any),
-    Items.RarewareCoin: Item("Rareware Coin", True, Types.Coin, Kongs.any),
-    Items.JungleJapesKey: Item("Key 1", True, Types.Key, Kongs.any),
-    Items.AngryAztecKey: Item("Key 2", True, Types.Key, Kongs.any),
-    Items.FranticFactoryKey: Item("Key 3", True, Types.Key, Kongs.any),
-    Items.GloomyGalleonKey: Item("Key 4", True, Types.Key, Kongs.any),
-    Items.FungiForestKey: Item("Key 5", True, Types.Key, Kongs.any),
-    Items.CrystalCavesKey: Item("Key 6", True, Types.Key, Kongs.any),
-    Items.CreepyCastleKey: Item("Key 7", True, Types.Key, Kongs.any),
-    Items.HideoutHelmKey: Item("Key 8", True, Types.Key, Kongs.any),
+    Items.NintendoCoin: Item("Nintendo Coin", True, Types.Coin, Kongs.any, [132]),
+    Items.RarewareCoin: Item("Rareware Coin", True, Types.Coin, Kongs.any, [379]),
+    Items.JungleJapesKey: Item("Key 1", True, Types.Key, Kongs.any, [26]),
+    Items.AngryAztecKey: Item("Key 2", True, Types.Key, Kongs.any, [74]),
+    Items.FranticFactoryKey: Item("Key 3", True, Types.Key, Kongs.any, [138]),
+    Items.GloomyGalleonKey: Item("Key 4", True, Types.Key, Kongs.any, [168]),
+    Items.FungiForestKey: Item("Key 5", True, Types.Key, Kongs.any, [236]),
+    Items.CrystalCavesKey: Item("Key 6", True, Types.Key, Kongs.any, [292]),
+    Items.CreepyCastleKey: Item("Key 7", True, Types.Key, Kongs.any, [317]),
+    Items.HideoutHelmKey: Item("Key 8", True, Types.Key, Kongs.any, [380]),
     Items.HelmDonkey1: Item("Helm Donkey Barrel 1", False, Types.Constant, Kongs.donkey),
     Items.HelmDonkey2: Item("Helm Donkey Barrel 2", False, Types.Constant, Kongs.donkey),
     Items.HelmDiddy1: Item("Helm Diddy Barrel 1", False, Types.Constant, Kongs.diddy),

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -25,16 +25,17 @@ class MapIDCombo:
 class Location:
     """A shufflable location at which a random item can be placed."""
 
-    def __init__(self, name, default, type, kong=Kongs.any, data=None):
+    def __init__(self, name, default, location_type, kong=Kongs.any, data=None):
         """Initialize with given parameters."""
         if data is None:
             data = []
         self.name = name
         self.default = default
-        self.type = type
+        self.type = location_type
         self.item = None
         self.delayedItem = None
         self.constant = False
+        self.is_reward = False
         self.map_id_list = None
         helmmedal_locations = (
             "Helm Donkey Medal",
@@ -44,12 +45,12 @@ class Location:
             "Helm Chunky Medal",
         )
         self.kong = kong
-        if type == Types.Shop:
+        if self.type == Types.Shop:
             self.level = data[0]
             self.movetype = data[1]
             self.index = data[2]
             self.vendor = data[3]
-        elif type == Types.Blueprint:
+        elif self.type == Types.Blueprint:
             self.map = data[0]
             level = getLevelFromMap(data[0])
             if level is None:
@@ -57,20 +58,23 @@ class Location:
             elif level in (Levels.DKIsles, Levels.HideoutHelm):
                 level = 7
             self.map_id_list = [MapIDCombo(0, -1, 469 + self.kong + (5 * level), self.kong)]
-        elif type == Types.Medal and name not in helmmedal_locations:
+        elif self.type == Types.Medal and name not in helmmedal_locations:
             level = data[0]
             if level is None:
                 level = 0
             elif level in (Levels.DKIsles, Levels.HideoutHelm):
                 level = 7
             self.map_id_list = [MapIDCombo(0, -1, 549 + self.kong + (5 * level), self.kong)]
-        elif type in (Types.Banana, Types.Key, Types.Coin, Types.Crown, Types.Medal):
+        elif self.type in (Types.Banana, Types.Key, Types.Coin, Types.Crown, Types.Medal):
             if "Turn In " not in name:
                 if data is None:
                     self.map_id_list = []
                 else:
                     self.map_id_list = data
         self.default_mapid_data = self.map_id_list
+        # "Reward" locations are locations that require an actor to exist for the location's item - something not all items have
+        if self.default_mapid_data is not None and len(self.default_mapid_data) > 0 and type(self.default_mapid_data[0]) is MapIDCombo and self.default_mapid_data[0].id == -1:
+            self.is_reward = True
 
     def PlaceItem(self, item):
         """Place item at this location."""
@@ -415,7 +419,7 @@ LocationList = {
     Locations.HelmDiddyMedal: Location("Helm Diddy Medal", Items.BananaMedal, Types.Medal, Kongs.diddy, [MapIDCombo(Maps.HideoutHelm, 0x61, 585, Kongs.diddy)]),
     Locations.HelmBananaFairy1: Location("Helm Banana Fairy 1", Items.BananaFairy, Types.Fairy),
     Locations.HelmBananaFairy2: Location("Helm Banana Fairy 2", Items.BananaFairy, Types.Fairy),
-    Locations.HelmKey: Location("Helm Key", Items.HideoutHelmKey, Types.Constant, Kongs.any, [MapIDCombo(Maps.HideoutHelm, 0x5A, 380)]),
+    Locations.HelmKey: Location("Helm Key", Items.HideoutHelmKey, Types.Key, Kongs.any, [MapIDCombo(Maps.HideoutHelm, 0x5A, 380)]),
 
     # Normal shop locations
     Locations.SimianSlam: Location("DK Isles Cranky Shared", Items.NoItem, Types.Shop, Kongs.any, [Levels.DKIsles, MoveTypes.Slam, 1, VendorType.Cranky]),

--- a/randomizer/Patching/ApplyRandomizer.py
+++ b/randomizer/Patching/ApplyRandomizer.py
@@ -441,8 +441,8 @@ def patching_response(responded_data):
     js.document.getElementById("nav-settings-tab").style.display = ""
     if spoiler.settings.generate_spoilerlog is True:
         js.document.getElementById("spoiler_log_block").style.display = ""
-        loop.run_until_complete(GenerateSpoiler(spoiler.toJson()))
-        js.document.getElementById("tracker_text").value = generateTracker(spoiler.toJson())
+        loop.run_until_complete(GenerateSpoiler(spoiler.json))
+        js.document.getElementById("tracker_text").value = generateTracker(spoiler.json)
     else:
         js.document.getElementById("spoiler_log_text").innerHTML = ""
         js.document.getElementById("spoiler_log_text").value = ""
@@ -450,7 +450,7 @@ def patching_response(responded_data):
         js.document.getElementById("spoiler_log_block").style.display = "none"
 
     js.document.getElementById("generated_seed_id").innerHTML = spoiler.settings.seed_id
-    loaded_settings = json.loads(spoiler.toJson())["Settings"]
+    loaded_settings = json.loads(spoiler.json)["Settings"]
     tables = {}
     t = 0
     for i in range(0, 3):

--- a/randomizer/Patching/MoveLocationRando.py
+++ b/randomizer/Patching/MoveLocationRando.py
@@ -65,7 +65,7 @@ def randomize_moves(spoiler: Spoiler):
     """Randomize Move locations based on move_data from spoiler."""
     varspaceOffset = spoiler.settings.rom_data
     movespaceOffset = spoiler.settings.move_location_data
-    if spoiler.settings.shuffle_items == "moves" and spoiler.move_data is not None:
+    if spoiler.settings.move_rando not in ("off", "starts_with") and spoiler.move_data is not None:
         # Take a copy of move_data before modifying
         move_arrays = spoiler.move_data.copy()
 

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -621,7 +621,16 @@ class Settings:
             if Types.Blueprint in self.shuffled_location_types:
                 # Blueprints are banned from Key or Crown locations
                 blueprintValidTypes = [typ for typ in self.shuffled_location_types if typ not in (Types.Crown, Types.Key)]
-                blueprintLocations = [location for location in LocationList if LocationList[location].type in blueprintValidTypes]
+                # These locations do not have a set Kong assigned to them and can't have blueprints
+                badBPLocations = (
+                    Locations.IslesDonkeyJapesRock,
+                    Locations.JapesDonkeyFrontofCage,
+                    Locations.JapesDonkeyFreeDiddy,
+                    Locations.AztecDiddyFreeTiny,
+                    Locations.AztecDonkeyFreeLanky,
+                    Locations.FactoryLankyFreeChunky,
+                )
+                blueprintLocations = [location for location in LocationList if location not in badBPLocations and LocationList[location].type in blueprintValidTypes]
                 self.valid_locations[Types.Blueprint] = {}
                 self.valid_locations[Types.Blueprint][Kongs.donkey] = [location for location in blueprintLocations if LocationList[location].kong in (Kongs.donkey, Kongs.any)]
                 self.valid_locations[Types.Blueprint][Kongs.diddy] = [location for location in blueprintLocations if LocationList[location].kong in (Kongs.diddy, Kongs.any)]
@@ -635,7 +644,7 @@ class Settings:
             if Types.Key in self.shuffled_location_types:
                 self.valid_locations[Types.Key] = shuffledLocations
             if Types.Medal in self.shuffled_location_types:
-                self.valid_locations[Types.Medal] = shuffledLocations
+                self.valid_locations[Types.Medal] = [location for location in shuffledLocations if not LocationList[location].is_reward]
             if Types.Coin in self.shuffled_location_types:
                 self.valid_locations[Types.Coin] = shuffledLocations
 

--- a/randomizer/ShuffleDoors.py
+++ b/randomizer/ShuffleDoors.py
@@ -54,8 +54,6 @@ def ShuffleDoors(spoiler):
             moveless_portal_selected = False
             # Make sure selected locations will be suitable to be a T&S portal
             available_doors = [door for door in available_doors if door_locations[level][door].door_type != "wrinkly"]
-            if level == Levels.JungleJapes:
-                number_of_portals_in_level -= 1  # One portal is forced in Japes
             for new_portal in range(number_of_portals_in_level):
                 if len(available_doors) > 0:  # Should only fail if we don't have enough door locations
                     if new_portal < (number_of_portals_in_level - 1) or moveless_portal_selected is True:

--- a/randomizer/ShuffleKasplats.py
+++ b/randomizer/ShuffleKasplats.py
@@ -125,7 +125,7 @@ def ShuffleKasplatsAndLocations(spoiler, LogicVariables):
                     item_id = GetBlueprintItemForKongAndLevel(level, kong)
                     location_id = GetBlueprintLocationForKongAndLevel(level, kong)
                     # Assemble the Location object
-                    location = Location(kasplat.name, item_id, Types.Blueprint, kong, [kasplat.map, kong])
+                    location = Location(kasplat.name, item_id, Types.Blueprint, kong, [kasplat.map])
                     Logic.LocationList[location_id] = location
                     # Insert the Location into the Region
                     kasplatRegion = Logic.Regions[kasplat.region_id]

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -70,8 +70,8 @@ class Spoiler:
 
         self.hint_list = {}
 
-    def toJson(self):
-        """Convert spoiler to JSON."""
+    def createJson(self):
+        """Convert spoiler to JSON and save it."""
         # Verify we match our hash
         self.settings.verify_hash()
         # We want to convert raw spoiler data into the important bits and in human-readable formats.
@@ -192,7 +192,6 @@ class Spoiler:
             "Kongs": {},
             "Shops": {},
             "Others": {},
-            "Item Placement": self.human_item_assignment,
         }
 
         prices = OrderedDict()
@@ -431,7 +430,7 @@ class Spoiler:
                     human_cb_type_map[group["type"]].strip()
                 ] += f"{map_name.strip()}: {group['name']}<br>"
 
-        return json.dumps(humanspoiler, indent=4)
+        self.json = json.dumps(humanspoiler, indent=4)
 
     def UpdateKasplats(self, kasplat_map):
         """Update kasplat data."""

--- a/templates/overworld.html.jinja2
+++ b/templates/overworld.html.jinja2
@@ -69,8 +69,7 @@
                         </label>
                     </div>
                     <div class="form-check form-switch item-switch">
-                        <label data-toggle="tooltip"
-                               title="Wrinkly Door Locations are randomized">
+                        <label data-toggle="tooltip" title="Wrinkly Door Locations are randomized">
                             <input class="form-check-input"
                                    type="checkbox"
                                    name="wrinkly_location_rando"
@@ -79,8 +78,7 @@
                         </label>
                     </div>
                     <div class="form-check form-switch item-switch">
-                        <label data-toggle="tooltip"
-                               title="T&S Portal Locations are randomized">
+                        <label data-toggle="tooltip" title="T&S Portal Locations are randomized">
                             <input class="form-check-input"
                                    type="checkbox"
                                    name="tns_location_rando"


### PR DESCRIPTION
This PR fixes the conversion from the logic's `LocationList` to the patcher's `item_placement`
A couple other bugs found and ironed out on the way - most notable among them is the spoiler json now being generated inside the logic loop. Anything wanting to be placed in the spoiler log needs to be determined before the seed is finished generating. May revisit this if certain things are desired. This is done so adjustments to `LocationList` (kasplat rando locations foremost) can have their placed items shown in the spoiler.