### PR TITLE
reworked foolish hints to match definitions

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -997,7 +997,7 @@ def compileHints(spoiler: Spoiler):
             location = LocationList[location_id]
             # Only hint things that are in shuffled locations - don't hint training barrels because you can't know which move it refers to and don't hint the Helm Key if you know key 8 is there
             if location.type in spoiler.settings.shuffled_location_types and location.type != Types.TrainingBarrel and not (spoiler.settings.key_8_helm and location_id == Locations.HelmKey):
-                hintable_locations.append(location)###############helm key still here madge
+                hintable_locations.append(location)
         random.shuffle(hintable_locations)
         for i in range(hint_distribution[HintType.WothLocation]):
             # If you run out of hintable woth locations, just pile on joke hints - this *should* be covered by the distribution earlier but this is a good failsafe

--- a/randomizer/Enums/Events.py
+++ b/randomizer/Enums/Events.py
@@ -98,6 +98,7 @@ class Events(IntEnum):
     KRoolLanky = auto()
     KRoolTiny = auto()
     KRoolChunky = auto()
+    KRoolDefeated = auto()
 
     # Level entered events for shops
     JapesEntered = auto()

--- a/randomizer/Enums/Regions.py
+++ b/randomizer/Enums/Regions.py
@@ -5,6 +5,9 @@ from enum import IntEnum, auto
 class Regions(IntEnum):
     """Region enum."""
 
