### PR TITLE
better item rando hints

### DIFF
--- a/randomizer/Enums/HintType.py
+++ b/randomizer/Enums/HintType.py
@@ -17,3 +17,5 @@ class HintType(IntEnum):
     MedalsRequired = auto()
     Entrance = auto()
     KeyLocation = auto()
+    FullShopWithItems = auto()
+    WothLocation = auto()

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -754,24 +754,6 @@ def GetItemPrerequisites(spoiler, targetItemId, ownedKongs=[]):
     return requiredMoves
 
 
-# def GetValidLocationsForMove(spoiler, move, blockedLocations=set({})):
-#     """Return the valid locations for the given move. Currently only returns shop locations for moves."""
-#     validLocations = set({})
-#     if spoiler.settings.move_rando == "cross_purchase" or move in ItemPool.DonkeyMoves:
-#         validLocations.update(DonkeyMoveLocations.copy())
-#     if spoiler.settings.move_rando == "cross_purchase" or move in ItemPool.DiddyMoves:
-#         validLocations.update(DiddyMoveLocations.copy())
-#     if spoiler.settings.move_rando == "cross_purchase" or move in ItemPool.TinyMoves:
-#         validLocations.update(TinyMoveLocations.copy())
-#     if spoiler.settings.move_rando == "cross_purchase" or move in ItemPool.ChunkyMoves:
-#         validLocations.update(ChunkyMoveLocations.copy())
-#     if spoiler.settings.move_rando == "cross_purchase" or move in ItemPool.LankyMoves:
-#         validLocations.update(LankyMoveLocations.copy())
-#     if spoiler.settings.training_barrels == "shuffled":
-#         validLocations.update(TrainingBarrelLocations.copy())
-#     return list(validLocations - blockedLocations)
-
-
 def PlaceItems(settings, algorithm, itemsToPlace, ownedItems=None, inOrder=False):
     """Places items using given algorithm."""
     if ownedItems is None:
@@ -841,6 +823,7 @@ def Fill(spoiler):
         if gbsUnplaced > 0:
             raise Ex.ItemPlacementException(str(gbsUnplaced) + " unplaced GBs.")
     # Finally, check if game is beatable
+    BlockAccessToLevel(spoiler.settings, 100)  # In case any blocks were still in place (lookin at you, no logic)
     Reset()
     if not GetAccessibleLocations(spoiler.settings, [], SearchMode.CheckBeatable):
         raise Ex.GameNotBeatableException("Game unbeatable after placing all items.")

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -113,7 +113,7 @@ def AllItems(settings):
         allItems.extend(Keys())
     if Types.Medal in settings.shuffled_location_types:
         allItems.extend(BananaMedalItems())
-    if settings.move_rando != "off" or Types.Shop in settings.shuffled_location_types:
+    if settings.move_rando != "off":
         allItems.extend(DonkeyMoves)
         allItems.extend(DiddyMoves)
         allItems.extend(LankyMoves)

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -130,7 +130,7 @@ LogicRegions = {
     ]),
 
     Regions.GloomyGalleonLobby: Region("Gloomy Galleon Lobby", Levels.DKIsles, True, None, [
-        LocationLogic(Locations.IslesTinyGalleonLobby, lambda l: l.chunky and l.superSlam and l.mini and l.twirl and l.tiny),
+        LocationLogic(Locations.IslesTinyGalleonLobby, lambda l: l.chunky and l.superSlam and l.mini and l.twirl and l.swim and l.tiny),
         LocationLogic(Locations.IslesKasplatGalleonLobby, lambda l: not l.settings.kasplat_rando),
     ], [], [
         TransitionFront(Regions.IslesMain, lambda l: l.swim, Transitions.IslesGalleonLobbyToMain),

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -372,10 +372,13 @@ class Settings:
                     for type in Types:
                         if type.name == item.capitalize():
                             self.shuffled_location_types.append(type)
-            if Types.Shop in self.shuffled_location_types and self.shockwave_status not in ("vanilla", "start_with"):
-                self.shuffled_location_types.append(Types.Shockwave)
-            if Types.Shop in self.shuffled_location_types and self.training_barrels != "normal":
-                self.shuffled_location_types.append(Types.TrainingBarrel)
+            if Types.Shop in self.shuffled_location_types:
+                if self.move_rando != "start_with":
+                    self.move_rando = "item_shuffle"
+                if self.shockwave_status not in ("vanilla", "start_with"):
+                    self.shuffled_location_types.append(Types.Shockwave)
+                if self.training_barrels != "normal":
+                    self.shuffled_location_types.append(Types.TrainingBarrel)
         self.progressives_locked_in_shops = False  # Technical limitation: for now (hopefully) progressive moves must be found in shops
 
         self.shuffle_prices()
@@ -579,15 +582,6 @@ class Settings:
                     ItemList[item_index].playthrough = True
         if self.win_condition == "all_medals":
             ItemList[Items.BananaMedal].playthrough = True
-        if self.win_condition == "all_keys":
-            ItemList[Items.JungleJapesKey].playthrough = True
-            ItemList[Items.AngryAztecKey].playthrough = True
-            ItemList[Items.FranticFactoryKey].playthrough = True
-            ItemList[Items.GloomyGalleonKey].playthrough = True
-            ItemList[Items.FungiForestKey].playthrough = True
-            ItemList[Items.CrystalCavesKey].playthrough = True
-            ItemList[Items.CreepyCastleKey].playthrough = True
-            ItemList[Items.HideoutHelmKey].playthrough = True
         if not self.crown_door_open:
             ItemList[Items.BattleCrown].playthrough = True
 
@@ -599,7 +593,7 @@ class Settings:
         self.valid_locations = {}
         self.valid_locations[Types.Kong] = [Locations.DiddyKong, Locations.LankyKong, Locations.TinyKong, Locations.ChunkyKong]
         # If shops are not shuffled into the larger pool, calculate shop locations for shop-bound moves
-        if self.move_rando != "off" and Types.Shop not in self.shuffled_location_types:
+        if self.move_rando not in ("off", "item_shuffle"):
             self.valid_locations[Types.Shop] = {}
             if self.move_rando == "on":
                 self.valid_locations[Types.Shop][Kongs.donkey] = DonkeyMoveLocations.copy()

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -31,6 +31,7 @@ class Spoiler:
         self.settings: Settings = settings
         self.playthrough = {}
         self.woth = {}
+        self.woth_locations = {}
         self.shuffled_barrel_data = {}
         self.shuffled_exit_data = {}
         self.shuffled_exit_instructions = []
@@ -669,6 +670,7 @@ class Spoiler:
     def UpdateWoth(self, locations, wothLocations):
         """Write woth locations as a dict of location/item pairs."""
         self.woth = {}
+        self.woth_locations = wothLocations
         for locationId in wothLocations:
             location = locations[locationId]
             self.woth[location.name] = ItemList[location.item].name


### PR DESCRIPTION
Improved hints for item rando:
- Converted shop hints to a new type that better handles all items being in shops
- Converted move location hints to Way of the Hoard location hints that tell you a specific location is on the Way of the Hoard

Minor logic fixes as well:
- Fixed issue with no logic having incorrect progression
- Tiny's GB in Galleon lobby now requires swim