### PR TITLE
fixed unlock all moves, moved starting shockwave

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1047,7 +1047,7 @@ def FillKongsAndMoves(spoiler):
         FillKongs(spoiler)
 
     # Once Kongs are placed, the top priority is placing training barrel moves first. These (mostly) need to be very early because they block access to whole levels.
-    if spoiler.settings.move_rando != "off" and spoiler.settings.training_barrels == "shuffled":
+    if not spoiler.settings.unlock_all_moves and spoiler.settings.move_rando != "off" and spoiler.settings.training_barrels == "shuffled":
         # First place barrels - needed for most bosses
         if spoiler.settings.shuffle_loading_zones != "all" and not spoiler.settings.hard_level_progression:
             # In standard level order, place barrels very early to prevent same-y boss orders
@@ -1211,7 +1211,7 @@ def FillKongsAndMoves(spoiler):
                 BlockAccessToLevel(spoiler.settings, 100)
 
     # Handle shared moves before other moves in move rando
-    if spoiler.settings.move_rando != "off":
+    if not spoiler.settings.unlock_all_moves and spoiler.settings.move_rando != "off":
         # Shuffle the shared move locations since they must be done first
         ShuffleSharedMoves(spoiler, preplacedPriorityMoves.copy())
         # Set up remaining kong moves to be shuffled
@@ -1244,7 +1244,7 @@ def FillKongsAndMoves(spoiler):
         raise Ex.ItemPlacementException(str(unplaced) + " unplaced items.")
 
     # Final touches to item placement, some locations need special treatment
-    if spoiler.settings.move_rando != "off":
+    if not spoiler.settings.unlock_all_moves and spoiler.settings.move_rando != "off":
         # If we're shuffling training moves, always put a move in each training barrel
         if spoiler.settings.training_barrels == "shuffled":
             emptyTrainingBarrels = [loc for loc in TrainingBarrelLocations if LocationList[loc].item is None]
@@ -1252,19 +1252,24 @@ def FillKongsAndMoves(spoiler):
                 # Find the list of locations that have a kong move in them
                 kongMoveLocationsList = []
                 for location in DonkeyMoveLocations:
-                    if LocationList[location].item is not None:
+                    item_at_location = LocationList[location].item
+                    if item_at_location is not None and item_at_location != Items.NoItem:
                         kongMoveLocationsList.append(location)
                 for location in DiddyMoveLocations:
-                    if LocationList[location].item is not None:
+                    item_at_location = LocationList[location].item
+                    if item_at_location is not None and item_at_location != Items.NoItem:
                         kongMoveLocationsList.append(location)
                 for location in LankyMoveLocations:
-                    if LocationList[location].item is not None:
+                    item_at_location = LocationList[location].item
+                    if item_at_location is not None and item_at_location != Items.NoItem:
                         kongMoveLocationsList.append(location)
                 for location in TinyMoveLocations:
-                    if LocationList[location].item is not None:
+                    item_at_location = LocationList[location].item
+                    if item_at_location is not None and item_at_location != Items.NoItem:
                         kongMoveLocationsList.append(location)
                 for location in ChunkyMoveLocations:
-                    if LocationList[location].item is not None:
+                    item_at_location = LocationList[location].item
+                    if item_at_location is not None and item_at_location != Items.NoItem:
                         kongMoveLocationsList.append(location)
                 # Worth noting that moving a move to the training barrels will always make it more accessible, and thus doesn't need any additional logic
                 for emptyBarrel in emptyTrainingBarrels:
@@ -1755,7 +1760,7 @@ def Generate_Spoiler(spoiler):
             ShuffleExits.ExitShuffle(spoiler.settings)
             spoiler.UpdateExits()
         # Handle Item Fill