+    # Special region housing the Banana Hoard
+    Credits = auto()
+
     # DK Isles Regions
     Treehouse = auto()
     TrainingGrounds = auto()

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -25,7 +25,6 @@ from randomizer.Enums.Warps import Warps
 from randomizer.Lists.Item import ItemList, KongFromItem
 from randomizer.Lists.Location import (
     LocationList,
-    SharedShopLocations,
     TrainingBarrelLocations,
     DonkeyMoveLocations,
     DiddyMoveLocations,
@@ -38,7 +37,8 @@ from randomizer.Lists.MapsAndExits import Maps
 from randomizer.Lists.Minigame import BarrelMetaData, MinigameRequirements
 from randomizer.Lists.ShufflableExit import GetLevelShuffledToIndex, GetShuffledLevelIndex
 from randomizer.Lists.Warps import BananaportVanilla
-from randomizer.Logic import STARTING_SLAM, LogicVarHolder, LogicVariables
+from randomizer.Logic import LogicVarHolder, LogicVariables
+from randomizer.Logic import Regions as RegionList
 from randomizer.LogicClasses import Sphere, TransitionFront
 from randomizer.Prices import GetMaxForKong
 from randomizer.Settings import Settings
@@ -109,7 +109,7 @@ def GetAccessibleLocations(settings, ownedItems, searchType=SearchMode.GetReacha
                 # If we want to generate the playthrough and the item is a playthrough item, add it to the sphere
                 if searchType == SearchMode.GeneratePlaythrough and ItemList[location.item].playthrough:
                     # Banana hoard in a sphere by itself
-                    if settings.win_condition == "beat_krool" and location.item == Items.BananaHoard:
+                    if location.item == Items.BananaHoard:
                         sphere.locations = [locationId]
                         break
                     if location.item == Items.GoldenBanana:
@@ -126,11 +126,11 @@ def GetAccessibleLocations(settings, ownedItems, searchType=SearchMode.GetReacha
         newItems = []
         if len(sphere.locations) > 0:
             if searchType == SearchMode.GeneratePlaythrough:
-                sphere.seedBeaten = LogicVariables.WinConditionMet()
+                sphere.seedBeaten = LogicVariables.bananaHoard
             playthroughLocations.append(sphere)
 
-        # If we're checking beatability, check the win condition after updating the last set of locations
-        if searchType == SearchMode.CheckBeatable and LogicVariables.WinConditionMet():
+        # If we're checking beatability, check for the Banana Hoard after updating the last set of locations
+        if searchType == SearchMode.CheckBeatable and LogicVariables.bananaHoard:
             return True
 
         # Do a search for each owned kong
@@ -324,8 +324,8 @@ def VerifyWorldWithWorstCoinUsage(settings):
             # print("Seed is valid, found enough coins with worst purchase order: " + str([LocationList[x].name + ": " + LocationList[x].item.name + ", " for x in locationsToPurchase]))
             Reset()
             return True
-        # If we meet the win condition, world is valid!
-        if LogicVariables.WinConditionMet():
+        # If we found the Banana Hoard, world is valid!
+        if LogicVariables.bananaHoard:
             # print("Seed is valid, found banana hoard with worst purchase order: " + str([LocationList[x].name + ": " + LocationList[x].item.name + ", " for x in locationsToPurchase]))
             Reset()
             return True
@@ -465,6 +465,7 @@ def PareWoth(spoiler, PlaythroughLocations):
             if not LocationList[loc].constant and ItemList[LocationList[loc].item].type not in (Types.Banana, Types.BlueprintBanana, Types.Crown, Types.Medal, Types.Blueprint)
         ]:
             WothLocations.append(loc)
+    WothLocations.append(Locations.BananaHoard)  # The Banana Hoard is the endpoint of the Way of the Hoard
     # Check every item location to see if removing it by itself makes the game unbeatable
     for i in range(len(WothLocations) - 1, -1, -1):
         locationId = WothLocations[i]
@@ -480,14 +481,13 @@ def PareWoth(spoiler, PlaythroughLocations):
         location.PlaceItem(item)
 
     CalculateWothPaths(spoiler, WothLocations)
+    CalculateFoolish(spoiler, WothLocations)
     return WothLocations
 
 
 def CalculateWothPaths(spoiler, WothLocations):
     """Calculate the Paths (dependencies) for each Way of the Hoard item."""
-    # Do not include bonus barrel logic in path hints
-    temp_helm_barrels_setting = spoiler.settings.helm_barrels
-    spoiler.settings.helm_barrels = "skip"
+    falseWothLocations = []
     # Prep the dictionary that will contain the path for the key item
     for locationId in WothLocations:
         spoiler.woth_paths[locationId] = [locationId]  # The endpoint is on its own path
@@ -500,6 +500,8 @@ def CalculateWothPaths(spoiler, WothLocations):
         # We assume Keys and Kongs because anything locked behind a them will then require everything that Key or Kong requires.
         # This sort of defeats the purpose of paths, as it would put everything in a Key or Kong's path into the path of many, many items.
         assumedItems = ItemPool.Keys() + ItemPool.Kongs(spoiler.settings)
+        # Vines and Swim invariably end up on long paths to many, many items because they can block whole levels, so we'll also assume these to shorten paths
+        assumedItems.extend([Items.Vines, Items.Swim])
         # Find all accessible locations without this item placed
         Reset()
         # At this point we know there is no breaking purchase order
@@ -507,14 +509,80 @@ def CalculateWothPaths(spoiler, WothLocations):
         # So give the logic infinite coins so it can purchase anything it needs
         LogicVariables.GainInfiniteCoins()
         accessible = GetAccessibleLocations(spoiler.settings, assumedItems, SearchMode.GetReachable)
+        isOnAnotherPath = False
         # Then check every other WotH location for accessibility
         for other_location in WothLocations:
             # If it is no longer accessible, then this location is on the path of that other location
             if other_location not in accessible:
                 spoiler.woth_paths[other_location].append(locationId)
+                isOnAnotherPath = True
         # Put the item back for future calculations
         location.PlaceItem(item_id)
-    spoiler.settings.helm_barrels = temp_helm_barrels_setting  # Reset the temporary change to this setting
+        # If this item doesn't show up on any other paths, it's not actually WotH
+        # This is rare, but could happen if the item at the location is needed for coins - it isn't *really* required
+        if item_id not in assumedItems and item_id != Items.BananaHoard and not isOnAnotherPath:
+            falseWothLocations.append(locationId)
+    # After everything is calculated, get rid of paths for false WotH locations
+    for locationId in falseWothLocations:
+        WothLocations.remove(locationId)
+        del spoiler.woth_paths[locationId]
+
+
+def CalculateFoolish(spoiler, WothLocations):
+    """Calculate the items and regions that are foolish (blocking no major items)"""
+    wothItems = [LocationList[loc].item for loc in WothLocations]
+    # First we need to determine what Major Items are foolish
+    foolishItems = []
+    # Determine which of our major items we need to check
+    majorItems = ItemPool.AllKongMoves()
+    if spoiler.settings.training_barrels != "normal":
+        # I don't trust oranges quite yet - you can put an item in Diddy's upper cabin and it might think oranges is foolish still
+        majorItems.extend([Items.Vines, Items.Swim, Items.Barrels])
+    if spoiler.settings.shockwave_status == "shuffled":
+        majorItems.append(Items.CameraAndShockwave)
+    if spoiler.settings.shockwave_status == "shuffled_decoupled":
+        majorItems.append(Items.Camera)
+        majorItems.append(Items.Shockwave)
+    for item in majorItems:
+        # If this item is in the WotH, it can't possibly be foolish so we can skip it
+        if item in wothItems:
+            continue
+        # Check the item to see if it locks *any* progression (even non-critical)
+        Reset()
+        LogicVariables.BanItem(item)  # Ban this item from being picked up
+        GetAccessibleLocations(spoiler.settings, [], SearchMode.GetReachable)  # Check what's reachable
+        if LogicVariables.HasAllItems():  # If you still have all the items, this one blocks no progression and is foolish
+            foolishItems.append(item)
+    spoiler.foolish_moves = foolishItems
+
+    # Use the settings to determine non-progression Major Items
+    majorItems = [item for item in majorItems if item not in foolishItems]
+    majorItems.extend(ItemPool.Keys())
+    majorItems.append(Items.Oranges)  # Again, not comfortable foolishing oranges yet
+    if Types.Coin in spoiler.settings.shuffled_location_types and spoiler.settings.coin_door_open in ["need_both", "need_rw"]:
+        majorItems.append(Items.RarewareCoin)
+    if Types.Coin in spoiler.settings.shuffled_location_types and spoiler.settings.coin_door_open in ["need_both", "need_nin"]:
+        majorItems.append(Items.NintendoCoin)
+    if Types.Blueprint in spoiler.settings.shuffled_location_types and spoiler.settings.win_condition == "all_blueprints":
+        majorItems.extend(ItemPool.Blueprints(spoiler.settings))
+    if Types.Medal in spoiler.settings.shuffled_location_types and spoiler.settings.win_condition == "all_medals":
+        majorItems.append(Items.BananaMedal)
+    if Types.Crown in spoiler.settings.shuffled_location_types and not spoiler.settings.crown_door_open:
+        majorItems.append(Items.BattleCrown)
+    # ***if fairy locations are shuffled*** and there's a major item on Rareware GB or fairies are the win con
+    # then we'd majorItems.append(Items.BananaFairy)
+
+    nonHintableNames = { "K. Rool Arena", "Snide", "Candy Generic", "Funky Generic", "Credits" }  # These regions never have anything useful so shouldn't be hinted
+    if Types.Coin not in spoiler.settings.shuffled_location_types:
+        nonHintableNames.add("Jetpac Game")  # If this is vanilla, it's never useful to hint
+    # In order for a region to be foolish, it can contain none of these Major Items
+    for id, region in RegionList.items():
+        locations = [loc for loc in region.locations if loc.id in LocationList.keys()]
+        # If this region DOES contain a major item, add it the name to the set of non-hintable hint regions
+        if any([loc for loc in locations if LocationList[loc.id].item in majorItems]):
+            nonHintableNames.add(region.hint_name)
+    # The regions that are foolish are all regions not in this list (that have locations in them!)
+    spoiler.foolish_region_names = list(set([region.hint_name for id, region in RegionList.items() if any(region.locations) and region.hint_name not in nonHintableNames]))
 
 
 def RandomFill(settings, itemsToPlace, inOrder=False):
@@ -1021,11 +1089,11 @@ def FillKongsAndMovesGeneric(spoiler):
             retries += 1
             if retries % 5 == 0:
                 js.postMessage("Retrying fill really hard. Tries: " + str(retries))
-                # Handle Loading Zones
-                if spoiler.settings.shuffle_loading_zones != "none":
-                    ShuffleExits.Reset()
-                    ShuffleExits.ExitShuffle(spoiler.settings)
-                    spoiler.UpdateExits()
+                # Handle Loading Zones - does not work right now but is something I want here eventually
+                # if spoiler.settings.shuffle_loading_zones != "none":
+                #     ShuffleExits.Reset()
+                #     ShuffleExits.ExitShuffle(spoiler.settings)
+                #     spoiler.UpdateExits()
                 spoiler.settings.shuffle_prices()
             else:
                 js.postMessage("Retrying fill. Tries: " + str(retries))

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -529,7 +529,7 @@ def CalculateWothPaths(spoiler, WothLocations):
 
 
 def CalculateFoolish(spoiler, WothLocations):
-    """Calculate the items and regions that are foolish (blocking no major items)"""
+    """Calculate the items and regions that are foolish (blocking no major items)."""
     wothItems = [LocationList[loc].item for loc in WothLocations]
     # First we need to determine what Major Items are foolish
     foolishItems = []
@@ -572,7 +572,7 @@ def CalculateFoolish(spoiler, WothLocations):
     # ***if fairy locations are shuffled*** and there's a major item on Rareware GB or fairies are the win con
     # then we'd majorItems.append(Items.BananaFairy)
 
-    nonHintableNames = { "K. Rool Arena", "Snide", "Candy Generic", "Funky Generic", "Credits" }  # These regions never have anything useful so shouldn't be hinted
+    nonHintableNames = {"K. Rool Arena", "Snide", "Candy Generic", "Funky Generic", "Credits"}  # These regions never have anything useful so shouldn't be hinted
     if Types.Coin not in spoiler.settings.shuffled_location_types:
         nonHintableNames.add("Jetpac Game")  # If this is vanilla, it's never useful to hint
     # In order for a region to be foolish, it can contain none of these Major Items

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -628,10 +628,45 @@ class LogicVarHolder:
         if not self.WinConditionMet():
             return False
         # Otherwise return true if you have all major moves
-        return (self.donkey and self.diddy and self.lanky and self.tiny and self.chunky and self.vines and self.swim and self.barrels and self.oranges and self.blast and self.strongKong and self.grab
-            and self.charge and self.jetpack and self.spring and self.handstand and self.balloon and self.sprint and self.mini and self.twirl and self.monkeyport and self.hunkyChunky and self.punch and self.gorillaGone
-            and self.superDuperSlam and self.coconut and self.peanut and self.grape and self.feather and self.pineapple and self.homing and self.scope and self.shockwave
-            and self.bongos and self.guitar and self.trombone and self.saxophone and self.triangle
+        return (
+            self.donkey
+            and self.diddy
+            and self.lanky
+            and self.tiny
+            and self.chunky
+            and self.vines
+            and self.swim
+            and self.barrels
+            and self.oranges
+            and self.blast
+            and self.strongKong
+            and self.grab
+            and self.charge
+            and self.jetpack
+            and self.spring
+            and self.handstand
+            and self.balloon
+            and self.sprint
+            and self.mini
+            and self.twirl
+            and self.monkeyport
+            and self.hunkyChunky
+            and self.punch
+            and self.gorillaGone
+            and self.superDuperSlam
+            and self.coconut
+            and self.peanut
+            and self.grape
+            and self.feather
+            and self.pineapple
+            and self.homing
+            and self.scope
+            and self.shockwave
+            and self.bongos
+            and self.guitar
+            and self.trombone
+            and self.saxophone
+            and self.triangle
         )
 
 

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -14,7 +14,7 @@ LogicRegions = {
     Regions.Credits: Region("Credits", "Credits", Levels.DKIsles, False, None, [
         LocationLogic(Locations.BananaHoard, lambda l: l.WinConditionMet())
     ], [], []),
-    
+
     Regions.Treehouse: Region("Treehouse", "Training Grounds", Levels.DKIsles, False, None, [], [], [
         TransitionFront(Regions.TrainingGrounds, lambda l: True, Transitions.IslesTreehouseToStart)
     ]),
@@ -191,7 +191,6 @@ LogicRegions = {
         Event(Events.KRoolLanky, lambda l: not l.settings.krool_lanky or (l.trombone and l.lanky)),
         Event(Events.KRoolTiny, lambda l: not l.settings.krool_tiny or (l.mini and l.feather and l.tiny)),
         Event(Events.KRoolChunky, lambda l: not l.settings.krool_chunky or (l.superSlam and l.gorillaGone and l.hunkyChunky and l.punch and l.chunky)),
-        Event(Events.KRoolDefeated, lambda l: Events.KRoolDonkey in l.Events and Events.KRoolDiddy in l.Events
-                      and Events.KRoolLanky in l.Events and Events.KRoolTiny in l.Events and Events.KRoolChunky in l.Events)
+        Event(Events.KRoolDefeated, lambda l: Events.KRoolDonkey in l.Events and Events.KRoolDiddy in l.Events and Events.KRoolLanky in l.Events and Events.KRoolTiny in l.Events and Events.KRoolChunky in l.Events)
     ], []),
 }

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -11,6 +11,10 @@ from randomizer.LogicClasses import (Event, LocationLogic, Region,
                                      TransitionFront)
 
 LogicRegions = {
+    Regions.Credits: Region("Credits", "Credits", Levels.DKIsles, False, None, [
+        LocationLogic(Locations.BananaHoard, lambda l: l.WinConditionMet())
+    ], [], []),
+    
     Regions.Treehouse: Region("Treehouse", "Training Grounds", Levels.DKIsles, False, None, [], [], [
         TransitionFront(Regions.TrainingGrounds, lambda l: True, Transitions.IslesTreehouseToStart)
     ]),
@@ -40,6 +44,7 @@ LogicRegions = {
     ], [
         Event(Events.IslesChunkyBarrelSpawn, lambda l: l.monkeyport and l.saxophone and l.tiny),
     ], [
+        TransitionFront(Regions.Credits, lambda l: True),
         TransitionFront(Regions.TrainingGrounds, lambda l: True, Transitions.IslesMainToStart),
         TransitionFront(Regions.Prison, lambda l: True),
         TransitionFront(Regions.BananaFairyRoom, lambda l: l.mini and l.istiny, Transitions.IslesMainToFairy),
@@ -132,6 +137,8 @@ LogicRegions = {
         LocationLogic(Locations.IslesTinyGalleonLobby, lambda l: l.chunky and l.superSlam and l.mini and l.twirl and l.swim and l.tiny),
         LocationLogic(Locations.IslesKasplatGalleonLobby, lambda l: not l.settings.kasplat_rando),
     ], [], [
+        # There exists a hellscape in the far flung future where you are trapped in Galleon and Galleon lobby because you cannot swim but your seed is beatable
+        TransitionFront(Regions.Credits, lambda l: True),  # For that reason, this lobby also gets access to the credits region
         TransitionFront(Regions.IslesMain, lambda l: l.swim, Transitions.IslesGalleonLobbyToMain),
         TransitionFront(Regions.GloomyGalleonStart, lambda l: l.IsLevelEnterable(Levels.GloomyGalleon), Transitions.IslesToGalleon),
     ]),
@@ -178,14 +185,13 @@ LogicRegions = {
         TransitionFront(Regions.HideoutHelmStart, lambda l: l.gorillaGone and l.chunky and l.IsLevelEnterable(Levels.HideoutHelm)),
     ]),
 
-    Regions.KRool: Region("K. Rool", "K. Rool Arena", Levels.DKIsles, True, None, [
-        LocationLogic(Locations.BananaHoard, lambda l: Events.KRoolDonkey in l.Events and Events.KRoolDiddy in l.Events
-                      and Events.KRoolLanky in l.Events and Events.KRoolTiny in l.Events and Events.KRoolChunky in l.Events),
-    ], [
+    Regions.KRool: Region("K. Rool", "K. Rool Arena", Levels.DKIsles, True, None, [], [
         Event(Events.KRoolDonkey, lambda l: not l.settings.krool_donkey or l.donkey),
         Event(Events.KRoolDiddy, lambda l: not l.settings.krool_diddy or (l.jetpack and l.peanut and l.diddy)),
         Event(Events.KRoolLanky, lambda l: not l.settings.krool_lanky or (l.trombone and l.lanky)),
         Event(Events.KRoolTiny, lambda l: not l.settings.krool_tiny or (l.mini and l.feather and l.tiny)),
-        Event(Events.KRoolChunky, lambda l: not l.settings.krool_chunky or (l.superSlam and l.gorillaGone and l.hunkyChunky and l.punch and l.chunky))
+        Event(Events.KRoolChunky, lambda l: not l.settings.krool_chunky or (l.superSlam and l.gorillaGone and l.hunkyChunky and l.punch and l.chunky)),
+        Event(Events.KRoolDefeated, lambda l: Events.KRoolDonkey in l.Events and Events.KRoolDiddy in l.Events
+                      and Events.KRoolLanky in l.Events and Events.KRoolTiny in l.Events and Events.KRoolChunky in l.Events)
     ], []),
 }

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -73,7 +73,7 @@ def generate_lo_rando_race_settings():
     data["hard_mad_jack"] = False
     data["perma_death"] = False
     data["crown_door_open"] = False  # usually True but False is better testing
-    data["coin_door_open"] = True
+    data["coin_door_open"] = "need_zero"  # usually need_zero, could be need_rw | need_nin | need_both
     data["bonus_barrel_rando"] = True
     data["gnawty_barrels"] = False
     data["bonus_barrel_auto_complete"] = False  # usually False
@@ -88,7 +88,7 @@ def generate_lo_rando_race_settings():
     data["helm_phase_count"] = 3  # usually 3
     data["krool_access"] = True  # usually True - this is the weirdly named key 8 required setting
     data["keys_random"] = False  # key count is random setting
-    data["krool_key_count"] = 8  # usually 5
+    data["krool_key_count"] = 6  # usually 5
     data["starting_random"] = False  # starting kong count is random setting
     data["starting_kongs_count"] = 2  # usually 2
 


### PR DESCRIPTION
Fixed foolish hints:
- Foolish moves are now moves that do not lock any other moves (even if they are foolish)
- Foolish region hints are now correct and point at regions with no major items (they can contain foolish moves)

Fixed WotH hints:
- If key 8 is locked in helm, that location cannot be hinted

Fixed Path hints:
- Removed moves from WotH that are only needed for coins
- A consequence of the above change is that **moves required for minigames are now in the path**
- You can now see a WotH for the Banana Hoard (your win condition)

Rework of win condition logic:
- New "Credits" region that houses the Banana Hoard. Meeting your win condition will give you access to this location