### PR TITLE
fix helm logic for "skip_start"

### DIFF
--- a/randomizer/LogicFiles/HideoutHelm.py
+++ b/randomizer/LogicFiles/HideoutHelm.py
@@ -39,11 +39,11 @@ LogicRegions = {
         LocationLogic(Locations.HelmKey, lambda l: Events.HelmKeyAccess in l.Events),
     ], [
         Event(Events.HelmDoorsOpened, lambda l: l.grab and l.donkey and l.jetpack and l.diddy and l.punch and l.chunky),
-        Event(Events.HelmDonkeyDone, lambda l: ((l.isPriorHelmComplete(Kongs.donkey) or l.settings.helm_setting != "default") and l.HelmDonkey1 and l.HelmDonkey2) or not l.settings.helm_donkey),
-        Event(Events.HelmChunkyDone, lambda l: ((l.isPriorHelmComplete(Kongs.chunky) or l.settings.helm_setting != "default") and l.HelmChunky1 and l.HelmChunky2) or not l.settings.helm_chunky),
-        Event(Events.HelmTinyDone, lambda l: ((l.isPriorHelmComplete(Kongs.tiny) or l.settings.helm_setting != "default") and l.HelmTiny1 and l.HelmTiny2) or not l.settings.helm_tiny),
-        Event(Events.HelmLankyDone, lambda l: ((l.isPriorHelmComplete(Kongs.lanky) or l.settings.helm_setting != "default") and l.HelmLanky1 and l.HelmLanky2) or not l.settings.helm_lanky),
-        Event(Events.HelmDiddyDone, lambda l: ((l.isPriorHelmComplete(Kongs.diddy) or l.settings.helm_setting != "default") and l.HelmDiddy1 and l.HelmDiddy2) or not l.settings.helm_diddy),
+        Event(Events.HelmDonkeyDone, lambda l: ((l.isPriorHelmComplete(Kongs.donkey) or l.settings.helm_setting == "skip_all") and l.HelmDonkey1 and l.HelmDonkey2) or not l.settings.helm_donkey),
+        Event(Events.HelmChunkyDone, lambda l: ((l.isPriorHelmComplete(Kongs.chunky) or l.settings.helm_setting == "skip_all") and l.HelmChunky1 and l.HelmChunky2) or not l.settings.helm_chunky),
+        Event(Events.HelmTinyDone, lambda l: ((l.isPriorHelmComplete(Kongs.tiny) or l.settings.helm_setting == "skip_all") and l.HelmTiny1 and l.HelmTiny2) or not l.settings.helm_tiny),
+        Event(Events.HelmLankyDone, lambda l: ((l.isPriorHelmComplete(Kongs.lanky) or l.settings.helm_setting == "skip_all") and l.HelmLanky1 and l.HelmLanky2) or not l.settings.helm_lanky),
+        Event(Events.HelmDiddyDone, lambda l: ((l.isPriorHelmComplete(Kongs.diddy) or l.settings.helm_setting == "skip_all") and l.HelmDiddy1 and l.HelmDiddy2) or not l.settings.helm_diddy),
         Event(Events.HelmKeyAccess, lambda l: (l.settings.helm_setting == "skip_all" or (Events.HelmDonkeyDone in l.Events and Events.HelmChunkyDone in l.Events
               and Events.HelmTinyDone in l.Events and Events.HelmLankyDone in l.Events and Events.HelmDiddyDone in l.Events))
               and (l.settings.crown_door_open or l.BattleCrowns >= 4) and (l.settings.coin_door_open or l.nintendoCoin and l.rarewareCoin)),


### PR DESCRIPTION
This fixes an issue where helm rooms are assumed to have every instrument spawned from the start when using the "skip start" helm setting (internally named "skip_start"), even when the B.o.M is active (1-5 rooms required to be completed first). 