-        if spoiler.settings.move_rando != "off" or spoiler.settings.kong_rando or any(spoiler.settings.shuffled_location_types):
+        if (spoiler.settings.move_rando != "off" and not spoiler.settings.unlock_all_moves) or spoiler.settings.kong_rando or any(spoiler.settings.shuffled_location_types):
             FillKongsAndMovesGeneric(spoiler)
         else:
             # Just check if normal item locations are beatable with given settings

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -36,12 +36,12 @@ def PlaceConstants(settings):
     typesOfItemsShuffled = []
     if settings.kong_rando:
         typesOfItemsShuffled.append(Types.Kong)
-    if settings.move_rando != "off":
+    if not settings.unlock_all_moves and settings.move_rando != "off":
         typesOfItemsShuffled.append(Types.Shop)
-    if settings.training_barrels == "shuffled":
-        typesOfItemsShuffled.append(Types.TrainingBarrel)
-    if settings.shockwave_status != "vanilla":
-        typesOfItemsShuffled.append(Types.Shockwave)
+        if settings.training_barrels == "shuffled":
+            typesOfItemsShuffled.append(Types.TrainingBarrel)
+        if settings.shockwave_status != "vanilla":
+            typesOfItemsShuffled.append(Types.Shockwave)
     if settings.shuffle_loading_zones == "levels":
         typesOfItemsShuffled.append(Types.Key)
     typesOfItemsShuffled.extend(settings.shuffled_location_types)
@@ -94,7 +94,7 @@ def PlaceConstants(settings):
         LocationList[Locations.MusicUpgrade1].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.ThirdMelon].PlaceConstantItem(Items.NoItem)
         LocationList[Locations.MusicUpgrade2].PlaceConstantItem(Items.NoItem)
-    if settings.unlock_fairy_shockwave and settings.shockwave_status == "vanilla":
+        # Shockwave also granted when unlocking all moves
         LocationList[Locations.CameraAndShockwave].PlaceConstantItem(Items.NoItem)
 
 
@@ -323,7 +323,7 @@ def Upgrades(settings):
         upgrades.append(Items.SniperSight)
         upgrades.extend(itertools.repeat(Items.ProgressiveAmmoBelt, 2))
         upgrades.extend(itertools.repeat(Items.ProgressiveInstrumentUpgrade, 3))
-    if not settings.unlock_fairy_shockwave:
+    if settings.shockwave_status != "start_with":
         if settings.shockwave_status == "vanilla" or settings.shockwave_status == "shuffled":
             upgrades.append(Items.CameraAndShockwave)
         else:

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -92,7 +92,7 @@ class Location:
 
     def PlaceConstantItem(self, item):
         """Place item at this location, and set constant so it's ignored in the spoiler."""
-        self.item = item
+        self.PlaceItem(item)
         self.constant = True
 
     def SetDelayedItem(self, item):
@@ -101,12 +101,12 @@ class Location:
 
     def PlaceDelayedItem(self):
         """Place the delayed item at this location."""
-        self.item = self.delayedItem
+        self.PlaceItem(self.delayedItem)
         self.delayedItem = None
 
     def PlaceDefaultItem(self):
         """Place whatever this location's default (vanilla) item is at it."""
-        self.item = self.default
+        self.PlaceItem(self.default)
         self.constant = True
 
 

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -101,8 +101,8 @@ class LogicVarHolder:
         self.nintendoCoin = False
         self.rarewareCoin = False
 
-        self.camera = self.settings.unlock_fairy_shockwave
-        self.shockwave = self.settings.unlock_fairy_shockwave
+        self.camera = self.settings.shockwave_status == "start_with"
+        self.shockwave = self.settings.shockwave_status == "start_with"
 
         self.scope = self.settings.unlock_all_moves
         self.homing = self.settings.unlock_all_moves

--- a/randomizer/Patching/ApplyRandomizer.py
+++ b/randomizer/Patching/ApplyRandomizer.py
@@ -171,7 +171,7 @@ def patching_response(responded_data):
     ROM().write(1)
 
     # Unlock Shockwave
