### PR TITLE
Kremlin kapture korrection and minor bug fixes

### DIFF
--- a/randomizer/Lists/CBLocations/AngryAztecCBLocations.py
+++ b/randomizer/Lists/CBLocations/AngryAztecCBLocations.py
@@ -1119,7 +1119,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=69,
         map_id=Maps.AztecLlamaTemple,
-        name="W2",
+        name="W2 in Llama temple",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.LlamaTempleBack,
         locations=[[5, 1.0, 2638, 385, 2632]],
@@ -1127,7 +1127,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=69,
         map_id=Maps.AztecLlamaTemple,
-        name="W2",
+        name="W2 in Llama temple",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.LlamaTemple,
         locations=[[5, 1.0, 1409, 434, 3754]],

--- a/randomizer/Lists/CBLocations/CreepyCastleCBLocations.py
+++ b/randomizer/Lists/CBLocations/CreepyCastleCBLocations.py
@@ -925,7 +925,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=74,
         map_id=Maps.CastleBallroom,
-        name="Ball Room - Entrance path",
+        name="Ballroom - Entrance path",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.Ballroom,
         locations=[

--- a/randomizer/Lists/CBLocations/CreepyCastleCBLocations.py
+++ b/randomizer/Lists/CBLocations/CreepyCastleCBLocations.py
@@ -925,7 +925,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=74,
         map_id=Maps.CastleBallroom,
-        name="Entrance path",
+        name="Ball Room - Entrance path",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.Ballroom,
         locations=[
@@ -1057,7 +1057,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=86,
         map_id=Maps.CastleShed,
-        name="Around room",
+        name="Shed - Around room",
         konglist=[Kongs.chunky],
         region=Regions.Shed,
         locations=[
@@ -1078,7 +1078,7 @@ ColoredBananaGroupList = [
             [1, 1.0, 402, 0, 495],
         ],
     ),
-    ColoredBananaGroup(group=87, map_id=Maps.CastleShed, name="On GG pad", konglist=[Kongs.chunky], region=Regions.Shed, logic=lambda l: l.punch, locations=[[5, 1.0, 304, 12, 354]]),
+    ColoredBananaGroup(group=87, map_id=Maps.CastleShed, name="On Gorilla Gone pad", konglist=[Kongs.chunky], region=Regions.Shed, logic=lambda l: l.punch, locations=[[5, 1.0, 304, 12, 354]]),
     ColoredBananaGroup(
         group=88,
         map_id=Maps.CastleLowerCave,
@@ -1144,7 +1144,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=93,
         map_id=Maps.CastleCrypt,
-        name="W1 (1 custom, 1 Diddy)",
+        name="Crypt - W1 (1 custom, 1 Diddy)",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.chunky],
         region=Regions.Crypt,
         locations=[[5, 1.0, 734, 254, 1564], [5, 1.0, 1738.5306396484375, 15.0, 378.6136169433594]],
@@ -1152,18 +1152,18 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=94,
         map_id=Maps.CastleCrypt,
-        name="W2 (1 custom, 1 Donkey)",
+        name="Crypt - W2 (1 custom, 1 Donkey)",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.chunky],
         region=Regions.Crypt,
         locations=[[5, 1.0, 732, 254, 1661], [5, 1.0, 1511.1583251953125, 105.0, 2047.6162109375]],
     ),
     ColoredBananaGroup(
-        group=95, map_id=Maps.CastleCrypt, name="W3", konglist=[Kongs.donkey, Kongs.diddy, Kongs.chunky], region=Regions.Crypt, locations=[[5, 1.0, 731, 254, 1769], [5, 1.0, 1076, 174, 2479]]
+        group=95, map_id=Maps.CastleCrypt, name="Crypt - W3", konglist=[Kongs.donkey, Kongs.diddy, Kongs.chunky], region=Regions.Crypt, locations=[[5, 1.0, 731, 254, 1769], [5, 1.0, 1076, 174, 2479]]
     ),
     ColoredBananaGroup(
         group=96,
         map_id=Maps.CastleCrypt,
-        name="Path from warps to T intersection",
+        name="Crypt - Path from warps to T intersection",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.chunky],
         region=Regions.Crypt,
         locations=[[1, 1.0, 730, 240, 1492], [1, 1.0, 730, 240, 1357], [1, 1.0, 815, 236, 1357], [1, 1.0, 900, 201, 1357], [1, 1.0, 985, 166, 1357]],
@@ -1171,7 +1171,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=97,
         map_id=Maps.CastleCrypt,
