### PR TITLE
fix vines woth being incorrect

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -537,6 +537,7 @@ def CalculateWothPaths(spoiler, WothLocations):
     LogicVariables.pathMode = False  # Don't carry this pathMode flag beyond this method ever
     spoiler.settings.open_lobbies = old_open_lobbies_temp  # Undo the open lobbies setting change too
 
+
 def CalculateFoolish(spoiler, WothLocations):
     """Calculate the items and regions that are foolish (blocking no major items)."""
     wothItems = [LocationList[loc].item for loc in WothLocations]

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -489,7 +489,14 @@ def PareWoth(spoiler, PlaythroughLocations):
 
 def CalculateWothPaths(spoiler, WothLocations):
     """Calculate the Paths (dependencies) for each Way of the Hoard item."""
-    LogicVariables.pathMode = True  # Helps get more accurate paths by removing important obstacles to level entry
+    # Helps get more accurate paths by removing important obstacles to level entry
+    # Removes the following:
+    # - The need for vines to progress in Aztec
+    # - The need for swim to get into level 4
+    # - The need for keys to open lobbies (this is done with open_lobbies)
+    LogicVariables.pathMode = True
+    old_open_lobbies_temp = spoiler.settings.open_lobbies
+    spoiler.settings.open_lobbies = True
     falseWothLocations = []
     # Prep the dictionary that will contain the path for the key item
     for locationId in WothLocations:
@@ -499,12 +506,10 @@ def CalculateWothPaths(spoiler, WothLocations):
         location = LocationList[locationId]
         item_id = location.item
         location.item = None
-        # We need to have some items assumed in order to get a "pure" path instead of most early paths being a subset of later paths.
-        # We assume Keys and Kongs because anything locked behind a them will then require everything that Key or Kong requires.
-        # This sort of defeats the purpose of paths, as it would put everything in a Key or Kong's path into the path of many, many items.
-        assumedItems = ItemPool.Keys() + ItemPool.Kongs(spoiler.settings)
-        # Vines and Swim invariably end up on long paths to many, many items because they can block whole levels, so we'll also assume these to shorten paths
-        assumedItems.extend([Items.Vines, Items.Swim])
+        # We also need to assume Kongs in order to get a "pure" path instead of Kong paths being a subset of most later paths.
+        # Anything locked behind a a Kong will then require everything that Kong requires.
+        # This sort of defeats the purpose of paths, as it would put everything in a Kong's path into the path of many, many items.
+        assumedItems = ItemPool.Kongs(spoiler.settings)
         # Find all accessible locations without this item placed
         Reset()
         # At this point we know there is no breaking purchase order
@@ -530,7 +535,7 @@ def CalculateWothPaths(spoiler, WothLocations):
         WothLocations.remove(locationId)
         del spoiler.woth_paths[locationId]
     LogicVariables.pathMode = False  # Don't carry this pathMode flag beyond this method ever
-
+    spoiler.settings.open_lobbies = old_open_lobbies_temp  # Undo the open lobbies setting change too
 
 def CalculateFoolish(spoiler, WothLocations):
     """Calculate the items and regions that are foolish (blocking no major items)."""
@@ -1056,6 +1061,7 @@ def ShuffleSharedMoves(spoiler, placedMoves):
         trainingMovesUnplaced = PlaceItems(spoiler.settings, "assumed", [Items.Oranges], [x for x in ItemPool.AllItems(spoiler.settings) if x != Items.Oranges and x not in placedMoves])
         if trainingMovesUnplaced > 0:
             raise Ex.ItemPlacementException("Failed to place Orange training barrel move.")
+        placedMoves.append(Items.Oranges)
     importantSharedToPlace = ItemPool.ImportantSharedMoves.copy()
     # Next place any fairy moves that need placing, settings dependent
     if spoiler.settings.shockwave_status == "shuffled" and Items.CameraAndShockwave not in placedMoves:

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -43,7 +43,7 @@ class LogicVarHolder:
         if settings is None:
             return
         self.settings = settings
-        self.pathMode = False
+        self.pathMode = False  # See CalculateWothPaths method for details
         self.startkong = self.settings.starting_kong
         self.Reset()
 