-    if spoiler.settings.unlock_fairy_shockwave:
+    if spoiler.settings.shockwave_status == "start_with":
         ROM().seek(sav + 0x02F)
         ROM().write(1)
 

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -167,7 +167,7 @@ class Settings:
         self.puzzle_rando = None
         self.shuffle_shops = None
 
-        # currently just set to moves by move_rando
+        # The major setting for item randomization
         # shuffle_items: str
         # none
         # phase1
@@ -213,8 +213,6 @@ class Settings:
         self.crown_door_open = None
         # coin_door_open: bool
         self.coin_door_open = None
-        # unlock_fairy_shockwave: bool
-        self.unlock_fairy_shockwave = None
         # krool_phase_count: int, [1-5]
         self.krool_phase_count = 5
         self.krool_random = False
@@ -271,6 +269,7 @@ class Settings:
         # vanilla - both located at Banana Fairy Isle
         # shuffled - located in a random valid location
         # shuffled_decoupled - camera and shockwave are separate upgrades and can be anywhere
+        # start_with - start with camera and shockwave
         self.shockwave_status = "vanilla"
 
         #  Music
@@ -590,7 +589,7 @@ class Settings:
                 self.valid_locations[Types.Shop][Kongs.diddy] = DiddyMoveLocations.copy()
                 self.valid_locations[Types.Shop][Kongs.lanky] = LankyMoveLocations.copy()
                 self.valid_locations[Types.Shop][Kongs.tiny] = TinyMoveLocations.copy()
-                if self.shockwave_status == "vanilla":
+                if self.shockwave_status in ("vanilla", "start_with"):
                     self.valid_locations[Types.Shop][Kongs.tiny].remove(Locations.CameraAndShockwave)
                 self.valid_locations[Types.Shop][Kongs.chunky] = ChunkyMoveLocations.copy()
             elif self.move_rando == "cross_purchase":
@@ -601,7 +600,7 @@ class Settings:
                 allKongMoveLocations.update(LankyMoveLocations.copy())
                 if self.training_barrels == "shuffled" and Types.TrainingBarrel not in self.shuffled_location_types:
                     allKongMoveLocations.update(TrainingBarrelLocations.copy())
-                if self.shockwave_status == "vanilla" and Types.Shockwave not in self.shuffled_location_types:
+                if self.shockwave_status in ("vanilla", "start_with") and Types.Shockwave not in self.shuffled_location_types:
                     allKongMoveLocations.remove(Locations.CameraAndShockwave)
                 self.valid_locations[Types.Shop][Kongs.donkey] = allKongMoveLocations
                 self.valid_locations[Types.Shop][Kongs.diddy] = allKongMoveLocations
@@ -609,7 +608,7 @@ class Settings:
                 self.valid_locations[Types.Shop][Kongs.tiny] = allKongMoveLocations
                 self.valid_locations[Types.Shop][Kongs.chunky] = allKongMoveLocations
             self.valid_locations[Types.Shop][Kongs.any] = SharedShopLocations
-            if self.shockwave_status != "vanilla" and Types.Shockwave not in self.shuffled_location_types:
+            if self.shockwave_status not in ("vanilla", "start_with") and Types.Shockwave not in self.shuffled_location_types:
                 self.valid_locations[Types.Shop][Kongs.any].add(Locations.CameraAndShockwave)
             if self.training_barrels == "shuffled" and Types.TrainingBarrel not in self.shuffled_location_types:
                 self.valid_locations[Types.Shop][Kongs.any].update(TrainingBarrelLocations.copy())

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -101,7 +101,7 @@ class Spoiler:
         settings["Puzzle Randomization"] = self.settings.puzzle_rando
         settings["Crown Door Open"] = self.settings.crown_door_open
         settings["Coin Door Open"] = self.settings.coin_door_open
-        settings["Unlock Fairy Shockwave"] = self.settings.unlock_fairy_shockwave
+        settings["Shockwave Shuffle"] = self.settings.shockwave_status
         settings["Random Medal Requirement"] = self.settings.random_medal_requirement
         settings["Random Shop Prices"] = self.settings.random_prices
         settings["Banana Port Randomization"] = self.settings.bananaport_rando