-        name="Path to W2",
+        name="Crypt - Path to W2",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.chunky],
         region=Regions.Crypt,
         locations=[
@@ -1190,7 +1190,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=98,
         map_id=Maps.CastleCrypt,
-        name="Path to W1",
+        name="Crypt - Path to W1",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.chunky],
         region=Regions.Crypt,
         locations=[
@@ -1214,7 +1214,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=99,
         map_id=Maps.CastleCrypt,
-        name="Path to W3",
+        name="Crypt - Path to W3",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.chunky],
         region=Regions.Crypt,
         locations=[
@@ -1338,7 +1338,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=113,
         map_id=Maps.CastleMuseum,
-        name="Path from entrance to main room",
+        name="Museum - Path from entrance to main room",
         konglist=[Kongs.chunky],
         region=Regions.Museum,
         locations=[
@@ -1383,7 +1383,7 @@ ColoredBananaGroupList = [
         name="In wind column",
         konglist=[Kongs.lanky],
         region=Regions.Tower,
-        logic=lambda l: (l.scope or l.homing) and l.balloon,
+        logic=lambda l: (l.scope or l.homing) and l.balloon and l.grape,
         locations=[[5, 1.3, 400, 460, 400], [5, 1.3, 400, 580, 400]],
     ),
     ColoredBananaGroup(group=117, map_id=Maps.CastleTower, name="On baboon balloon pad", konglist=[Kongs.lanky], region=Regions.Tower, locations=[[5, 1.0, 511, 239, 342]]),
@@ -1409,7 +1409,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=119,
         map_id=Maps.CastleTree,
-        name="Middle of first room",
+        name="Big Tree - Middle of first room",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.CastleTree,
         locations=[[5, 1.0, 979, 405, 884]],

--- a/randomizer/Lists/CBLocations/CrystalCavesCBLocations.py
+++ b/randomizer/Lists/CBLocations/CrystalCavesCBLocations.py
@@ -507,7 +507,12 @@ ColoredBananaGroupList = [
         ],
     ),
     ColoredBananaGroup(
-        group=38, map_id=Maps.CrystalCaves, name="Bunch on 5DI", konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky], region=Regions.IglooArea, locations=[[5, 1.0, 577, 150, 1285]]
+        group=38,
+        map_id=Maps.CrystalCaves,
+        name="Bunch on 5DI",
+        konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
+        region=Regions.IglooArea,
+        locations=[[5, 1.0, 577, 150, 1285]],
     ),
     ColoredBananaGroup(
         group=39, map_id=Maps.CrystalCaves, name="On pointy pillar by Chunky igloo", konglist=[Kongs.diddy], region=Regions.IglooArea, logic=lambda l: l.jetpack, locations=[[5, 1.0, 731, 150, 994]]
@@ -1027,18 +1032,52 @@ ColoredBananaGroupList = [
     ),
     ColoredBananaGroup(group=92, map_id=Maps.CavesLankyCabin, name="Stack of books in entrance corner", konglist=[Kongs.lanky], region=Regions.LankyCabin, locations=[[5, 1.0, 530, 35, 118]]),
     ColoredBananaGroup(
-        group=93, map_id=Maps.CavesLankyCabin, name="Stacks of books on shelves in Lanky's cabin", konglist=[Kongs.lanky], region=Regions.LankyCabin, locations=[[5, 1.0, 400, 72, 505], [5, 1.0, 150, 72, 335]]
+        group=93,
+        map_id=Maps.CavesLankyCabin,
+        name="Stacks of books on shelves in Lanky's cabin",
+        konglist=[Kongs.lanky],
+        region=Regions.LankyCabin,
+        locations=[[5, 1.0, 400, 72, 505], [5, 1.0, 150, 72, 335]],
     ),
     ColoredBananaGroup(
-        group=94, map_id=Maps.CavesChunkyCabin, name="Stacks of books on shelves in Chunky's cabin", konglist=[Kongs.chunky], region=Regions.ChunkyCabin, locations=[[5, 1.0, 177, 72, 116], [5, 1.0, 77, 72, 356]]
+        group=94,
+        map_id=Maps.CavesChunkyCabin,
+        name="Stacks of books on shelves in Chunky's cabin",
+        konglist=[Kongs.chunky],
+        region=Regions.ChunkyCabin,
+        locations=[[5, 1.0, 177, 72, 116], [5, 1.0, 77, 72, 356]],
     ),
     ColoredBananaGroup(
-        group=95, map_id=Maps.CavesChunkyCabin, name="Books on floor and back shelf in Chunky's cabin", konglist=[Kongs.chunky], region=Regions.ChunkyCabin, locations=[[5, 1.0, 402, 50, 561], [5, 1.0, 445, 15, 112]]
+        group=95,
+        map_id=Maps.CavesChunkyCabin,
+        name="Books on floor and back shelf in Chunky's cabin",
+        konglist=[Kongs.chunky],
+        region=Regions.ChunkyCabin,
+        locations=[[5, 1.0, 402, 50, 561], [5, 1.0, 445, 15, 112]],
     ),
-    ColoredBananaGroup(group=96, map_id=Maps.CavesDiddyUpperCabin, name="Books on shelf near entrance in Diddy's upper cabin", konglist=[Kongs.diddy], region=Regions.DiddyUpperCabin, locations=[[5, 1.0, 201, 70, 119]]),
-    ColoredBananaGroup(group=97, map_id=Maps.CavesDiddyUpperCabin, name="Books on shelf on back wall in Diddy's upper cabin", konglist=[Kongs.diddy], region=Regions.DiddyUpperCabin, locations=[[5, 1.0, 469, 70, 606]]),
     ColoredBananaGroup(
-        group=98, map_id=Maps.CavesDonkeyCabin, name="On books on shelves in DK's cabin", konglist=[Kongs.donkey], region=Regions.DonkeyCabin, locations=[[5, 1.0, 190, 70, 486], [5, 1.0, 143, 70, 119]]
+        group=96,
+        map_id=Maps.CavesDiddyUpperCabin,
+        name="Books on shelf near entrance in Diddy's upper cabin",
+        konglist=[Kongs.diddy],
+        region=Regions.DiddyUpperCabin,
+        locations=[[5, 1.0, 201, 70, 119]],
+    ),
+    ColoredBananaGroup(
+        group=97,
+        map_id=Maps.CavesDiddyUpperCabin,
+        name="Books on shelf on back wall in Diddy's upper cabin",
+        konglist=[Kongs.diddy],
+        region=Regions.DiddyUpperCabin,
+        locations=[[5, 1.0, 469, 70, 606]],
+    ),
+    ColoredBananaGroup(
+        group=98,
+        map_id=Maps.CavesDonkeyCabin,
+        name="On books on shelves in DK's cabin",
+        konglist=[Kongs.donkey],
+        region=Regions.DonkeyCabin,
+        locations=[[5, 1.0, 190, 70, 486], [5, 1.0, 143, 70, 119]],
     ),
     ColoredBananaGroup(
         group=99,

--- a/randomizer/Lists/CBLocations/CrystalCavesCBLocations.py
+++ b/randomizer/Lists/CBLocations/CrystalCavesCBLocations.py
@@ -490,7 +490,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=37,
         map_id=Maps.CrystalCaves,
-        name="On 5DI",
+        name="Singles on 5DI",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.IglooArea,
         locations=[
@@ -507,7 +507,7 @@ ColoredBananaGroupList = [
         ],
     ),
     ColoredBananaGroup(
-        group=38, map_id=Maps.CrystalCaves, name="On 5DI", konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky], region=Regions.IglooArea, locations=[[5, 1.0, 577, 150, 1285]]
+        group=38, map_id=Maps.CrystalCaves, name="Bunch on 5DI", konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky], region=Regions.IglooArea, locations=[[5, 1.0, 577, 150, 1285]]
     ),
     ColoredBananaGroup(
         group=39, map_id=Maps.CrystalCaves, name="On pointy pillar by Chunky igloo", konglist=[Kongs.diddy], region=Regions.IglooArea, logic=lambda l: l.jetpack, locations=[[5, 1.0, 731, 150, 994]]
@@ -1009,7 +1009,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=91,
         map_id=Maps.CavesTinyIgloo,
-        name="Around igloo",
+        name="Inside Tiny's igloo room",
         konglist=[Kongs.tiny],
         region=Regions.TinyIgloo,
         locations=[
@@ -1027,18 +1027,18 @@ ColoredBananaGroupList = [
     ),
     ColoredBananaGroup(group=92, map_id=Maps.CavesLankyCabin, name="Stack of books in entrance corner", konglist=[Kongs.lanky], region=Regions.LankyCabin, locations=[[5, 1.0, 530, 35, 118]]),
     ColoredBananaGroup(
-        group=93, map_id=Maps.CavesLankyCabin, name="Stacks of books on shelves", konglist=[Kongs.lanky], region=Regions.LankyCabin, locations=[[5, 1.0, 400, 72, 505], [5, 1.0, 150, 72, 335]]
+        group=93, map_id=Maps.CavesLankyCabin, name="Stacks of books on shelves in Lanky's cabin", konglist=[Kongs.lanky], region=Regions.LankyCabin, locations=[[5, 1.0, 400, 72, 505], [5, 1.0, 150, 72, 335]]
     ),
     ColoredBananaGroup(
-        group=94, map_id=Maps.CavesChunkyCabin, name="Stacks of books on shelves", konglist=[Kongs.chunky], region=Regions.ChunkyCabin, locations=[[5, 1.0, 177, 72, 116], [5, 1.0, 77, 72, 356]]
+        group=94, map_id=Maps.CavesChunkyCabin, name="Stacks of books on shelves in Chunky's cabin", konglist=[Kongs.chunky], region=Regions.ChunkyCabin, locations=[[5, 1.0, 177, 72, 116], [5, 1.0, 77, 72, 356]]
     ),
     ColoredBananaGroup(
-        group=95, map_id=Maps.CavesChunkyCabin, name="Books on floor and back shelf", konglist=[Kongs.chunky], region=Regions.ChunkyCabin, locations=[[5, 1.0, 402, 50, 561], [5, 1.0, 445, 15, 112]]
+        group=95, map_id=Maps.CavesChunkyCabin, name="Books on floor and back shelf in Chunky's cabin", konglist=[Kongs.chunky], region=Regions.ChunkyCabin, locations=[[5, 1.0, 402, 50, 561], [5, 1.0, 445, 15, 112]]
     ),
-    ColoredBananaGroup(group=96, map_id=Maps.CavesDiddyUpperCabin, name="Books on shelf near entrance", konglist=[Kongs.diddy], region=Regions.DiddyUpperCabin, locations=[[5, 1.0, 201, 70, 119]]),
-    ColoredBananaGroup(group=97, map_id=Maps.CavesDiddyUpperCabin, name="Books on shelf on back wall", konglist=[Kongs.diddy], region=Regions.DiddyUpperCabin, locations=[[5, 1.0, 469, 70, 606]]),
+    ColoredBananaGroup(group=96, map_id=Maps.CavesDiddyUpperCabin, name="Books on shelf near entrance in Diddy's upper cabin", konglist=[Kongs.diddy], region=Regions.DiddyUpperCabin, locations=[[5, 1.0, 201, 70, 119]]),
+    ColoredBananaGroup(group=97, map_id=Maps.CavesDiddyUpperCabin, name="Books on shelf on back wall in Diddy's upper cabin", konglist=[Kongs.diddy], region=Regions.DiddyUpperCabin, locations=[[5, 1.0, 469, 70, 606]]),
     ColoredBananaGroup(
-        group=98, map_id=Maps.CavesDonkeyCabin, name="On books on shelves", konglist=[Kongs.donkey], region=Regions.DonkeyCabin, locations=[[5, 1.0, 190, 70, 486], [5, 1.0, 143, 70, 119]]
+        group=98, map_id=Maps.CavesDonkeyCabin, name="On books on shelves in DK's cabin", konglist=[Kongs.donkey], region=Regions.DonkeyCabin, locations=[[5, 1.0, 190, 70, 486], [5, 1.0, 143, 70, 119]]
     ),
     ColoredBananaGroup(
         group=99,
@@ -1367,7 +1367,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.CrystalCavesMain,
         vanilla=True,
-        logic=lambda l: l.punch and l.chunky,
+        logic=lambda l: l.barrels and l.chunky,
         locations=[[5, 1.0, 1658.8216552734375, 291.8333435058594, 1007.8945922851562]],
     ),
     ColoredBananaGroup(

--- a/randomizer/Lists/CBLocations/FranticFactoryCBLocations.py
+++ b/randomizer/Lists/CBLocations/FranticFactoryCBLocations.py
@@ -527,7 +527,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.BeyondHatch,
         logic=lambda l: l.punch,
-        locations=[[5, 1.0, 2730, 52, 528]],
+        locations=[[5, 1.0, 2130, 52, 528]],
     ),
     ColoredBananaGroup(
         group=47,
@@ -541,7 +541,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=48,
         map_id=Maps.FranticFactory,
-        name="On box in stack of boxes to Candy/Cranky",
+        name="On box in stack of boxes to Candy/Cranky - left",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.BeyondHatch,
         locations=[[5, 1.0, 976, 52, 868]],
@@ -549,7 +549,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=49,
         map_id=Maps.FranticFactory,
-        name="On box in stack of boxes to Candy/Cranky",
+        name="On box in stack of boxes to Candy/Cranky - right",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.BeyondHatch,
         locations=[[5, 1.0, 972, 52, 628]],
@@ -1057,7 +1057,7 @@ ColoredBananaGroupList = [
         locations=[[5, 1.0, 540.67431640625, 623.0, 1692.7386474609375], [5, 1.0, 376.5771484375, 615.0, 1563.20947265625], [5, 1.0, 302.7023010253906, 615.0, 1410.3233642578125]],
     ),
     ColoredBananaGroup(
-        group=92,
+        group=91,
         map_id=Maps.FranticFactory,
         name="R&D upper walkway (Lanky)",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],

--- a/randomizer/Lists/CBLocations/FungiForestCBLocations.py
+++ b/randomizer/Lists/CBLocations/FungiForestCBLocations.py
@@ -931,7 +931,12 @@ ColoredBananaGroupList = [
         locations=[[5, 1.0, 2550, 885, 2186], [5, 1.0, 2636, 762, 1200]],
     ),
     ColoredBananaGroup(
-        group=80, map_id=Maps.ForestWinchRoom, name="On boxes in winch room", konglist=[Kongs.diddy], region=Regions.WinchRoom, locations=[[5, 1.0, 236, 55, 135], [5, 1.0, 342, 26, 394], [5, 1.0, 388, 26, 173]]
+        group=80,
+        map_id=Maps.ForestWinchRoom,
+        name="On boxes in winch room",
+        konglist=[Kongs.diddy],
+        region=Regions.WinchRoom,
+        locations=[[5, 1.0, 236, 55, 135], [5, 1.0, 342, 26, 394], [5, 1.0, 388, 26, 173]],
     ),
     ColoredBananaGroup(
         group=81,

--- a/randomizer/Lists/CBLocations/FungiForestCBLocations.py
+++ b/randomizer/Lists/CBLocations/FungiForestCBLocations.py
@@ -931,7 +931,7 @@ ColoredBananaGroupList = [
         locations=[[5, 1.0, 2550, 885, 2186], [5, 1.0, 2636, 762, 1200]],
     ),
     ColoredBananaGroup(
-        group=80, map_id=Maps.ForestWinchRoom, name="On boxes", konglist=[Kongs.diddy], region=Regions.WinchRoom, locations=[[5, 1.0, 236, 55, 135], [5, 1.0, 342, 26, 394], [5, 1.0, 388, 26, 173]]
+        group=80, map_id=Maps.ForestWinchRoom, name="On boxes in winch room", konglist=[Kongs.diddy], region=Regions.WinchRoom, locations=[[5, 1.0, 236, 55, 135], [5, 1.0, 342, 26, 394], [5, 1.0, 388, 26, 173]]
     ),
     ColoredBananaGroup(
         group=81,
@@ -979,7 +979,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=86,
         map_id=Maps.ForestThornvineBarn,
-        name="Near melon crate",
+        name="Near melon crate in thornvine area",
         konglist=[Kongs.donkey],
         region=Regions.ThornvineBarn,
         locations=[[1, 1.0, 512, 4, 620], [1, 1.0, 512, 4, 565], [1, 1.0, 512, 4, 510], [1, 1.0, 512, 4, 455], [1, 1.0, 512, 4, 400]],
@@ -1085,7 +1085,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=97,
         map_id=Maps.ForestMillAttic,
-        name="On boxes",
+        name="On boxes in Lanky attic",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.MillAttic,
         locations=[[5, 1.0, 398, 42, 437], [5, 1.0, 164, 32, 251]],
@@ -1513,7 +1513,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=128,
         map_id=Maps.ForestRafters,
-        name="Right side (Diddy)",
+        name="Rafters Right side (Diddy)",
         konglist=[Kongs.diddy],
         region=Regions.MillRafters,
         logic=lambda l: l.guitar,
@@ -1523,7 +1523,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=129,
         map_id=Maps.ForestRafters,
-        name="Left side (Diddy)",
+        name="Rafters Left side (Diddy)",
         konglist=[Kongs.diddy],
         region=Regions.MillRafters,
         logic=lambda l: l.guitar,

--- a/randomizer/Lists/CBLocations/GloomyGalleonCBLocations.py
+++ b/randomizer/Lists/CBLocations/GloomyGalleonCBLocations.py
@@ -340,6 +340,7 @@ ColoredBananaGroupList = [
         name="Cannon game room underwater",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.GalleonBeyondPineappleGate,
+        logic=lambda l: l.swim,
         locations=[[5, 1.2, 1245, 1530, 3289], [5, 1.2, 1360, 1495, 2561]],
     ),
     ColoredBananaGroup(
@@ -678,6 +679,7 @@ ColoredBananaGroupList = [
         name="In corner behind cactus above the water surface",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.Shipyard,
+        logic = lambda l: Events.WaterSwitch in l.Events,
         locations=[[5, 1.0, 4389, 1600, 778], [5, 1.0, 4605, 1600, 1038]],
     ),
     ColoredBananaGroup(
@@ -724,7 +726,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=61,
         map_id=Maps.GloomyGalleon,
-        name="Bottom of water near mermaid on seashells",
+        name="Bottom of water near mermaid on seashells (Right)",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.LighthouseUnderwater,
         locations=[[5, 1.2, 790, 148, 4175], [5, 1.2, 893, 148, 4161]],
@@ -732,7 +734,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=62,
         map_id=Maps.GloomyGalleon,
-        name="Bottom of water near mermaid on seashells",
+        name="Bottom of water near mermaid on seashells (Center)",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.LighthouseUnderwater,
         locations=[[5, 1.2, 1042, 148, 4196], [5, 1.2, 1136, 148, 4303], [5, 1.2, 1184, 148, 4444]],
@@ -740,7 +742,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=63,
         map_id=Maps.GloomyGalleon,
-        name="Bottom of water near mermaid on seashells",
+        name="Bottom of water near mermaid on seashells (Left)",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.LighthouseUnderwater,
         locations=[[5, 1.2, 1154, 148, 4574], [5, 1.2, 1058, 148, 4631]],
@@ -756,7 +758,7 @@ ColoredBananaGroupList = [
     ColoredBananaGroup(
         group=65,
         map_id=Maps.GloomyGalleon,
-        name="Mermaid area top of pilars on each side",
+        name="Mermaid area top of pillars on each side",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.LighthouseUnderwater,
         locations=[[5, 1.2, 889, 420, 4618], [5, 1.2, 714, 420, 4361]],

--- a/randomizer/Lists/CBLocations/GloomyGalleonCBLocations.py
+++ b/randomizer/Lists/CBLocations/GloomyGalleonCBLocations.py
@@ -679,7 +679,7 @@ ColoredBananaGroupList = [
         name="In corner behind cactus above the water surface",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.Shipyard,
-        logic = lambda l: Events.WaterSwitch in l.Events,
+        logic=lambda l: Events.WaterSwitch in l.Events,
         locations=[[5, 1.0, 4389, 1600, 778], [5, 1.0, 4605, 1600, 1038]],
     ),
     ColoredBananaGroup(

--- a/randomizer/Lists/CBLocations/JungleJapesCBLocations.py
+++ b/randomizer/Lists/CBLocations/JungleJapesCBLocations.py
@@ -947,24 +947,24 @@ ColoredBananaGroupList = [
         region=Regions.JungleJapesMain,
         locations=[[1, 1.0, 1204, 853, 2350], [1, 1.0, 1134, 853, 2300], [1, 1.0, 1041, 853, 2297], [1, 1.0, 929, 853, 2328], [1, 1.0, 907, 853, 2454]],
     ),
-    ColoredBananaGroup(
-        group=65,
-        map_id=Maps.JungleJapes,
-        name="Tiny's caged GB",
-        konglist=[Kongs.tiny],
-        region=Regions.JungleJapesMain,
-        logic=lambda l: Events.JapesTinySwitch in l.Events and l.Slam,
-        locations=[[5, 1.0, 1335, 285, 1974], [5, 1.0, 1300, 285, 1946]],
-    ),
-    ColoredBananaGroup(
-        group=66,
-        map_id=Maps.JungleJapes,
-        name="Lanky's caged GB",
-        konglist=[Kongs.lanky],
-        region=Regions.JungleJapesMain,
-        logic=lambda l: Events.JapesLankySwitch in l.Events and l.Slam,
-        locations=[[5, 1.0, 1140, 525, 2346], [5, 1.0, 1186, 525, 2326]],
-    ),
+    # ColoredBananaGroup(
+    #     group=65,
+    #     map_id=Maps.JungleJapes,
+    #     name="Tiny's caged GB",
+    #     konglist=[Kongs.tiny],
+    #     region=Regions.JungleJapesMain,
+    #     logic=lambda l: Events.JapesTinySwitch in l.Events and l.Slam,
+    #     locations=[[5, 1.0, 1335, 285, 1974], [5, 1.0, 1300, 285, 1946]],
+    # ),  # Temporarily disabled
+    # ColoredBananaGroup(
+    #     group=66,
+    #     map_id=Maps.JungleJapes,
+    #     name="Lanky's caged GB",
+    #     konglist=[Kongs.lanky],
+    #     region=Regions.JungleJapesMain,
+    #     logic=lambda l: Events.JapesLankySwitch in l.Events and l.Slam,
+    #     locations=[[5, 1.0, 1140, 525, 2346], [5, 1.0, 1186, 525, 2326]],
+    # ),  # Temporarily disabled
     ColoredBananaGroup(
         group=67,
         map_id=Maps.JungleJapes,
@@ -974,24 +974,24 @@ ColoredBananaGroupList = [
         logic=lambda l: l.vines,
         locations=[[5, 1.0, 801, 543, 2356], [5, 1.0, 729, 543, 2295], [5, 1.0, 774.623291015625, 543.0, 2313.9326171875]],
     ),
-    ColoredBananaGroup(
-        group=68,
-        map_id=Maps.JungleJapes,
-        name="Diddy's Caged GB",
-        konglist=[Kongs.diddy],
-        region=Regions.JungleJapesMain,
-        logic=lambda l: Events.JapesDiddySwitch1 in l.Events and l.Slam,
-        locations=[[5, 1.0, 2305, 525, 2101], [5, 1.0, 2310, 525, 2142]],
-    ),
-    ColoredBananaGroup(
-        group=69,
-        map_id=Maps.JungleJapes,
-        name="Chunky's Caged GB",
-        konglist=[Kongs.chunky],
-        region=Regions.JungleJapesMain,
-        logic=lambda l: Events.JapesChunkySwitch in l.Events and l.Slam,
-        locations=[[5, 1.0, 2335, 685, 2207], [5, 1.0, 2362, 685, 2253]],
-    ),
+    # ColoredBananaGroup(
+    #     group=68,
+    #     map_id=Maps.JungleJapes,
+    #     name="Diddy's Caged GB",
+    #     konglist=[Kongs.diddy],
+    #     region=Regions.JungleJapesMain,
+    #     logic=lambda l: Events.JapesDiddySwitch1 in l.Events and l.Slam,
+    #     locations=[[5, 1.0, 2305, 525, 2101], [5, 1.0, 2310, 525, 2142]],
+    # ),  # Temporarily disabled
+    # ColoredBananaGroup(
+    #     group=69,
+    #     map_id=Maps.JungleJapes,
+    #     name="Chunky's Caged GB",
+    #     konglist=[Kongs.chunky],
+    #     region=Regions.JungleJapesMain,
+    #     logic=lambda l: Events.JapesChunkySwitch in l.Events and l.Slam,
+    #     locations=[[5, 1.0, 2335, 685, 2207], [5, 1.0, 2362, 685, 2253]],
+    # ),  # Temporarily disabled
     ColoredBananaGroup(
         group=70,
         map_id=Maps.JungleJapes,
@@ -1745,7 +1745,7 @@ BalloonList = [
     Balloon(
         id=37,
         map_id=Maps.JungleJapes,
-        name="In boulder cave (Chunky)",
+        name="In boulder cave 1 (Chunky)",
         speed=4,
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.BeyondRambiGate,
@@ -1815,7 +1815,7 @@ BalloonList = [
     Balloon(
         id=44,
         map_id=Maps.JungleJapes,
-        name="In boulder cave (Chunky)",
+        name="In boulder cave 2 (Chunky)",
         speed=3,
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.BeyondRambiGate,
@@ -1825,7 +1825,7 @@ BalloonList = [
     Balloon(
         id=45,
         map_id=Maps.JungleJapes,
-        name="In boulder cave (Chunky)",
+        name="In boulder cave 3 (Chunky)",
         speed=3,
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.BeyondRambiGate,

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -158,9 +158,9 @@ LogicRegions = {
     ]),
 
     Regions.Anthill: Region("Anthill", "Owl Tree", Levels.FungiForest, False, -1, [
-        LocationLogic(Locations.ForestTinyAnthill, lambda l: (l.istiny or l.settings.free_trade_items) and l.oranges),
+        LocationLogic(Locations.ForestTinyAnthill, lambda l: (l.istiny or l.settings.free_trade_items) and (l.oranges or l.HasInstrument(Kongs.any))),
     ], [
-        Event(Events.Bean, lambda l: (l.istiny or l.settings.free_trade_items) and l.oranges),
+        Event(Events.Bean, lambda l: (l.istiny or l.settings.free_trade_items) and (l.oranges or l.HasInstrument(Kongs.any))),
     ], [
         TransitionFront(Regions.FungiForestMedals, lambda l: True),
         TransitionFront(Regions.HollowTreeArea, lambda l: True, Transitions.ForestAnthillToTree),

--- a/randomizer/Patching/EnemyRando.py
+++ b/randomizer/Patching/EnemyRando.py
@@ -388,11 +388,14 @@ def randomize_enemies(spoiler: Spoiler):
     # Define Enemies that can be placed in those classes
     enemy_placement_classes = {}
     banned_classes = []
+    no_ground_simple_selected = False
     for enemy_class in enemy_classes:
         class_list = []
         for enemy in enemy_classes[enemy_class]:
             if convertEnemyName(EnemyMetaData[enemy].name) in spoiler.settings.enemies_selected:
                 class_list.append(enemy)
+        if enemy_class == EnemySubtype.GroundSimple and len(class_list) == 0:
+            no_ground_simple_selected = True
         if len(class_list) == 0:
             # Nothing present, use backup
             for repl_type in replacement_priority[enemy_class]:
@@ -471,36 +474,38 @@ def randomize_enemies(spoiler: Spoiler):
                     for spawner in vanilla_spawners:
                         if spawner["enemy_id"] in class_types:
                             if cont_map_id != Maps.FranticFactory or spawner["index"] < 35 or spawner["index"] > 44:
-                                if cont_map_id != Maps.AztecTinyTemple or spawner["index"] < 20 or spawner["index"] > 23:
-                                    new_enemy_id = arr[sub_index]
-                                    sub_index += 1
-                                    if cont_map_id != Maps.ForestSpider or EnemyMetaData[new_enemy_id].aggro != 4:  # Prevent enemies being stuck in the ceiling
-                                        if new_enemy_id != Enemies.Book or cont_map_id not in (Maps.CavesDonkeyCabin, Maps.JapesLankyCave, Maps.AngryAztecLobby):
-                                            if new_enemy_id != Enemies.Kosha or cont_map_id not in (Maps.CavesDiddyLowerCabin, Maps.CavesTinyCabin):
-                                                if new_enemy_id != Enemies.Guard or cont_map_id not in (Maps.CavesDiddyLowerCabin, Maps.CavesTinyIgloo, Maps.CavesTinyCabin):
-                                                    ROM().seek(cont_map_spawner_address + spawner["offset"])
-                                                    ROM().writeMultipleBytes(new_enemy_id, 1)
-                                                    if new_enemy_id in EnemyMetaData.keys():
-                                                        ROM().seek(cont_map_spawner_address + spawner["offset"] + 0x10)
-                                                        ROM().writeMultipleBytes(EnemyMetaData[new_enemy_id].aggro, 1)
-                                                        if new_enemy_id == Enemies.RoboKremling:
-                                                            ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xB)
-                                                            ROM().writeMultipleBytes(0xC8, 1)
-                                                        ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xF)
-                                                        default_scale = int.from_bytes(ROM().readBytes(1), "big")
-                                                        if EnemyMetaData[new_enemy_id].size_cap > 0:
-                                                            if default_scale > EnemyMetaData[new_enemy_id].size_cap:
+                                new_enemy_id = arr[sub_index]
+                                sub_index += 1
+                                if new_enemy_id != Enemies.Book or cont_map_id not in (Maps.CavesDonkeyCabin, Maps.JapesLankyCave, Maps.AngryAztecLobby):
+                                    if new_enemy_id != Enemies.Kosha or cont_map_id not in (Maps.CavesDiddyLowerCabin, Maps.CavesTinyCabin):
+                                        if new_enemy_id != Enemies.Guard or cont_map_id not in (Maps.CavesDiddyLowerCabin, Maps.CavesTinyIgloo, Maps.CavesTinyCabin):
+                                            if cont_map_id != Maps.AztecTinyTemple or spawner["index"] < 20 or spawner["index"] > 23 or not no_ground_simple_selected:
+                                                if cont_map_id != Maps.CastleBallroom or spawner["index"] > 5 or not no_ground_simple_selected:
+                                                    if cont_map_id != Maps.CastleLibrary or spawner["index"] > 4 or not no_ground_simple_selected:
+                                                        if cont_map_id != Maps.ForestSpider or EnemyMetaData[new_enemy_id].aggro != 4:  # Prevent enemies being stuck in the ceiling
+                                                            ROM().seek(cont_map_spawner_address + spawner["offset"])
+                                                            ROM().writeMultipleBytes(new_enemy_id, 1)
+                                                            if new_enemy_id in EnemyMetaData.keys():
+                                                                ROM().seek(cont_map_spawner_address + spawner["offset"] + 0x10)
+                                                                ROM().writeMultipleBytes(EnemyMetaData[new_enemy_id].aggro, 1)
+                                                                if new_enemy_id == Enemies.RoboKremling:
+                                                                    ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xB)
+                                                                    ROM().writeMultipleBytes(0xC8, 1)
                                                                 ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xF)
-                                                                ROM().writeMultipleBytes(EnemyMetaData[new_enemy_id].size_cap, 1)
-                                                        if spoiler.settings.enemy_speed_rando:
-                                                            min_speed = EnemyMetaData[new_enemy_id].min_speed
-                                                            max_speed = EnemyMetaData[new_enemy_id].max_speed
-                                                            if min_speed > 0 and max_speed > 0:
-                                                                ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xD)
-                                                                agg_speed = random.randint(min_speed, max_speed)
-                                                                ROM().writeMultipleBytes(agg_speed, 1)
-                                                                ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xC)
-                                                                ROM().writeMultipleBytes(random.randint(min_speed, agg_speed), 1)
+                                                                default_scale = int.from_bytes(ROM().readBytes(1), "big")
+                                                                if EnemyMetaData[new_enemy_id].size_cap > 0:
+                                                                    if default_scale > EnemyMetaData[new_enemy_id].size_cap:
+                                                                        ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xF)
+                                                                        ROM().writeMultipleBytes(EnemyMetaData[new_enemy_id].size_cap, 1)
+                                                                if spoiler.settings.enemy_speed_rando:
+                                                                    min_speed = EnemyMetaData[new_enemy_id].min_speed
+                                                                    max_speed = EnemyMetaData[new_enemy_id].max_speed
+                                                                    if min_speed > 0 and max_speed > 0:
+                                                                        ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xD)
+                                                                        agg_speed = random.randint(min_speed, max_speed)
+                                                                        ROM().writeMultipleBytes(agg_speed, 1)
+                                                                        ROM().seek(cont_map_spawner_address + spawner["offset"] + 0xC)
+                                                                        ROM().writeMultipleBytes(random.randint(min_speed, agg_speed), 1)
             if spoiler.settings.enemy_rando and cont_map_id in minigame_maps_total:
                 tied_enemy_list = []
                 if cont_map_id in minigame_maps_easy:
@@ -623,6 +628,12 @@ def randomize_enemies(spoiler: Spoiler):
                     check = True
                     if cont_map_id == Maps.AztecTinyTemple and spawner["index"] < 17:
                         # Prevent One-Time-Only Enemies in Tiny Temple from being required
+                        check = False
+                    if cont_map_id == Maps.CastleBallroom and spawner["index"] < 6:
+                        # Prevent One-Time-Only Enemies in Castle Ball Room from being required
+                        check = False
+                    if cont_map_id == Maps.CastleLibrary and spawner["index"] < 5:
+                        # Prevent One-Time-Only Enemies in Castle Library from being required
                         check = False
                     if cont_map_id == Maps.AztecTinyTemple and spawner["index"] > 19 and spawner["index"] < 24:
                         # Prevent One-Time-Only Enemies in Tiny Temple from being required

--- a/randomizer/Patching/EnemyRando.py
+++ b/randomizer/Patching/EnemyRando.py
@@ -630,7 +630,7 @@ def randomize_enemies(spoiler: Spoiler):
                         # Prevent One-Time-Only Enemies in Tiny Temple from being required
                         check = False
                     if cont_map_id == Maps.CastleBallroom and spawner["index"] < 6:
-                        # Prevent One-Time-Only Enemies in Castle Ball Room from being required
+                        # Prevent One-Time-Only Enemies in Castle BallRoom from being required
                         check = False
                     if cont_map_id == Maps.CastleLibrary and spawner["index"] < 5:
                         # Prevent One-Time-Only Enemies in Castle Library from being required


### PR DESCRIPTION
-Made sure one-time-only enemies in Castle's Library and Museum are not required for Kremling Kapture
-Re-introduced enemy rando to Tiny's room in tiny temple, if at least 1 suitable enemy type is selected. (same goes for Library and Ball Room)
-Added instrument to Fungi Anthill logic
-Shifted an out of bounds CB bunch back into bounds
-Temporarily disabled the CB bunches in Japes' cage until access to them can be guaranteed
-A few CB name changes for readability
-A stray typo fix or two