### PR TITLE
catching up on known issues

### DIFF
--- a/randomizer/Enums/HintType.py
+++ b/randomizer/Enums/HintType.py
@@ -8,7 +8,6 @@ class HintType(IntEnum):
     Joke = auto()
     KRoolOrder = auto()
     HelmOrder = auto()
-    FullShop = auto()
     MoveLocation = auto()
     DirtPatch = auto()
     BLocker = auto()

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -727,6 +727,8 @@ def GetMaxCoinsSpent(settings, purchasedShops):
         elif location.item == Items.ProgressiveInstrumentUpgrade:
             movePrice = settings.prices[location.item][instUpgrades]
             instUpgrades += 1
+        elif settings.random_prices == "vanilla":
+            movePrice = settings.prices[location.item]
         else:
             movePrice = settings.prices[location_id]
         if movePrice is not None:
@@ -1892,16 +1894,6 @@ def SetNewProgressionRequirementsUnordered(settings: Settings):
                     ]
                     ownedMoves[bossCompletedLevel] = accessibleMoves
 
-    # We still need to set T&S for some levels, but we'll have access to every level by this point
-    for level in range(len(settings.BossBananas)):
-        # This means that the level hasn't been unset from completion blocking
-        if settings.BossBananas[level] > 500:
-            # We should have access to everything by this point
-            settings.BossBananas[level] = initialTNS[level]
-        if Levels(level) not in ownedKongs.keys():
-            ownedKongs[Levels(level)] = LogicVariables.GetKongs()
-            ownedMoves[Levels(level)] = allMoves
-
     # For any boss location behind a T&S we didn't lower...
     bossLocations = [
         location for id, location in LocationList.items() if location.type == Types.Key and location.level in levelsProgressed and settings.BossBananas[location.level] >= initialTNS[location.level]
@@ -1911,8 +1903,9 @@ def SetNewProgressionRequirementsUnordered(settings: Settings):
         if settings.BossBananas[bossLocation.level] > 500:
             # We should have access to everything by this point
             settings.BossBananas[bossLocation.level] = initialTNS[bossLocation.level]
+        # For any level we haven't lowered yet, assume we own everything
         if bossLocation.level not in ownedKongs.keys():
-            ownedKongs[bossLocation.level] = LogicVariables.GetKongs()
+            ownedKongs[bossLocation.level] = [Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky]
             ownedMoves[bossLocation.level] = allMoves
         # If boss rewards could be anything, we have to make sure they're accessible independent of all else
         if isKeyItemRando:
@@ -1950,6 +1943,12 @@ def SetNewProgressionRequirementsUnordered(settings: Settings):
     ShuffleBossesBasedOnOwnedItems(settings, ownedKongs, ownedMoves)
     settings.owned_kongs_by_level = ownedKongs
     settings.owned_moves_by_level = ownedMoves
+
+    # After setting all the progression, make sure we did it right
+    # Technically the coin logic check after this will cover it, but this will help identify issues better
+    Reset()
+    if not GetAccessibleLocations(settings, [], SearchMode.CheckAllReachable):
+        raise Ex.GameNotBeatableException("Complex progression generation prevented 101%.")
 
 
 def GetAccessibleOpenLevels(settings, accessible):

--- a/randomizer/Prices.py
+++ b/randomizer/Prices.py
@@ -152,6 +152,9 @@ def GetMaxForKong(settings, kong):
             elif item_id == Items.ProgressiveAmmoBelt:
                 total_price += settings.prices[item_id][found_ammo_belts]
                 found_ammo_belts += 1
+            # Vanilla prices are by item, not by location
+            elif settings.random_prices == "vanilla":
+                total_price += settings.prices[item_id]
             else:
                 total_price += settings.prices[location]
 
@@ -179,6 +182,9 @@ def GetMaxForKong(settings, kong):
             elif item_id == Items.ProgressiveAmmoBelt:
                 total_price += settings.prices[item_id][found_ammo_belts]
                 found_ammo_belts += 1
+            # Vanilla prices are by item, not by location
+            elif settings.random_prices == "vanilla":
+                total_price += settings.prices[item_id]
             else:
                 total_price += settings.prices[location]
     return total_price
@@ -283,6 +289,9 @@ def GetPriceAtLocation(settings, location_id, location, slamLevel, ammoBelts, in
         else:
             # If already have max instrument upgrade, there's move to buy
             return 0
+    # Vanilla prices are by item, not by location
+    elif settings.random_prices == "vanilla":
+        return settings.prices[item]
     else:
         return settings.prices[location_id]
 

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -663,7 +663,7 @@ class Settings:
                 self.valid_locations[Types.Shop][Kongs.lanky] = allKongMoveLocations
                 self.valid_locations[Types.Shop][Kongs.tiny] = allKongMoveLocations
                 self.valid_locations[Types.Shop][Kongs.chunky] = allKongMoveLocations
-            self.valid_locations[Types.Shop][Kongs.any] = SharedShopLocations
+            self.valid_locations[Types.Shop][Kongs.any] = SharedShopLocations.copy()
             if self.shockwave_status not in ("vanilla", "start_with") and Types.Shockwave not in self.shuffled_location_types:
                 self.valid_locations[Types.Shop][Kongs.any].add(Locations.CameraAndShockwave)
             elif Locations.CameraAndShockwave in self.valid_locations[Types.Shop][Kongs.tiny]:
@@ -755,7 +755,7 @@ class Settings:
         else:
             valid_locations = self.valid_locations[item_obj.type]
         if self.progressives_locked_in_shops and item_obj in SharedShopLocations:
-            valid_locations = SharedShopLocations
+            valid_locations = SharedShopLocations.copy()
         return valid_locations
 
     def SelectKongLocations(self):

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -107,7 +107,8 @@ class Spoiler:
         settings["Crown Door Open"] = self.settings.crown_door_open
         settings["Coin Door Open"] = self.settings.coin_door_open
         settings["Shockwave Shuffle"] = self.settings.shockwave_status
-        settings["Random Medal Requirement"] = self.settings.random_medal_requirement
+        settings["Random Jetpac Medal Requirement"] = self.settings.random_medal_requirement
+        settings["Bananas Required for Medal"] = self.settings.medal_cb_req
         settings["Random Shop Prices"] = self.settings.random_prices
         settings["Banana Port Randomization"] = self.settings.bananaport_rando
         settings["Shuffle Shop Locations"] = self.settings.shuffle_shops
@@ -251,6 +252,9 @@ class Spoiler:
                         price = f"{self.settings.prices[Items.ProgressiveAmmoBelt][0]}->{self.settings.prices[Items.ProgressiveAmmoBelt][1]}"
                     elif location.item == Items.ProgressiveInstrumentUpgrade:
                         price = f"{self.settings.prices[Items.ProgressiveInstrumentUpgrade][0]}->{self.settings.prices[Items.ProgressiveInstrumentUpgrade][1]}->{self.settings.prices[Items.ProgressiveInstrumentUpgrade][2]}"
+                # Vanilla prices are by item, not by location
+                elif self.settings.random_prices == "vanilla":
+                    price = str(self.settings.prices[location.item])
                 else:
                     price = str(self.settings.prices[location_id])
                 humanspoiler["Items"]["Shops"][location.name] = item.name + f" ({price})"
@@ -566,6 +570,9 @@ class Spoiler:
                     price = 0
                     if id in self.settings.prices:
                         price = self.settings.prices[id]
+                    # Vanilla prices are by item, not by location
+                    if self.settings.random_prices == "vanilla":
+                        price = self.settings.prices[location.item]
                     # Moves that are set with a single flag (e.g. training barrels, shockwave) are handled differently
                     if move_type == MoveTypes.Flag:
                         for kong_index in kong_indices:

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -1,59 +1,143 @@
 """Temp file used for testing new logic system."""
 import json
 import random
-from copy import deepcopy
 
 import pytest
 
+import randomizer.Lists.Exceptions as Ex
 from randomizer.Fill import Generate_Spoiler
-from randomizer.Lists import Exceptions
 from randomizer.Settings import Settings
 from randomizer.Spoiler import Spoiler
 
 
 @pytest.fixture
+def generate_lo_rando_race_settings():
+    """Generate a data dictionary that mimics what the front end passes to the shuffler."""
+    # PLEASE NOTE: THIS LIST OF SETTINGS IS NOT COMPREHENSIVE - use the comments as quick references, not the entire story
+    # You may have to add new options as you add them or as they get added
+
+    data = {}
+    data["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
+
+    data["fast_start_beginning_of_game"] = True
+    data["enemy_rando"] = True
+    data["crown_enemy_rando"] = True
+    data["enemy_speed_rando"] = True
+    data["boss_kong_rando"] = True  # usually True
+    data["boss_location_rando"] = True  # usually True
+    data["random_medal_requirement"] = False
+    data["kasplat_rando_setting"] = "vanilla_locations"  # usually vanilla_locations but i like location_shuffle
+    data["kong_rando"] = True  # usually True - FORCED True if level_order shuffle
+
+    data["bananaport_rando"] = "off"  # usually "off", could be "in_level" "crossmap_coupled" "crossmap_decoupled"
+    data["activate_all_bananaports"] = "isles"  # usually isles, could be all or off
+
+    # item shuffler options here
+    data["move_rando"] = "on"  # usually "on" but i like "cross_purchase", rarely need to test with "start_with"
+    data["shuffle_items"] = False  # Must be true to trigger the list selector below
+    data["item_rando_list_selected"] = ["shop", "banana", "crown", "blueprint", "key", "medal"]  # no coins because i hate rareware coin logic
+
+    data["random_prices"] = "vanilla"  # usually "medium, might need free, rarely vanilla"
+    data["randomize_blocker_required_amounts"] = True  # usually True, if false set values below
+    data["blocker_0"] = 0
+    data["blocker_1"] = 0
+    data["blocker_2"] = 0
+    data["blocker_3"] = 0
+    data["blocker_4"] = 0
+    data["blocker_5"] = 0
+    data["blocker_6"] = 0
+    data["blocker_7"] = 50
+    data["blocker_text"] = 69  # usually 69
+    data["maximize_helm_blocker"] = True  # usually True
+
+    data["randomize_cb_required_amounts"] = True  # usually True, if false set values below
+    data["troff_0"] = 500
+    data["troff_1"] = 500
+    data["troff_2"] = 500
+    data["troff_3"] = 500
+    data["troff_4"] = 500
+    data["troff_5"] = 500
+    data["troff_6"] = 500
+    data["troff_text"] = 400  # usually 400?
+
+    data["level_randomization"] = "level_order"  # usually "level_order" may need to test with "loadingzone" or "loadingzonesdecoupled"
+
+    data["damage_amount"] = "default"
+    data["no_healing"] = False
+    data["no_melons"] = False
+    data["hard_shooting"] = False
+    data["hard_mad_jack"] = False
+    data["perma_death"] = False
+    data["crown_door_open"] = False  # usually True but False is better testing
+    data["coin_door_open"] = True
+    data["bonus_barrel_rando"] = True
+    data["gnawty_barrels"] = False
+    data["bonus_barrel_auto_complete"] = False  # usually False
+    data["open_lobbies"] = False
+    data["open_levels"] = False  # usually False
+    data["randomize_pickups"] = True
+
+    data["krool_phase_order_rando"] = True  # usually True
+    data["krool_random"] = False  # phase count is random setting
+    data["krool_phase_count"] = 3  # usually 3
+    data["helm_random"] = False  # room count is random setting
+    data["helm_phase_count"] = 3  # usually 3
+    data["krool_access"] = True  # usually True - this is the weirdly named key 8 required setting
+    data["keys_random"] = False  # key count is random setting
+    data["krool_key_count"] = 5  # usually 5
+    data["starting_random"] = False  # starting kong count is random setting
+    data["starting_kongs_count"] = 2  # usually 2
+
+    data["quality_of_life"] = True
+    data["enable_tag_anywhere"] = True
+    data["wrinkly_hints"] = "standard"
+    data["disable_shop_hints"] = False
+    data["warp_to_isles"] = True
+    data["helm_setting"] = "skip_start"
+    data["portal_numbers"] = True
+    data["shop_indicator"] = True
+    data["puzzle_rando"] = True
+    data["fast_gbs"] = True  # usually True
+    data["high_req"] = True  # usually True
+    data["random_patches"] = False  # usually False
+    data["shuffle_shops"] = False  # usually False
+
+    data["training_barrels"] = "shuffled"  # usually "normal", could be "shuffled"
+    data["shockwave_status"] = "shuffled_decoupled"  # usually "vanilla", could be "shuffled" or "shuffled_decoupled" or "start_with"
+    data["free_trade_setting"] = "none"  # none | not_blueprints | major_collectibles
+    data["crown_placement_rando"] = False  # usually false
+    data["hard_blockers"] = False  # likely to be False
+    data["hard_troff_n_scoff"] = False  # likely to be False
+    data["cb_rando"] = False  # likely to be False?
+    data["win_condition"] = "all_keys"
+    data["wrinkly_location_rando"] = True
+    data["tns_location_rando"] = True
+    data["key_8_helm"] = True  # likely to be False? unclear as of yet
+
+    data["hard_level_progression"] = False  # likely to be False
+
+    data["no_logic"] = False  # CURSED -------------- DO NOT DO LOGIC TESTING WITH THIS GUY HERE
+
+    return data
+
+
+@pytest.fixture
 def generate_settings():
+    """Asdf."""
     # Setting test settings
     data = json.load(open('static/presets/default.json'))
     data["seed"] = random.randint(0, 100000000)
     return data
 
 
-def test_forward(generate_settings):
-    generate_settings["algorithm"] = "forward"
-    settings = Settings(generate_settings)
+def test_forward_fill(generate_lo_rando_race_settings):
+    """Asdf."""
+    generate_lo_rando_race_settings["algorithm"] = "forward"
+    settings = Settings(generate_lo_rando_race_settings)
     spoiler = Spoiler(settings)
     Generate_Spoiler(spoiler)
-    spoiler.toJson()
-
-
-def test_shuffles(generate_settings):
-    generate_settings["algorithm"] = "forward"
-    settings = Settings(generate_settings)
-    duped = deepcopy(settings)
-    duped.training_barrels = True
-    duped.unlock_all_moves = True
-    duped.starting_kongs_count = 5
-    duped.unlock_fairy_shockwave = True
-    duped.shuffle_items = "moves"
-    duped.shuffle_loading_zones = "all"
-    duped.decoupled_loading_zones = True
-    spoiler = Spoiler(duped)
-    # TODO: We know this exception is a bit overkill, and will be replaced in the future, we are expecting failures
-    try:
-        Generate_Spoiler(spoiler)
-        spoiler.toJson()
-    except Exception:
-        pass
-
-
-def test_assumed(generate_settings):
-    generate_settings["algorithm"] = "assumed"
-    settings = Settings(generate_settings)
-    spoiler = Spoiler(settings)
-    # TODO: We know this exception is a bit overkill, and will be replaced in the future, we are expecting failures
-    try:
-        Generate_Spoiler(spoiler)
-        spoiler.toJson()
-    except Exception:
-        pass
+    print(spoiler)
+    print(spoiler.json)
+    asdf = 1 / 0
+    print(asdf)
+    raise Exception


### PR DESCRIPTION
- Vanilla prices are fixed
- A couple issues with non-item rando hints are fixed including bad WotH errors and shop dumps not working. The latter was fixed by axing the old hint category and just using the new shop dump hints
- An issue with duplicate code messing up kong calculations for the complex shuffler that made me question how it ever worked recently at all

BIG ADDITION is the debug file update that should make it a lot easier to debug settings