--- a/randomizer/LogicFiles/AngryAztec.py
+++ b/randomizer/LogicFiles/AngryAztec.py
@@ -25,7 +25,7 @@ LogicRegions = {
     ], [
         TransitionFront(Regions.AngryAztecMedals, lambda l: True),
         TransitionFront(Regions.AngryAztecLobby, lambda l: True, Transitions.AztecToIsles),
-        TransitionFront(Regions.BetweenVinesByPortal, lambda l: l.vines or (l.istiny and l.twirl)),
+        TransitionFront(Regions.BetweenVinesByPortal, lambda l: l.pathMode or l.vines or (l.istiny and l.twirl)),
     ]),
 
     Regions.BetweenVinesByPortal: Region("Angry Aztec Between Vines By Portal", "Various Aztec Tunnels", Levels.AngryAztec, False, None, [
@@ -33,7 +33,7 @@ LogicRegions = {
     ], [], [
         TransitionFront(Regions.AngryAztecMedals, lambda l: True),
         TransitionFront(Regions.AngryAztecStart, lambda l: l.vines or (l.istiny and l.twirl)),
-        TransitionFront(Regions.AngryAztecOasis, lambda l: l.vines or (l.istiny and l.twirl)),
+        TransitionFront(Regions.AngryAztecOasis, lambda l: l.pathMode or l.vines or (l.istiny and l.twirl)),
     ]),
 
     Regions.AztecTunnelBeforeOasis: Region("Angry Aztec Tunnel Before Oasis", "Various Aztec Tunnels", Levels.AngryAztec, False, None, [

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -61,8 +61,8 @@ LogicRegions = {
         TransitionFront(Regions.BananaFairyRoom, lambda l: l.mini and l.istiny, Transitions.IslesMainToFairy),
         TransitionFront(Regions.JungleJapesLobby, lambda l: l.settings.open_lobbies or Events.KLumsyTalkedTo in l.Events, Transitions.IslesMainToJapesLobby),
         TransitionFront(Regions.CrocodileIsleBeyondLift, lambda l: l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events),
-        TransitionFront(Regions.IslesMainUpper, lambda l: l.vines),
-        TransitionFront(Regions.GloomyGalleonLobby, lambda l: (l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events) and l.swim, Transitions.IslesMainToGalleonLobby),
+        TransitionFront(Regions.IslesMainUpper, lambda l: l.vines or l.pathMode),
+        TransitionFront(Regions.GloomyGalleonLobby, lambda l: (l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events) and (l.swim or l.pathMode), Transitions.IslesMainToGalleonLobby),
         TransitionFront(Regions.CabinIsle, lambda l: l.settings.open_lobbies or Events.GalleonKeyTurnedIn in l.Events),
         TransitionFront(Regions.CreepyCastleLobby, lambda l: l.settings.open_lobbies or Events.ForestKeyTurnedIn in l.Events, Transitions.IslesMainToCastleLobby),
         TransitionFront(Regions.HideoutHelmLobby, lambda l: l.monkeyport and l.istiny

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -217,6 +217,7 @@ class Spoiler:
         humanspoiler["Way of the Hoard"] = self.woth
         # Paths for Woth items - does not show up on the site, just for debugging
         humanspoiler["Paths"] = {}
+        wothSlams = 0
         for loc, path in self.woth_paths.items():
             destination_item = ItemList[LocationList[loc].item]
             path_dict = {}
@@ -224,7 +225,11 @@ class Spoiler:
                 path_location = LocationList[path_loc_id]
                 path_item = ItemList[path_location.item]
                 path_dict[path_location.name] = path_item.name
-            humanspoiler["Paths"][destination_item.name] = path_dict
+            extra = ""
+            if LocationList[loc].item == Items.ProgressiveSlam:
+                wothSlams += 1
+                extra = " " + str(wothSlams)
+            humanspoiler["Paths"][destination_item.name + extra] = path_dict
 
         for location_id, location in LocationList.items():
             # No need to spoiler constants


### PR DESCRIPTION
Fixed an issue where vines was incorrectly woth
A consequence of this change is that vines and swim will now appear on paths again, but only in regards to prerequisites beyond level entry.