--- a/static/presets/2dos_special.json
+++ b/static/presets/2dos_special.json
@@ -39,7 +39,6 @@
     "hard_level_progression":false,
     "hard_blockers":false,
     "hard_troff_n_scoff":false,
-    "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":true,
     "bonus_barrel_auto_complete":false,
     "open_lobbies":true,

--- a/static/presets/cfox_luck.json
+++ b/static/presets/cfox_luck.json
@@ -33,7 +33,6 @@
     "hard_level_progression":false,
     "hard_blockers":false,
     "hard_troff_n_scoff":false,
-    "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":true,
     "bonus_barrel_auto_complete":false,
     "open_lobbies":false,

--- a/static/presets/coupled_lzr_balanced.json
+++ b/static/presets/coupled_lzr_balanced.json
@@ -39,7 +39,6 @@
     "hard_level_progression":false,
     "hard_blockers":false,
     "hard_troff_n_scoff":false,
-    "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":true,
     "bonus_barrel_auto_complete":false,
     "open_lobbies":true,

--- a/static/presets/decoupled_lzr_balanced.json
+++ b/static/presets/decoupled_lzr_balanced.json
@@ -39,7 +39,6 @@
     "hard_level_progression":false,
     "hard_blockers":false,
     "hard_troff_n_scoff":false,
-    "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":false,
     "bonus_barrel_auto_complete":true,
     "open_lobbies":true,

--- a/static/presets/default.json
+++ b/static/presets/default.json
@@ -95,7 +95,6 @@
     "troff_5": 6,
     "troff_6": 7,
     "troff_text": 300,
-    "unlock_fairy_shockwave": false,
     "warp_to_isles": true,
     "win_condition": "beat_krool",
     "wrinkly_hints": "standard",

--- a/static/presets/hell.json
+++ b/static/presets/hell.json
@@ -32,7 +32,6 @@
     "hard_level_progression":false,
     "hard_blockers":false,
     "hard_troff_n_scoff":false,
-    "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":false,
     "bonus_barrel_auto_complete":false,
     "open_lobbies":false,

--- a/static/presets/qol_only.json
+++ b/static/presets/qol_only.json
@@ -43,7 +43,6 @@
     "hard_bosses":false,
     "perma_death":false,
     "disable_tag_barrels":false,
-    "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":false,
     "gnawty_barrels":false,
     "bonus_barrel_auto_complete":false,

--- a/static/presets/season1.json
+++ b/static/presets/season1.json
@@ -33,7 +33,6 @@
     "hard_level_progression":false,
     "hard_blockers":false,
     "hard_troff_n_scoff":false,
-    "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":true,
     "bonus_barrel_auto_complete":false,
     "open_lobbies":false,

--- a/static/presets/suggested.json
+++ b/static/presets/suggested.json
@@ -33,7 +33,6 @@
     "hard_level_progression":false,
     "hard_blockers":false,
     "hard_troff_n_scoff":false,
-    "unlock_fairy_shockwave":false,
     "bonus_barrel_rando":true,
     "bonus_barrel_auto_complete":false,
     "open_lobbies":false,

--- a/templates/overworld.html.jinja2
+++ b/templates/overworld.html.jinja2
@@ -6,13 +6,13 @@
             <div class="flex-container">
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"
-                           title="This option makes the fairy camera and shockwave attack available from the start.&#10;Normally obtainable by visiting the Banana Fairy Queen with Tiny as Mini Monkey.">
+                           title="Bonus Barrels outside of Helm auto complete.">
                         <input class="form-check-input"
                                type="checkbox"
-                               name="unlock_fairy_shockwave"
-                               id="unlock_fairy_shockwave"
+                               name="bonus_barrel_auto_complete"
+                               id="bonus_barrel_auto_complete"
                                value="True"/>
-                        Unlock Fairy Camera and Shockwave Attack
+                        Auto Complete Bonus Barrels
                     </label>
                 </div>
                 <div class="form-check form-switch item-switch">
