### PR TITLE
Priority Place Refactor

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -365,7 +365,7 @@ def compileHints(spoiler: Spoiler):
         hint_distribution[HintType.BLocker] = max(1, hint_distribution[HintType.TroffNScoff])  # Always want a helm hint in there
         hint_distribution[HintType.TroffNScoff] = temp
         valid_types.append(HintType.Entrance)
-    if Types.Key in spoiler.settings.shuffled_location_types:
+    if spoiler.settings.shuffle_items and Types.Key in spoiler.settings.shuffled_location_types:
         valid_types.append(HintType.RequiredKeyHint)
         # Only hint keys that are in the Way of the Hoard
         woth_key_ids = [LocationList[woth_loc].item for woth_loc in spoiler.woth_locations if ItemList[LocationList[woth_loc].item].type == Types.Key]
@@ -612,6 +612,9 @@ def compileHints(spoiler: Spoiler):
         for key_id in late_keys_required:
             path = spoiler.woth_paths[key_location_ids[key_id]]
             key_item = ItemList[key_id]
+            # Don't put a path hint for Helm Key when you know it's there
+            if key_id == Items.HideoutHelmKey and spoiler.settings.key_8_helm:
+                path = [loc for loc in path if loc != Locations.HelmKey]
             for i in range(2):
                 path_location_id = random.choice(path)
                 region = GetRegionOfLocation(path_location_id)
@@ -665,7 +668,6 @@ def compileHints(spoiler: Spoiler):
                     message = f"Your training with {hinted_item_name} is on the path to aiding your fight against K. Rool."
                 else:
                     message = f"An item in the {region.hint_name} is on the path to aiding your fight against K. Rool."
-
                 hint_location = getRandomHintLocation()
                 hint_location.hint_type = HintType.RequiredWinConditionHint
                 UpdateHint(hint_location, message)

--- a/randomizer/Enums/Regions.py
+++ b/randomizer/Enums/Regions.py
@@ -5,8 +5,9 @@ from enum import IntEnum, auto
 class Regions(IntEnum):
     """Region enum."""
 
-    # Special region housing the Banana Hoard
-    Credits = auto()
+    # Special regions
+    GameStart = auto()  # This holds your training barrels for fast start and sends you off to your starting region
+    Credits = auto()  # This holds the Banana Hoard
 
     # DK Isles Regions
     Treehouse = auto()

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -160,7 +160,6 @@ def AllMovesForOwnedKongs(kongs):
     if KongObject.Kongs.chunky in kongs:
         kongMoves.extend(ChunkyMoves)
     kongMoves.extend(ImportantSharedMoves)
-    kongMoves.extend(JunkSharedMoves)
     return kongMoves
 
 

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -579,6 +579,17 @@ class LogicVarHolder:
 
     def IsLevelEnterable(self, level):
         """Check if level entry requirement is met."""
+        # Later levels can have some special requirements
+        if level >= 3:
+            level_order_matters = not self.settings.hard_level_progression and self.settings.shuffle_loading_zones in ("none", "levels")
+            # If level order matters...
+            if level_order_matters:
+                # Require barrels by level 3 to prevent boss barrel fill failures
+                if not self.barrels:
+                    return False
+                # Require one of twirl or hunky chunky by level 7 to prevent non-hard-boss fill failures
+                if not self.settings.hard_bosses and level >= 7 and not (self.twirl or self.hunkyChunky):
+                    return False
         return self.HasEnoughKongs(level, forPreviousLevel=True) and self.GoldenBananas >= self.settings.EntryGBs[level]
 
     def WinConditionMet(self):
@@ -611,7 +622,7 @@ class LogicVarHolder:
         """Check if you meet the logical requirements to obtain the Rareware Coin."""
         have_enough_medals = self.BananaMedals >= self.settings.medal_requirement
         # Make sure you have access to enough levels to fit the locations in. This isn't super precise and doesn't need to be.
-        required_level = min(ceil(self.settings.medal_requirement / 5), 6)
+        required_level = min(ceil(self.settings.medal_requirement / 4), 6)
         return have_enough_medals and self.IsLevelEnterable(required_level)
 
     def BanItem(self, item):

