### PR TITLE
Kongs on Items Logic

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -356,7 +356,10 @@ def compileHints(spoiler: Spoiler):
     if spoiler.settings.randomize_cb_required_amounts and len(spoiler.settings.krool_keys_required) > 0 and spoiler.settings.krool_keys_required != [Events.HelmKeyTurnedIn]:
         valid_types.append(HintType.TroffNScoff)
     if spoiler.settings.kong_rando:
-        valid_types.append(HintType.KongLocation)
+        if spoiler.settings.shuffle_items and Types.Kong in spoiler.settings.shuffled_location_types:
+            print("item rando kong hints under construction")
+        else:
+            valid_types.append(HintType.KongLocation)
     # if spoiler.settings.coin_door_open == "need_both" or spoiler.settings.coin_door_open == "need_rw":
     #     valid_types.append(HintType.MedalsRequired)
     if spoiler.settings.shuffle_loading_zones == "all":

--- a/randomizer/Lists/Item.py
+++ b/randomizer/Lists/Item.py
@@ -29,6 +29,8 @@ class Item:
         if type == Types.Key:
             self.rando_flag = data[0]
             self.index = data[1]  # Key 1 = 1, Key 2 = 2, etc
+        if type == Types.Kong:
+            self.rando_flag = data[0]
 
 
 def ItemFromKong(kong):
