### PR TITLE
door location rando bug fix

### DIFF
--- a/randomizer/ShuffleDoors.py
+++ b/randomizer/ShuffleDoors.py
@@ -53,15 +53,15 @@ def ShuffleDoors(spoiler):
                     shuffled_door_data[level].append((selected_door_index, "wrinkly", (kong % 5)))
         elif "remove_wrinkly_puzzles" in spoiler.settings.misc_changes_selected or len(spoiler.settings.misc_changes_selected) == 0:
             # place vanilla wrinkly doors
+            vanilla_wrinkly_doors = [door for door in available_doors if door_locations[level][door].default_placed == "wrinkly"]
             for kong in range(5):
-                if len(available_doors) > 0:  # Should only fail if we don't have enough door locations
-                    selected_door_index = available_doors.pop()
+                if len(vanilla_wrinkly_doors) > 0:  # Should only fail if we don't have enough door locations
+                    selected_door_index = vanilla_wrinkly_doors.pop()
                     selected_door = door_locations[level][selected_door_index]
-                    if selected_door.default_placed == "wrinkly":
-                        assignee = selected_door.default_kong
-                        selected_door.assignDoor(assignee)
-                        human_hint_doors[level_list[level]][str(assignee).capitalize()] = selected_door.name
-                        shuffled_door_data[level].append((selected_door_index, "wrinkly", int(assignee)))
+                    assignee = selected_door.default_kong
+                    selected_door.assignDoor(assignee)
+                    human_hint_doors[level_list[level]][str(assignee).capitalize()] = selected_door.name
+                    shuffled_door_data[level].append((selected_door_index, "wrinkly", int(assignee)))
         if spoiler.settings.tns_location_rando:
             number_of_portals_in_level = random.choice([3, 4, 5])
             moveless_portal_selected = False


### PR DESCRIPTION
Fixes a bug where vanilla wrinkly doors would fail to exist if Wrinkly Location rando is off, TnS Portal Location rando is on and the Remove Wrinkly Puzzles QoL feature is enabled.