@@ -27,17 +27,6 @@
                     </label>
                     {{ list_selector(minigames, "minigames_list", "MINIGAME SELECTOR", "This will open a popup that will let you customize what Bonus Games are in the pool.&#10;This defaults to All minigames.") }}
                     {# Remove end </div> as it's included in the macro for formatting #}
-                    <div class="form-check form-switch item-switch">
-                        <label data-toggle="tooltip"
-                               title="Bonus Barrels outside of Helm auto complete.">
-                            <input class="form-check-input"
-                                   type="checkbox"
-                                   name="bonus_barrel_auto_complete"
-                                   id="bonus_barrel_auto_complete"
-                                   value="True"/>
-                            Auto Complete Bonus Barrels
-                        </label>
-                    </div>
                     <div class="form-check form-switch item-switch">
                         <label data-toggle="tooltip"
                                title="All lobbies will be open as if the key to K. Lumsy was already turned in.&#10;This does not affect K. Rool's ship.">

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -215,7 +215,7 @@
                                 class="form-select"
                                 aria-label="Randomization type"
                                 data-toggle="tooltip"
-                                title="Determines if and how moves are randomized.&#10;-Vanilla: Moves are in their vanilla locations and can only be bought by their normal kongs.&#10;-Shuffle: Moves can be randomized to different shops, but must still be bought by their normal kong. Shared moves can be bought by any kong.&#10;-Cross Kong Purchases: Kongs can now purchase another kongs moves. Shop Indicator will still show which kong buys the move.&#10;-Unlock All Moves: This option will make all moves available from the start without purchasing them. Does not include shockwave.">
+                                title="Determines if and how moves are randomized.&#10;-Vanilla: Moves are in their vanilla locations and can only be bought by their normal kongs.&#10;-Shuffle: Moves can be randomized to different shops, but must still be bought by their normal kong. Shared moves can be bought by any kong.&#10;-Cross Kong Purchases: Kongs can now purchase another kongs moves. Shop Indicator will still show which kong buys the move.&#10;-Unlock All Moves: This option will make all moves available from the start without purchasing them.">
                             <option id="move_off"
                                     selected
                                     value="off"
@@ -240,7 +240,7 @@
                                 class="form-select"
                                 aria-label="Randomization type"
                                 data-toggle="tooltip"
-                                title="Determines if and how training barrel moves are randomized.&#10;-Vanilla: Training barrel moves are learned from the training barrels.&#10;-Shuffle: Training barrel moves are shuffled with other moves.">
+                                title="Determines if and how training barrel moves are randomized.&#10;-Vanilla: Training barrel moves are learned from the training barrels.&#10;-Shuffle: Training barrel moves are shuffled with other moves, giving you 4 random starting moves.">
                             <option id="training_barrels_normal" value="normal">
                                 Vanilla
                             </option>
@@ -284,7 +284,7 @@
                                 class="form-select"
                                 aria-label="Randomization type"
                                 data-toggle="tooltip"
-                                title="Determines how Banana Fairy Isle is handled.&#10;-Vanilla: Shockwave and Camera are given at BFI.&#10;-Shuffle: Camera and Shockwave are shuffled with other moves and BFI can hold a shared or Tiny move.&#10;-Shuffle Separately: Same as Shuffle but Camera and Shockwave are separate upgrades.">
+                                title="Determines how Banana Fairy Isle is handled.&#10;-Vanilla: Shockwave and Camera are given at BFI.&#10;-Shuffle: Camera and Shockwave are shuffled with other moves and BFI can hold a shared or Tiny move.&#10;-Shuffle Separately: Same as Shuffle but Camera and Shockwave are separate upgrades.&#10;-Start With: Start with Camera and Shockwave. BFI will have nothing.">
                             <option id="shockwave_status_vanilla" value="vanilla">
                                 Vanilla
                             </option>
@@ -293,6 +293,9 @@
                             </option>
                             <option id="shockwave_status_shuffled_decoupled" value="shuffled_decoupled">
                                 Shuffle Separately
+                            </option>
+                            <option id="shockwave_status_start_with" value="start_with">
+                                Start With
                             </option>
                         </select>
                     </div>

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -5,7 +5,7 @@ from ui.rando_options import (
     disable_boss_rando,
     disable_colors,
     disable_music,
-    disable_prices,
+    disable_move_shuffles,
     disable_rw,
     hide_rgb,
     max_randomized_blocker,
@@ -28,7 +28,7 @@ toggle_b_locker_boxes(None)
 update_boss_required(None)
 disable_colors(None)
 disable_music(None)
-disable_prices(None)
+disable_move_shuffles(None)
 max_randomized_blocker(None)
 max_randomized_troff(None)
 disable_barrel_modal(None)

--- a/ui/generate_buttons.py
+++ b/ui/generate_buttons.py
@@ -16,7 +16,7 @@ from ui.rando_options import (
     disable_barrel_modal,
     disable_colors,
     disable_music,
-    disable_prices,
+    disable_move_shuffles,
     max_randomized_blocker,
     max_randomized_troff,
     toggle_b_locker_boxes,
@@ -76,7 +76,7 @@ def import_settings_string(event):
         update_boss_required(None)
         disable_colors(None)
         disable_music(None)
-        disable_prices(None)
+        disable_move_shuffles(None)
         max_randomized_blocker(None)
         max_randomized_troff(None)
         disable_barrel_modal(None)

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -345,15 +345,29 @@ def disable_helm_phases(evt):
 
 
 @bind("change", "move_rando")
-def disable_prices(evt):
-    """Disable prices if move rando is set to start with all moves."""
+def disable_move_shuffles(evt):
+    """Disable some settings based on the move rando setting."""
     moves = js.document.getElementById("move_rando")
     prices = js.document.getElementById("random_prices")
+    training_barrels = js.document.getElementById("training_barrels")
+    shockwave_status = js.document.getElementById("shockwave_status")
     try:
         if moves.value == "start_with":
             prices.setAttribute("disabled", "disabled")
+            training_barrels.value = "normal"
+            training_barrels.setAttribute("disabled", "disabled")
+            shockwave_status.value = "vanilla"
+            shockwave_status.setAttribute("disabled", "disabled")
+        elif moves.value == "off":
+            prices.removeAttribute("disabled")
+            training_barrels.value = "normal"
+            training_barrels.setAttribute("disabled", "disabled")
+            shockwave_status.value = "vanilla"
+            shockwave_status.setAttribute("disabled", "disabled")
         else:
             prices.removeAttribute("disabled")
+            training_barrels.removeAttribute("disabled")
+            shockwave_status.removeAttribute("disabled")
     except AttributeError:
         pass
 
@@ -411,7 +425,7 @@ def preset_select_changed(event):
     update_boss_required(None)
     disable_colors(None)
     disable_music(None)
-    disable_prices(None)
+    disable_move_shuffles(None)
     max_randomized_blocker(None)
     max_randomized_troff(None)
     disable_barrel_modal(None)
@@ -474,10 +488,10 @@ def disable_rw(evt):
             pass
 
 
-@bind("change", "unlock_fairy_shockwave")
+@bind("change", "shockwave_status")
 def toggle_extreme_prices_option(event):
     """Determine the visibility of the extreme prices option."""
-    unlocked_shockwave = document.getElementById("unlock_fairy_shockwave").checked
+    unlocked_shockwave = document.getElementById("shockwave_status").value == "start_with"
     no_logic = document.getElementById("no_logic").checked
     option = document.getElementById("extreme_price_option")
     if unlocked_shockwave or no_logic:


### PR DESCRIPTION
Fixed unlock all moves not generating correctly.

Updated the UI to lock out some mutually exclusive settings.

Shockwave is now included in "Unlock All Moves"

Moved unlock shockwave toggle to the dropdown for BFI's status