@@ -82,11 +84,11 @@ def KongFromItem(item):
 ItemList = {
     Items.NoItem: Item("No Item", False, Types.Constant, Kongs.any),
     Items.TestItem: Item("Fill Helper Item - SHOULD NOT BE PLACED", False, Types.Constant, Kongs.any),
-    Items.Donkey: Item("Donkey", True, Types.Kong, Kongs.any),
-    Items.Diddy: Item("Diddy", True, Types.Kong, Kongs.any),
-    Items.Lanky: Item("Lanky", True, Types.Kong, Kongs.any),
-    Items.Tiny: Item("Tiny", True, Types.Kong, Kongs.any),
-    Items.Chunky: Item("Chunky", True, Types.Kong, Kongs.any),
+    Items.Donkey: Item("Donkey", True, Types.Kong, Kongs.any, [385]),
+    Items.Diddy: Item("Diddy", True, Types.Kong, Kongs.any, [6]),
+    Items.Lanky: Item("Lanky", True, Types.Kong, Kongs.any, [70]),
+    Items.Tiny: Item("Tiny", True, Types.Kong, Kongs.any, [66]),
+    Items.Chunky: Item("Chunky", True, Types.Kong, Kongs.any, [117]),
     Items.Vines: Item("Vines", True, Types.TrainingBarrel, Kongs.any, [MoveTypes.Flag, "vine", 387]),
     Items.Swim: Item("Swim", True, Types.TrainingBarrel, Kongs.any, [MoveTypes.Flag, "dive", 386]),
     Items.Oranges: Item("Oranges", True, Types.TrainingBarrel, Kongs.any, [MoveTypes.Flag, "orange", 388]),

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -43,6 +43,7 @@ class LogicVarHolder:
         if settings is None:
             return
         self.settings = settings
+        self.pathMode = False
         self.startkong = self.settings.starting_kong
         self.Reset()
 
@@ -580,7 +581,8 @@ class LogicVarHolder:
     def IsLevelEnterable(self, level):
         """Check if level entry requirement is met."""
         # Later levels can have some special requirements
-        if level >= 3:
+        # "pathMode" is so WotH paths can always enter levels regardless of owned items
+        if not self.pathMode and level >= 3:
             level_order_matters = not self.settings.hard_level_progression and self.settings.shuffle_loading_zones in ("none", "levels")
             # If level order matters...
             if level_order_matters:

--- a/randomizer/LogicFiles/JungleJapes.py
+++ b/randomizer/LogicFiles/JungleJapes.py
@@ -97,7 +97,7 @@ LogicRegions = {
     ]),
 
     Regions.TinyHive: Region("Tiny Hive", "Hive Area", Levels.JungleJapes, False, -1, [
-        LocationLogic(Locations.JapesTinyBeehive, lambda l: l.Slam and l.istiny and l.oranges),
+        LocationLogic(Locations.JapesTinyBeehive, lambda l: l.Slam and l.istiny and (l.saxophone or l.oranges)),
     ], [], [
         TransitionFront(Regions.JungleJapesMedals, lambda l: True),
         TransitionFront(Regions.JapesBeyondFeatherGate, lambda l: True, Transitions.JapesTinyHiveToMain),

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -384,8 +384,9 @@ class Settings:
                     self.shuffled_location_types.append(Types.Shockwave)
                 if self.training_barrels != "normal":
                     self.shuffled_location_types.append(Types.TrainingBarrel)
-        self.progressives_locked_in_shops = False  # Technical limitation: for now (hopefully) progressive moves must be found in shops
-
+            # DEBUG CODE for testing, put it in the list selector when it's completed
+            # Uncomment the next line if you want Kongs in the item rando location pool
+            # self.shuffled_location_types.append(Types.Kong)  
         self.shuffle_prices()
 
         # B Locker and Troff n Scoff amounts Rando
@@ -572,8 +573,10 @@ class Settings:
             self.lanky_freeing_kong = Kongs.any
             self.tiny_freeing_kong = Kongs.any
             self.chunky_freeing_kong = Kongs.any
-            # Kong locations are adjusted in the fill, set all possible for now
-            self.kong_locations = self.SelectKongLocations()
+            if self.shuffle_items and Types.Kong in self.shuffled_location_types:
+                self.kong_locations = [Locations.DiddyKong, Locations.LankyKong, Locations.TinyKong, Locations.ChunkyKong]
+            else:
+                self.kong_locations = self.SelectKongLocations()
         else:
             self.possible_kong_list = kongs.copy()
             self.possible_kong_list.remove(0)
@@ -633,7 +636,7 @@ class Settings:
     def update_valid_locations(self):
         """Calculate (or recalculate) valid locations for items by type."""
         self.valid_locations = {}
-        self.valid_locations[Types.Kong] = [Locations.DiddyKong, Locations.LankyKong, Locations.TinyKong, Locations.ChunkyKong]
+        self.valid_locations[Types.Kong] = self.kong_locations.copy()
         # If shops are not shuffled into the larger pool, calculate shop locations for shop-bound moves
         if self.move_rando not in ("off", "item_shuffle"):
             self.valid_locations[Types.Shop] = {}
@@ -674,8 +677,9 @@ class Settings:
             self.valid_locations[Types.Shockwave] = self.valid_locations[Types.Shop][Kongs.any]
             self.valid_locations[Types.TrainingBarrel] = self.valid_locations[Types.Shop][Kongs.any]
 
-        if any(self.shuffled_location_types):
-            shuffledLocations = [location for location in LocationList if LocationList[location].type in self.shuffled_location_types]
+        if self.shuffle_items and any(self.shuffled_location_types):
+            # All shuffled locations are valid except for Kong locations (the Kong inside the cage, not the GB) - those can only be Kongs
+            shuffledLocations = [location for location in LocationList if LocationList[location].type in self.shuffled_location_types and LocationList[location].type != Types.Kong]
             if Types.Shop in self.shuffled_location_types:
                 self.valid_locations[Types.Shop] = {}
                 # Cross-kong acquisition is assumed in full item rando, calculate the list of all Kong-specific shops
@@ -722,6 +726,7 @@ class Settings:
             if Types.Banana in self.shuffled_location_types:
                 self.valid_locations[Types.Banana] = shuffledLocations
             if Types.Crown in self.shuffled_location_types:
+                # Banned for technical reasons
                 banned_crown_locations = (
                     Locations.HelmDonkeyMedal,
                     Locations.HelmDiddyMedal,
@@ -744,6 +749,16 @@ class Settings:
                 self.valid_locations[Types.Medal] = shuffledLocations
             if Types.Coin in self.shuffled_location_types:
                 self.valid_locations[Types.Coin] = shuffledLocations
+            if Types.Kong in self.shuffled_location_types:
+                # Banned because it defeats the purpose of starting with X Kongs
+                banned_kong_locations = (
+                    Locations.IslesSwimTrainingBarrel,
+                    Locations.IslesVinesTrainingBarrel,
+                    Locations.IslesBarrelsTrainingBarrel,
+                    Locations.IslesOrangesTrainingBarrel,
+                    Locations.IslesDonkeyJapesRock
+                )
+                self.valid_locations[Types.Kong].extend(shuffledLocations)  # No items can be in Kong cages but Kongs can be in all other locations
 
     def GetValidLocationsForItem(self, item_id):
         """Return the valid locations the input item id can be placed in."""
@@ -754,8 +769,6 @@ class Settings:
             valid_locations = self.valid_locations[item_obj.type][item_obj.kong]
         else:
             valid_locations = self.valid_locations[item_obj.type]
-        if self.progressives_locked_in_shops and item_obj in SharedShopLocations:
-            valid_locations = SharedShopLocations.copy()
         return valid_locations
 
     def SelectKongLocations(self):

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -386,7 +386,7 @@ class Settings:
                     self.shuffled_location_types.append(Types.TrainingBarrel)
             # DEBUG CODE for testing, put it in the list selector when it's completed
             # Uncomment the next line if you want Kongs in the item rando location pool
-            # self.shuffled_location_types.append(Types.Kong)  
+            # self.shuffled_location_types.append(Types.Kong)
         self.shuffle_prices()
 
         # B Locker and Troff n Scoff amounts Rando
@@ -756,7 +756,7 @@ class Settings:
                     Locations.IslesVinesTrainingBarrel,
                     Locations.IslesBarrelsTrainingBarrel,
                     Locations.IslesOrangesTrainingBarrel,
-                    Locations.IslesDonkeyJapesRock
+                    Locations.IslesDonkeyJapesRock,
                 )
                 self.valid_locations[Types.Kong].extend(shuffledLocations)  # No items can be in Kong cages but Kongs can be in all other locations
 

--- a/randomizer/ShuffleExits.py
+++ b/randomizer/ShuffleExits.py
@@ -2,6 +2,7 @@
 import random
 
 import js
+from randomizer.Enums.Types import Types
 import randomizer.Fill as Fill
 import randomizer.Lists.Exceptions as Ex
 import randomizer.Logic as Logic
@@ -194,7 +195,8 @@ def ShuffleExits(settings: Settings):
     # Set up front and back entrance pools for each setting
     # Assume all shuffled exits reachable by default
     if settings.shuffle_loading_zones == "levels":
-        if settings.kongs_for_progression:
+        # If we are restricted on kong locations, we need to carefully place levels in order to meet the kongs-by-level requirement
+        if settings.kongs_for_progression and not (settings.shuffle_items and Types.Kong in settings.shuffled_location_types):
             ShuffleLevelOrderWithRestrictions(settings)
         else:
             ShuffleLevelExits(settings)


### PR DESCRIPTION
Implements a more generic kong placement strategy that will work with kongs in the larger item rando location pool.

Other fixes:
- If Barrels was WotH your paths could be seriously wrong, this is now fixed
- Remembered you can use your instrument in the shellhive
- Hopefully fixed weird error with placed moves not being found in a list of all moves
- Set up placeholder for kong path hints when they're in the pool