--- a/randomizer/LogicFiles/CreepyCastle.py
+++ b/randomizer/LogicFiles/CreepyCastle.py
@@ -20,7 +20,7 @@ LogicRegions = {
         LocationLogic(Locations.CastleChunkyMedal, lambda l: l.ColoredBananas[Levels.CreepyCastle][Kongs.chunky] >= l.settings.medal_cb_req),
     ], [], []),
 
-    Regions.CreepyCastleMain: Region("Creepy Castle Main", "Castle Exterior", Levels.CreepyCastle, True, None, [
+    Regions.CreepyCastleMain: Region("Creepy Castle Main", "Castle Surroundings", Levels.CreepyCastle, True, None, [
         LocationLogic(Locations.CastleDiddyAboveCastle, lambda l: l.jetpack and l.isdiddy, MinigameType.BonusBarrel),
         LocationLogic(Locations.CastleKasplatHalfway, lambda l: not l.settings.kasplat_rando),
         LocationLogic(Locations.CastleKasplatLowerLedge, lambda l: not l.settings.kasplat_rando),
@@ -48,7 +48,7 @@ LogicRegions = {
         TransitionFront(Regions.CastleBaboonBlast, lambda l: l.blast and l.isdonkey)  # , Transitions.CastleMainToBBlast)
     ]),
 
-    Regions.CastleBaboonBlast: Region("Castle Baboon Blast", "Castle Exterior", Levels.CreepyCastle, False, None, [], [
+    Regions.CastleBaboonBlast: Region("Castle Baboon Blast", "Castle Surroundings", Levels.CreepyCastle, False, None, [], [
         Event(Events.CastleTreeOpened, lambda l: l.isdonkey)
     ], [
         TransitionFront(Regions.CreepyCastleMedals, lambda l: True),
@@ -56,13 +56,13 @@ LogicRegions = {
     ]),
 
     # This region just exists to facilitate the multiple exits from the upper cave
-    Regions.CastleWaterfall: Region("Castle Waterfall", "Castle Exterior", Levels.CreepyCastle, False, None, [], [], [
+    Regions.CastleWaterfall: Region("Castle Waterfall", "Castle Surroundings", Levels.CreepyCastle, False, None, [], [], [
         TransitionFront(Regions.CreepyCastleMedals, lambda l: True),
         TransitionFront(Regions.CreepyCastleMain, lambda l: True),
         TransitionFront(Regions.UpperCave, lambda l: True, Transitions.CastleWaterfallToUpper),
     ]),
 
-    Regions.CastleTree: Region("Castle Tree", "Castle Exterior", Levels.CreepyCastle, False, -1, [
+    Regions.CastleTree: Region("Castle Tree", "Castle Surroundings", Levels.CreepyCastle, False, -1, [
         LocationLogic(Locations.CastleDonkeyTree, lambda l: l.scope and l.coconut and l.isdonkey),
         LocationLogic(Locations.CastleChunkyTree, lambda l: (l.scope or l.settings.hard_shooting) and l.pineapple and l.punch and l.ischunky, MinigameType.BonusBarrel),
         LocationLogic(Locations.CastleKasplatTree, lambda l: not l.settings.kasplat_rando and l.coconut and l.isdonkey),
@@ -74,7 +74,7 @@ LogicRegions = {
         TransitionFront(Regions.CreepyCastleMain, lambda l: l.coconut and l.isdonkey and l.swim, Transitions.CastleTreeDrainToMain),
     ]),
 
-    Regions.Library: Region("Library", "Castle Interior", Levels.CreepyCastle, False, -1, [
+    Regions.Library: Region("Library", "Castle Rooms", Levels.CreepyCastle, False, -1, [
         LocationLogic(Locations.CastleDonkeyLibrary, lambda l: l.superDuperSlam and l.isdonkey and l.strongKong),
     ], [], [
         TransitionFront(Regions.CreepyCastleMedals, lambda l: True),
@@ -82,7 +82,7 @@ LogicRegions = {
         TransitionFront(Regions.CreepyCastleMain, lambda l: l.superDuperSlam and l.isdonkey and l.strongKong, Transitions.CastleLibraryEndToMain),
     ]),
 
-    Regions.Ballroom: Region("Ballroom", "Castle Interior", Levels.CreepyCastle, False, -1, [
+    Regions.Ballroom: Region("Ballroom", "Castle Rooms", Levels.CreepyCastle, False, -1, [
         LocationLogic(Locations.CastleDiddyBallroom, lambda l: l.jetpack and l.isdiddy, MinigameType.BonusBarrel),
     ], [], [
         TransitionFront(Regions.CreepyCastleMedals, lambda l: True),
@@ -90,7 +90,7 @@ LogicRegions = {
         TransitionFront(Regions.MuseumBehindGlass, lambda l: l.monkeyport and l.mini and l.istiny, Transitions.CastleBallroomToMuseum),
     ]),
 
-    Regions.MuseumBehindGlass: Region("Museum Behind Glass", "Castle Interior", Levels.CreepyCastle, False, -1, [
+    Regions.MuseumBehindGlass: Region("Museum Behind Glass", "Castle Rooms", Levels.CreepyCastle, False, -1, [
         LocationLogic(Locations.CastleBananaFairyBallroom, lambda l: l.camera),
     ], [], [
         TransitionFront(Regions.CreepyCastleMedals, lambda l: True),
@@ -98,7 +98,7 @@ LogicRegions = {
         TransitionFront(Regions.CastleTinyRace, lambda l: l.mini and l.istiny, Transitions.CastleMuseumToCarRace),
     ]),
 
-    Regions.CastleTinyRace: Region("Castle Tiny Race", "Castle Interior", Levels.CreepyCastle, False, None, [
+    Regions.CastleTinyRace: Region("Castle Tiny Race", "Castle Rooms", Levels.CreepyCastle, False, None, [
         LocationLogic(Locations.CastleTinyCarRace, lambda l: l.istiny or l.settings.free_trade_items),
     ], [], [
         TransitionFront(Regions.CreepyCastleMedals, lambda l: True),
@@ -106,14 +106,14 @@ LogicRegions = {
     ], Transitions.CastleMuseumToCarRace
     ),
 
-    Regions.Tower: Region("Tower", "Castle Interior", Levels.CreepyCastle, False, -1, [
+    Regions.Tower: Region("Tower", "Castle Rooms", Levels.CreepyCastle, False, -1, [
         LocationLogic(Locations.CastleLankyTower, lambda l: (l.scope or l.homing) and l.balloon and l.grape and l.islanky, MinigameType.BonusBarrel),
     ], [], [
         TransitionFront(Regions.CreepyCastleMedals, lambda l: True),
         TransitionFront(Regions.CreepyCastleMain, lambda l: True, Transitions.CastleTowerToMain),
     ]),
 
-    Regions.Greenhouse: Region("Greenhouse", "Castle Exterior", Levels.CreepyCastle, False, -1, [
+    Regions.Greenhouse: Region("Greenhouse", "Castle Surroundings", Levels.CreepyCastle, False, -1, [
         # Sprint is not actually required
         LocationLogic(Locations.CastleLankyGreenhouse, lambda l: l.islanky or l.settings.free_trade_items),
         LocationLogic(Locations.CastleBattleArena, lambda l: not l.settings.crown_placement_rando and (l.islanky or l.settings.free_trade_items)),
@@ -123,21 +123,21 @@ LogicRegions = {
         TransitionFront(Regions.CreepyCastleMain, lambda l: l.islanky or l.settings.free_trade_items, Transitions.CastleGreenhouseEndToMain),
     ]),
 
-    Regions.TrashCan: Region("Trash Can", "Castle Exterior", Levels.CreepyCastle, False, -1, [
+    Regions.TrashCan: Region("Trash Can", "Castle Surroundings", Levels.CreepyCastle, False, -1, [
         LocationLogic(Locations.CastleTinyTrashCan, lambda l: (l.istiny and (l.saxophone or (l.feather and (l.homing or l.settings.hard_shooting)))) or (l.settings.free_trade_items and (l.HasInstrument(Kongs.any) or (l.HasGun(Kongs.any) and (l.homing or l.settings.hard_shooting))))),
     ], [], [
         TransitionFront(Regions.CreepyCastleMedals, lambda l: True),
         TransitionFront(Regions.CreepyCastleMain, lambda l: True, Transitions.CastleTrashToMain),
     ]),
 
-    Regions.Shed: Region("Shed", "Castle Exterior", Levels.CreepyCastle, False, None, [
+    Regions.Shed: Region("Shed", "Castle Surroundings", Levels.CreepyCastle, False, None, [
         LocationLogic(Locations.CastleChunkyShed, lambda l: l.punch and ((l.gorillaGone and l.pineapple) or l.triangle) and l.ischunky),
     ], [], [
         TransitionFront(Regions.CreepyCastleMedals, lambda l: True),
         TransitionFront(Regions.CreepyCastleMain, lambda l: True, Transitions.CastleShedToMain),
     ]),
 
-    Regions.Museum: Region("Museum", "Castle Interior", Levels.CreepyCastle, False, -1, [
+    Regions.Museum: Region("Museum", "Castle Rooms", Levels.CreepyCastle, False, -1, [
         LocationLogic(Locations.CastleChunkyMuseum, lambda l: l.punch and l.ischunky and l.barrels),
     ], [], [
         TransitionFront(Regions.CreepyCastleMedals, lambda l: True),

--- a/randomizer/LogicFiles/CrystalCaves.py
+++ b/randomizer/LogicFiles/CrystalCaves.py
@@ -22,7 +22,6 @@ LogicRegions = {
 
     Regions.CrystalCavesMain: Region("Crystal Caves Main", "Main Caves Area", Levels.CrystalCaves, True, None, [
         LocationLogic(Locations.CavesDiddyJetpackBarrel, lambda l: l.jetpack and l.isdiddy, MinigameType.BonusBarrel),
-        LocationLogic(Locations.CavesTinyMonkeyportIgloo, lambda l: l.monkeyport and l.mini and l.twirl and l.istiny),
         LocationLogic(Locations.CavesChunkyGorillaGone, lambda l: l.punch and l.gorillaGone and l.ischunky),
         LocationLogic(Locations.CavesKasplatNearLab, lambda l: not l.settings.kasplat_rando),
         LocationLogic(Locations.CavesKasplatNearCandy, lambda l: not l.settings.kasplat_rando),
@@ -110,7 +109,8 @@ LogicRegions = {
         TransitionFront(Regions.CrystalCavesMain, lambda l: True, Transitions.CavesCastleToMain),
     ]),
 
-    Regions.IglooArea: Region("Igloo Area", "Caves Igloo", Levels.CrystalCaves, True, None, [
+    Regions.IglooArea: Region("Igloo Area", "Igloo Area", Levels.CrystalCaves, True, None, [
+        LocationLogic(Locations.CavesTinyMonkeyportIgloo, lambda l: l.monkeyport and l.mini and l.twirl and l.istiny),  # GB is in this region but the rest is not
         LocationLogic(Locations.CavesChunkyTransparentIgloo, lambda l: Events.CavesLargeBoulderButton in l.Events and l.chunky),
         LocationLogic(Locations.CavesKasplatOn5DI, lambda l: not l.settings.kasplat_rando),
     ], [], [
@@ -125,35 +125,35 @@ LogicRegions = {
         TransitionFront(Regions.CavesBossLobby, lambda l: not l.settings.tns_location_rando),
     ]),
 
-    Regions.GiantKosha: Region("Giant Kosha", "Caves Igloo", Levels.CrystalCaves, False, -1, [], [
+    Regions.GiantKosha: Region("Giant Kosha", "Igloo Area", Levels.CrystalCaves, False, -1, [], [
         Event(Events.GiantKoshaDefeated, lambda l: l.shockwave or l.HasInstrument(Kongs.any)),
     ], [
         TransitionFront(Regions.CrystalCavesMedals, lambda l: True),
     ]),
 
     # Deaths in Donkey and Diddy's igloos take you back to them, the others to the beginning of the level
-    Regions.DonkeyIgloo: Region("Donkey Igloo", "Caves Igloo", Levels.CrystalCaves, False, None, [
+    Regions.DonkeyIgloo: Region("Donkey Igloo", "Igloo Area", Levels.CrystalCaves, False, None, [
         LocationLogic(Locations.CavesDonkey5DoorIgloo, lambda l: l.strongKong and l.isdonkey),
     ], [], [
         TransitionFront(Regions.CrystalCavesMedals, lambda l: True),
         TransitionFront(Regions.IglooArea, lambda l: True, Transitions.CavesDonkeyToIgloo),
     ]),
 
-    Regions.DiddyIgloo: Region("Diddy Igloo", "Caves Igloo", Levels.CrystalCaves, False, None, [
+    Regions.DiddyIgloo: Region("Diddy Igloo", "Igloo Area", Levels.CrystalCaves, False, None, [
         LocationLogic(Locations.CavesDiddy5DoorIgloo, lambda l: (l.isdiddy or l.settings.free_trade_items) and l.barrels),
     ], [], [
         TransitionFront(Regions.CrystalCavesMedals, lambda l: True),
         TransitionFront(Regions.IglooArea, lambda l: True, Transitions.CavesDiddyToIgloo),
     ]),
 
-    Regions.LankyIgloo: Region("Lanky Igloo", "Caves Igloo", Levels.CrystalCaves, False, -1, [
+    Regions.LankyIgloo: Region("Lanky Igloo", "Igloo Area", Levels.CrystalCaves, False, -1, [
         LocationLogic(Locations.CavesLanky5DoorIgloo, lambda l: l.balloon and l.islanky),
     ], [], [
         TransitionFront(Regions.CrystalCavesMedals, lambda l: True),
         TransitionFront(Regions.IglooArea, lambda l: True, Transitions.CavesLankyToIgloo),
     ]),
 
-    Regions.TinyIgloo: Region("Tiny Igloo", "Caves Igloo", Levels.CrystalCaves, False, -1, [
+    Regions.TinyIgloo: Region("Tiny Igloo", "Igloo Area", Levels.CrystalCaves, False, -1, [
         LocationLogic(Locations.CavesTiny5DoorIgloo, lambda l: l.Slam and (l.istiny or l.settings.free_trade_items)),
         LocationLogic(Locations.CavesBananaFairyIgloo, lambda l: l.camera),
     ], [], [
@@ -161,7 +161,7 @@ LogicRegions = {
         TransitionFront(Regions.IglooArea, lambda l: True, Transitions.CavesTinyToIgloo),
     ]),
 
-    Regions.ChunkyIgloo: Region("Chunky Igloo", "Caves Igloo", Levels.CrystalCaves, False, -1, [
+    Regions.ChunkyIgloo: Region("Chunky Igloo", "Igloo Area", Levels.CrystalCaves, False, -1, [
         LocationLogic(Locations.CavesChunky5DoorIgloo, lambda l: l.ischunky or l.settings.free_trade_items),
     ], [], [
         TransitionFront(Regions.CrystalCavesMedals, lambda l: True),

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -11,6 +11,18 @@ from randomizer.LogicClasses import (Event, LocationLogic, Region,
                                      TransitionFront)
 
 LogicRegions = {
+    Regions.GameStart: Region("Game Start", "Training Grounds", Levels.DKIsles, False, None, [
+        LocationLogic(Locations.IslesVinesTrainingBarrel, lambda l: l.settings.fast_start_beginning_of_game),
+        LocationLogic(Locations.IslesSwimTrainingBarrel, lambda l: l.settings.fast_start_beginning_of_game),
+        LocationLogic(Locations.IslesOrangesTrainingBarrel, lambda l: l.settings.fast_start_beginning_of_game),
+        LocationLogic(Locations.IslesBarrelsTrainingBarrel, lambda l: l.settings.fast_start_beginning_of_game),
+    ], [], [
+        TransitionFront(Regions.Credits, lambda l: True),
+        # Replace these with the actual starting region if we choose to randomize it
+        TransitionFront(Regions.IslesMain, lambda l: l.settings.fast_start_beginning_of_game),
+        TransitionFront(Regions.Treehouse, lambda l: not l.settings.fast_start_beginning_of_game)
+    ]),
+
     Regions.Credits: Region("Credits", "Credits", Levels.DKIsles, False, None, [
         LocationLogic(Locations.BananaHoard, lambda l: l.WinConditionMet())
     ], [], []),
@@ -44,7 +56,6 @@ LogicRegions = {
     ], [
         Event(Events.IslesChunkyBarrelSpawn, lambda l: l.monkeyport and l.saxophone and l.tiny),
     ], [
-        TransitionFront(Regions.Credits, lambda l: True),
         TransitionFront(Regions.TrainingGrounds, lambda l: True, Transitions.IslesMainToStart),
         TransitionFront(Regions.Prison, lambda l: True),
         TransitionFront(Regions.BananaFairyRoom, lambda l: l.mini and l.istiny, Transitions.IslesMainToFairy),
@@ -137,8 +148,6 @@ LogicRegions = {
         LocationLogic(Locations.IslesTinyGalleonLobby, lambda l: l.chunky and l.superSlam and l.mini and l.twirl and l.swim and l.tiny),
         LocationLogic(Locations.IslesKasplatGalleonLobby, lambda l: not l.settings.kasplat_rando),
     ], [], [
-        # There exists a hellscape in the far flung future where you are trapped in Galleon and Galleon lobby because you cannot swim but your seed is beatable
-        TransitionFront(Regions.Credits, lambda l: True),  # For that reason, this lobby also gets access to the credits region
         TransitionFront(Regions.IslesMain, lambda l: l.swim, Transitions.IslesGalleonLobbyToMain),
         TransitionFront(Regions.GloomyGalleonStart, lambda l: l.IsLevelEnterable(Levels.GloomyGalleon), Transitions.IslesToGalleon),
     ]),

--- a/randomizer/LogicFiles/FranticFactory.py
+++ b/randomizer/LogicFiles/FranticFactory.py
@@ -80,7 +80,7 @@ LogicRegions = {
     ], Transitions.FactoryRandDToRace
     ),
 
-    Regions.ChunkyRoomPlatform: Region("Chunky Room Platform", "Storage Room", Levels.FranticFactory, False, -1, [
+    Regions.ChunkyRoomPlatform: Region("Chunky Room Platform", "Storage Area", Levels.FranticFactory, False, -1, [
         LocationLogic(Locations.FactoryDiddyChunkyRoomBarrel, lambda l: l.Slam and l.isdiddy and l.vines, MinigameType.BonusBarrel),
     ], [], [
         TransitionFront(Regions.FranticFactoryMedals, lambda l: True),
@@ -88,7 +88,7 @@ LogicRegions = {
         TransitionFront(Regions.BeyondHatch, lambda l: True),
     ]),
 
-    Regions.PowerHut: Region("Power Hut", "Storage Room", Levels.FranticFactory, False, None, [
+    Regions.PowerHut: Region("Power Hut", "Storage Area", Levels.FranticFactory, False, None, [
         LocationLogic(Locations.FactoryDonkeyPowerHut, lambda l: Events.MainCoreActivated in l.Events and (l.isdonkey or l.settings.free_trade_items)),
     ], [
         Event(Events.MainCoreActivated, lambda l: l.coconut and l.grab and l.isdonkey),
@@ -97,7 +97,7 @@ LogicRegions = {
         TransitionFront(Regions.ChunkyRoomPlatform, lambda l: True, Transitions.FactoryPowerToChunkyRoom),
     ]),
 
-    Regions.BeyondHatch: Region("Beyond Hatch", "Storage Room", Levels.FranticFactory, True, None, [
+    Regions.BeyondHatch: Region("Beyond Hatch", "Storage Area", Levels.FranticFactory, True, None, [
         LocationLogic(Locations.ChunkyKong, lambda l: l.CanFreeChunky()),
         LocationLogic(Locations.NintendoCoin, lambda l: Events.ArcadeLeverSpawned in l.Events and l.grab and l.isdonkey),
         LocationLogic(Locations.FactoryDonkeyDKArcade, lambda l: not l.settings.fast_gbs and (Events.ArcadeLeverSpawned in l.Events and l.grab and l.isdonkey)),
@@ -118,7 +118,7 @@ LogicRegions = {
         TransitionFront(Regions.FactoryBaboonBlast, lambda l: l.blast and l.isdonkey)  # , Transitions.FactoryMainToBBlast)
     ]),
 
-    Regions.FactoryBaboonBlast: Region("Factory Baboon Blast", "Storage Room", Levels.FranticFactory, False, None, [
+    Regions.FactoryBaboonBlast: Region("Factory Baboon Blast", "Storage Area", Levels.FranticFactory, False, None, [
         LocationLogic(Locations.FactoryDonkeyDKArcade, lambda l: l.settings.fast_gbs),  # The GB is moved here on fast GBs
     ], [
         Event(Events.ArcadeLeverSpawned, lambda l: l.isdonkey)

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -21,7 +21,7 @@ LogicRegions = {
         LocationLogic(Locations.ForestChunkyMedal, lambda l: l.ColoredBananas[Levels.FungiForest][Kongs.chunky] >= l.settings.medal_cb_req),
     ], [], []),
 
-    Regions.FungiForestStart: Region("Fungi Forest Start", "Forest Center", Levels.FungiForest, True, None, [], [
+    Regions.FungiForestStart: Region("Fungi Forest Start", "Forest Center and Beanstalk", Levels.FungiForest, True, None, [], [
         Event(Events.ForestEntered, lambda l: True),
         Event(Events.Night, lambda l: l.HasGun(Kongs.any)),
         Event(Events.WormGatesOpened, lambda l: (l.feather and l.tiny) and (l.pineapple and l.chunky)),
@@ -34,7 +34,7 @@ LogicRegions = {
         TransitionFront(Regions.WormArea, lambda l: l.settings.open_levels or Events.WormGatesOpened in l.Events),
     ]),
 
-    Regions.ForestMinecarts: Region("Forest Minecarts", "Forest Center", Levels.FungiForest, False, None, [
+    Regions.ForestMinecarts: Region("Forest Minecarts", "Forest Center and Beanstalk", Levels.FungiForest, False, None, [
         LocationLogic(Locations.ForestChunkyMinecarts, lambda l: l.ischunky or l.settings.free_trade_items),
     ], [], [
         TransitionFront(Regions.FungiForestMedals, lambda l: True),
@@ -256,7 +256,7 @@ LogicRegions = {
         TransitionFront(Regions.ThornvineArea, lambda l: True, Transitions.ForestBarnToMain),
     ]),
 
-    Regions.WormArea: Region("Worm Area", "Beanstalk Area", Levels.FungiForest, True, -1, [
+    Regions.WormArea: Region("Worm Area", "Forest Center and Beanstalk", Levels.FungiForest, True, -1, [
         LocationLogic(Locations.ForestTinyBeanstalk, lambda l: Events.Bean in l.Events and l.saxophone and l.mini and l.istiny),
         LocationLogic(Locations.ForestChunkyApple, lambda l: Events.WormGatesOpened in l.Events and l.hunkyChunky and l.ischunky and l.barrels),
     ], [], [


### PR DESCRIPTION
This PR tackles a couple major logic issues:
- Refactors priority placement to be independent of placing kong prerequisites. This allows arbitrary priority placing, which is now applied to critical training barrel moves. This (combined with a side effects fix) should dramatically reduce fill fail errors.
- Fixes an issue where logic often couldn't find your training barrel moves in LZR. This is achieved with a "Game Start" region that will always be where the logic starts.

Misc fixes:
- Implements some feedback on hint region names
- Prevent Helm Key from being on the path of key 8 if it's locked there
- No longer generating paths for seeds that don't need them, should be a minor time save