### PR TITLE
Dynamic Path Hint Quantity

### DIFF
--- a/templates/base.html.jinja2
+++ b/templates/base.html.jinja2
@@ -9,9 +9,12 @@
     <meta Http-Equiv="Cache-directive: no-cache" />
     <link href="./static/img/dk.png" rel="icon" />
     <title>DK64 Randomizer</title>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/11.0.2/bootstrap-slider.min.js"></script>
+    <script type="text/javascript"
+            src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script type="text/javascript"
+            src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"></script>
+    <script type="text/javascript"
+            src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/11.0.2/bootstrap-slider.min.js"></script>
     <script type="text/javascript" src="static/js/izoColorPicker.js"></script>
     <script type="text/javascript" src="static/js/md5.min.js"></script>
     <script type="text/javascript" src="static/js/loggly.tracker-2.2.4.min.js"></script>
@@ -77,7 +80,7 @@
                              aria-valuemin="0"
                              aria-valuemax="100"
                              id="patchprogress"
-                             style="width: 0%;">
+                             style="width: 0%">
                         </div>
                         <small id="progress-text"
                                style="color:black"
@@ -90,9 +93,12 @@
     <img src="./static/img/logo.png"
          alt="DK64 Randomizer"
          class="center_image"
-         style="cursor: pointer; margin-top: 70px"
+         style="cursor: pointer;
+                margin-top: 70px"
          onClick="render_page('./index.html')"/>
-    <div style="width: 80%; min-width: 400px; max-width: 1500px"
+    <div style="width: 80%;
+                min-width: 400px;
+                max-width: 1500px"
          class="center">
         <div class="card bg-dark" style="max-width: 1500px">
             <form id="form" action="/" method="POST">
@@ -226,8 +232,7 @@
                                     </div>
                                     <div class="row">
                                         <div class="flex-container" style="justify-content: center;">
-                                            <div class="form-check form-switch item-switch"
-                                                 style="text-align: center;">
+                                            <div class="form-check form-switch item-switch" style="text-align: center">
                                                 <label data-toggle="tooltip"
                                                        title="Used for Races to download generated ROM as patch file.">
                                                     <input class="form-check-input"
@@ -238,8 +243,7 @@
                                                     Generate Patch File
                                                 </label>
                                             </div>
-                                            <div class="form-check form-switch item-switch"
-                                                 style="text-align: center;">
+                                            <div class="form-check form-switch item-switch" style="text-align: center">
                                                 <label data-toggle="tooltip"
                                                        title="This option enables spoiler log files to be created on randomizer generation.">
                                                     <input class="form-check-input"
@@ -259,9 +263,9 @@
                                         </label>
                                         <div class="input-group mb-3 file-select"
                                              style="width: 50%;
-                                                    margin: 0 auto;">
+                                                    margin: 0 auto">
                                             <div class="input-group-text choose-file"
-                                                 style="background-color: #6c757d;">
+                                                 style="background-color: #6c757d">
                                                 <input class="btn btn-primary file-button"
                                                        type="button"
                                                        value="Choose File"
@@ -281,7 +285,7 @@
                                            class="btn btn-primary"
                                            style="width: 60%;
                                                   height: 50px;
-                                                  text-align: center;"
+                                                  text-align: center"
                                            type="button"
                                            value="Generate Seed"/>
                                 </div>
@@ -304,16 +308,16 @@
                                            style="margin-right: 5px;
                                                   width: 50%;
                                                   height: 100%;
-                                                  margin: 0 auto;"/>
+                                                  margin: 0 auto"/>
                                     <div class="row">
                                         <label for="input-file-rom_1" class="select-title">
                                             ROM File
                                         </label>
                                         <div class="input-group mb-3 file-select"
                                              style="width: 50%;
-                                                    margin: 0 auto;">
+                                                    margin: 0 auto">
                                             <div class="input-group-text choose-file"
-                                                 style="background-color: #6c757d;">
+                                                 style="background-color: #6c757d">
                                                 <input class="btn btn-primary file-button"
                                                        type="button"
                                                        value="Choose File"
@@ -334,7 +338,7 @@
                                        class="btn btn-primary"
                                        style="width: 60%;
                                               height: 50px;
-                                              text-align: center;"
+                                              text-align: center"
                                        type="button"
                                        value="Generate Seed from Patch"/>
                             </div>
@@ -359,9 +363,9 @@
                                         </label>
                                         <div class="input-group mb-3 file-select"
                                              style="width: 50%;
-                                                    margin: 0 auto;">
+                                                    margin: 0 auto">
                                             <div class="input-group-text choose-file"
-                                                 style="background-color: #6c757d;">
+                                                 style="background-color: #6c757d">
                                                 <input class="btn btn-primary file-button"
                                                        type="button"
                                                        value="Choose File"
@@ -382,7 +386,7 @@
                                        class="btn btn-primary"
                                        style="width: 60%;
                                               height: 50px;
-                                              text-align: center;"
+                                              text-align: center"
                                        type="button"
                                        value="Generate Seed from history"/>
                             </div>
@@ -397,17 +401,17 @@
     <div class="center">
         <a href="https://github.com/2dos/DK64-Randomizer"
            target="_blank"
-           style="text-decoration: none;">
+           style="text-decoration: none">
             <img src="./static/img/github.png" alt="GitHub" />
         </a>
         <a href="https://github.com/2dos/DK64-Randomizer/wiki"
            target="_blank"
-           style="text-decoration: none;">
+           style="text-decoration: none">
             <img src="./static/img/wiki.png" alt="Wiki" />
         </a>
         <a href="https://discord.dk64randomizer.com"
            target="_blank"
-           style="text-decoration: none;">
+           style="text-decoration: none">
             <img src="./static/img/discord.png" alt="Discord" />
         </a>
     </div>
@@ -422,13 +426,20 @@
         DK64Randomizer.com does not distribute copyright material.
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/toastify-js@1.11.2/src/toastify.js"></script>
+    <script type="text/javascript"
+            src="https://cdn.jsdelivr.net/npm/toastify-js@1.11.2/src/toastify.js"></script>
     <script type="text/javascript" src="./static/js/webworker_main.js" defer></script>
     <script type="text/javascript" src="./static/js/rompatcher/crc.js" defer></script>
-    <script type="text/javascript" src="./static/js/rompatcher/formats/bps.js" defer></script>
+    <script type="text/javascript"
+            src="./static/js/rompatcher/formats/bps.js"
+            defer></script>
     <script type="text/javascript" src="./static/js/rompatcher/MarcFile.js" defer></script>
-    <script type="text/javascript" src="./static/js/rompatcher/RomPatcher.js" defer></script>
-    <script type="text/javascript" src="./static/js/rompatcher/filesaver.js" defer></script>
+    <script type="text/javascript"
+            src="./static/js/rompatcher/RomPatcher.js"
+            defer></script>
+    <script type="text/javascript"
+            src="./static/js/rompatcher/filesaver.js"
+            defer></script>
     <script type="text/javascript" src="./static/js/initalize.js"></script>
     <script>
         function render_page(page) {

--- a/templates/cosmetics.html.jinja2
+++ b/templates/cosmetics.html.jinja2
@@ -519,7 +519,7 @@
             }
         })
     })
-    
+
     $('.nav-tabs').click(function() {
         var settings = (document.cookie).split('saved_settings=')
         if (typeof settings[1] !== 'undefined') {

--- a/templates/difficulty.html.jinja2
+++ b/templates/difficulty.html.jinja2
@@ -17,7 +17,7 @@
                                    max="200"
                                    name="blocker_{{ i }}"
                                    id="blocker_{{ i }}"
-                                   style="width: 100%;"
+                                   style="width: 100%"
                                    value="{{ i+1 }}"
                                    type="number"
                                    data-toggle="tooltip"
@@ -30,7 +30,7 @@
                                        max="500"
                                        name="troff_{{ i }}"
                                        id="troff_{{ i }}"
-                                       style="width: 100%;"
+                                       style="width: 100%"
                                        value="{{ i+1 }}"
                                        type="number"
                                        data-toggle="tooltip"
@@ -171,7 +171,7 @@
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"
                            title="Only relevant in Level Order shuffle. Generally increase the values randomly rolled by B. Lockers, making them closer to the total number of available GBs."
-                           style="text-align: left;">
+                           style="text-align: left">
                         <input class="form-check-input"
                                type="checkbox"
                                name="hard_blockers"
@@ -183,7 +183,7 @@
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"
                            title="Increase the minimum values rollable by Troff n Scoff."
-                           style="text-align: left;">
+                           style="text-align: left">
                         <input class="form-check-input"
                                type="checkbox"
                                name="hard_troff_n_scoff"
@@ -195,7 +195,7 @@
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"
                            title="Level Order randomizer only. Shuffles levels without regard for key acquisition order or steady Kong progression. May have Kongs locked very deep into seeds. Likely to have high cost Troff n Scoffs that require returning to levels later."
-                           style="text-align: left;">
+                           style="text-align: left">
                         <input class="form-check-input"
                                type="checkbox"
                                name="hard_level_progression"
@@ -207,7 +207,7 @@
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"
                            title="Makes certain enemies tougher:&#10;- Small Spiders will now spawn one of 4 projectiles randomly.&#10;- Kasplats have a 6% higher chance to shockwave.&#10;- Guards have a higher health."
-                           style="text-align: left;">
+                           style="text-align: left">
                         <input class="form-check-input"
                                type="checkbox"
                                name="hard_enemies"

--- a/templates/frontpage.html.jinja2
+++ b/templates/frontpage.html.jinja2
@@ -6,7 +6,8 @@
               content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
         <meta name="description" content="" />
         <meta name="author" content="" />
-        <script src="https://use.fontawesome.com/releases/v5.15.4/js/all.js" crossorigin="anonymous"></script>
+        <script src="https://use.fontawesome.com/releases/v5.15.4/js/all.js"
+                crossorigin="anonymous"></script>
         <link href="https://fonts.googleapis.com/css?family=Catamaran:100,200,300,400,500,600,700,800,900"
               rel="stylesheet"/>
         <link href="https://fonts.googleapis.com/css?family=Lato:100,100i,300,300i,400,400i,700,700i,900,900i"
@@ -112,126 +113,126 @@
                                     <li>Difficulty Modifiers</li>
                                 </ul>
                                 <p>And much more!</p>
-                            <a class="btn btn-success rounded-pill"
-                               href="https://github.com/2dos/DK64-Randomizer/wiki/Feature-List">Full Feature List</a
-                            >
+                                <a class="btn btn-success rounded-pill"
+                                   href="https://github.com/2dos/DK64-Randomizer/wiki/Feature-List">Full Feature List</a
+                                    >
+                                </div>
+                            </div>
+                            <div class="col-lg-6 order-lg-1">
+                                <div class="p-5">
+                                    <h2 class="display-6">Compatibility</h2>
+                                    <p>
+                                        The NTSC-U version of the game (the US release) is the
+                                        compatible DK64 version for DK64 Randomizer. The NTSC-J
+                                        (Japan) and PAL (Europe) versions of the game are
+                                        incompatible. The following are the supported platforms:
+                                    </p>
+                                    <ul>
+                                        <li>Most Nintendo 64 Flashcarts</li>
+                                        <li>Wii U VC inject</li>
+                                        <li>Bizhawk DK64 Fork</li>
+                                        <li>Project 64 Version 3.0 or above</li>
+                                    </ul>
+                                    <p>
+                                        Other platforms may be compatible but are not supported at
+                                        this time. Check out the video for setting up DK64 Randomizer.
+                                    </p>
+                                    <a class="btn btn-success rounded-pill"
+                                       href="https://github.com/2dos/DK64-Randomizer/wiki/Consoles-and-Emulators">Wiki Version of Setup</a
+                                        >
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                    <div class="col-lg-6 order-lg-1">
-                        <div class="p-5">
-                            <h2 class="display-6">Compatibility</h2>
-                            <p>
-                                The NTSC-U version of the game (the US release) is the
-                                compatible DK64 version for DK64 Randomizer. The NTSC-J
-                                (Japan) and PAL (Europe) versions of the game are
-                                incompatible. The following are the supported platforms:
-                            </p>
-                            <ul>
-                                <li>Most Nintendo 64 Flashcarts</li>
-                                <li>Wii U VC inject</li>
-                                <li>Bizhawk DK64 Fork</li>
-                                <li>Project 64 Version 3.0 or above</li>
-                            </ul>
-                            <p>
-                                Other platforms may be compatible but are not supported at
-                                this time. Check out the video for setting up DK64 Randomizer.
-                            </p>
-                        <a class="btn btn-success rounded-pill"
-                           href="https://github.com/2dos/DK64-Randomizer/wiki/Consoles-and-Emulators">Wiki Version of Setup</a
-                        >
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-    <section id="community">
-        <div class="container px-5">
-            <div class="row gx-5 align-items-center">
-                <div class="col-lg-6 order-lg-2">
-                    <div class="p-5">
-                        <h2 class="display-6">Development</h2>
-                        <p>
-                            Interested in contributing various features to DK64
-                            randomizer? Want to run DK64 randomizer locally? Just want to
-                            check out the inner workings? The DK64 Randomizer project is
-                            open source and is available for view on Github!
-                        </p>
-                    <a class="btn btn-success rounded-pill"
-                       href="https://github.com/2dos/DK64-Randomizer">View on Github</a
-                    >
-                </div>
-            </div>
-            <div class="col-lg-6 order-lg-1">
-                <div class="p-5">
-                    <h2 class="display-6">
-                        Community
-                    </h2>
-                    <p>
-                        The DK64 Randomizer Discord server is available to talk about
-                        DK64 Randomizer with other players! Share your playthrough,
-                        get help, and talk about strategies and tricks!
-                    </p>
-                <a class="btn btn-success rounded-pill"
-                   href="https://discord.dk64randomizer.com">Join the Discord</a
-                >
-            </div>
-        </div>
-    </div>
-</div>
-</section>
-</div>
-<footer id="footer">
-    <div class="center">
-        <a href="https://github.com/2dos/DK64-Randomizer"
-           target="_blank"
-           style="text-decoration: none;">
-            <img src="./static/img/github.png" alt="GitHub" />
-        </a>
-        <a href="https://github.com/2dos/DK64-Randomizer/wiki"
-           target="_blank"
-           style="text-decoration: none;">
-            <img src="./static/img/wiki.png" alt="Wiki" />
-        </a>
-        <a href="https://discord.dk64randomizer.com"
-           target="_blank"
-           style="text-decoration: none;">
-            <img src="./static/img/discord.png" alt="Discord" />
-        </a>
-    </div>
-    <div class="center" style="font-size: small; color:#e3e3e3;">
-        <a id="live-version">DK64 Randomizer |</a>
-        <a href="https://dev.dk64randomizer.com">Dev Branch</a>
-        <br />
-        Randomizer by 2dos and Ballaam | Web Generator by Killklli
-        <br />
-        In-game characters, images and logos copyright © 1999-2021 Nintendo or Rareware respectively.
-        <br />
-        DK64Randomizer.com does not distribute copyright material.
-    </div>
-</footer>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-<script>
-    function render_page(page) {
-        xmlhttp = new XMLHttpRequest();
-        xmlhttp.open("GET", page, false);
-        xmlhttp.send();
-        var data = xmlhttp.responseText;
-        document.documentElement.innerHTML = "";
-        document.open();
-        document.write(data);
-        document.close();
-        history.pushState({}, "page 1", "randomizer.html");
-    }
-    if (window.location.protocol != 'https:') {
-        if (location.hostname != "localhost" && location.hostname != "127.0.0.1") {
-            location.href = location.href.replace("http://", "https://");
-        }
-    }
-    $(function() {
-        $('[data-toggle="tooltip"]').tooltip({
-            trigger: 'hover'
-        })
-    })
-</script>
-</body>
-</html>
+                    </section>
+                    <section id="community">
+                        <div class="container px-5">
+                            <div class="row gx-5 align-items-center">
+                                <div class="col-lg-6 order-lg-2">
+                                    <div class="p-5">
+                                        <h2 class="display-6">Development</h2>
+                                        <p>
+                                            Interested in contributing various features to DK64
+                                            randomizer? Want to run DK64 randomizer locally? Just want to
+                                            check out the inner workings? The DK64 Randomizer project is
+                                            open source and is available for view on Github!
+                                        </p>
+                                        <a class="btn btn-success rounded-pill"
+                                           href="https://github.com/2dos/DK64-Randomizer">View on Github</a
+                                            >
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6 order-lg-1">
+                                        <div class="p-5">
+                                            <h2 class="display-6">
+                                                Community
+                                            </h2>
+                                            <p>
+                                                The DK64 Randomizer Discord server is available to talk about
+                                                DK64 Randomizer with other players! Share your playthrough,
+                                                get help, and talk about strategies and tricks!
+                                            </p>
+                                            <a class="btn btn-success rounded-pill"
+                                               href="https://discord.dk64randomizer.com">Join the Discord</a
+                                                >
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </section>
+                        </div>
+                        <footer id="footer">
+                            <div class="center">
+                                <a href="https://github.com/2dos/DK64-Randomizer"
+                                   target="_blank"
+                                   style="text-decoration: none">
+                                    <img src="./static/img/github.png" alt="GitHub" />
+                                </a>
+                                <a href="https://github.com/2dos/DK64-Randomizer/wiki"
+                                   target="_blank"
+                                   style="text-decoration: none">
+                                    <img src="./static/img/wiki.png" alt="Wiki" />
+                                </a>
+                                <a href="https://discord.dk64randomizer.com"
+                                   target="_blank"
+                                   style="text-decoration: none">
+                                    <img src="./static/img/discord.png" alt="Discord" />
+                                </a>
+                            </div>
+                            <div class="center" style="font-size: small; color:#e3e3e3;">
+                                <a id="live-version">DK64 Randomizer |</a>
+                                <a href="https://dev.dk64randomizer.com">Dev Branch</a>
+                                <br />
+                                Randomizer by 2dos and Ballaam | Web Generator by Killklli
+                                <br />
+                                In-game characters, images and logos copyright © 1999-2021 Nintendo or Rareware respectively.
+                                <br />
+                                DK64Randomizer.com does not distribute copyright material.
+                            </div>
+                        </footer>
+                        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+                        <script>
+                            function render_page(page) {
+                                xmlhttp = new XMLHttpRequest();
+                                xmlhttp.open("GET", page, false);
+                                xmlhttp.send();
+                                var data = xmlhttp.responseText;
+                                document.documentElement.innerHTML = "";
+                                document.open();
+                                document.write(data);
+                                document.close();
+                                history.pushState({}, "page 1", "randomizer.html");
+                            }
+                            if (window.location.protocol != 'https:') {
+                                if (location.hostname != "localhost" && location.hostname != "127.0.0.1") {
+                                    location.href = location.href.replace("http://", "https://");
+                                }
+                            }
+                            $(function() {
+                                $('[data-toggle="tooltip"]').tooltip({
+                                    trigger: 'hover'
+                                })
+                            })
+                        </script>
+                    </body>
+                </html>

--- a/templates/getting_started.html.jinja2
+++ b/templates/getting_started.html.jinja2
@@ -42,7 +42,7 @@
                     <h2 class="select-title">
                         <img src="./static/img/GodsIntendedConsole.png"
                              alt="Setup"
-                             style="width:50px;"/>
+                             style="width:50px"/>
                         <a href="https://github.com/2dos/DK64-Randomizer/wiki/Consoles-and-Emulators"
                            target="_blank">Console and Emulator Setup</a>
                     </h2>
@@ -51,7 +51,7 @@
                     <h2 class="select-title">
                         <img src="./static/img/EmoTracker.ico"
                              alt="BananaTracker"
-                             style="width:50px;"/>
+                             style="width:50px"/>
                         <a href="https://github.com/2dos/bananatracker" target="_blank">BananaTracker</a>
                     </h2>
                 </div>
@@ -65,7 +65,7 @@
             trigger: 'hover'
         })
     })
-    
+
     $('#presets').on('change', function() {
         var selected = $("#presets option:selected").text();
         if (selected == "Suggested") $("#output").html("- Suggested: Level Order Randomizer of shorter length that showcases a lot of the randomization options while keeping the seed accessible. Moves are in randomized locations with Low prices. Requires 40 GBs to enter Helm and shutoff the Blast-o-Matic. Good Place to start.")

--- a/templates/macros.html.jinja2
+++ b/templates/macros.html.jinja2
@@ -65,27 +65,27 @@
 <script>
     $('#{{ name }}_selected option').mousedown(function(e) {
         var el = e.target
-    
+
         $(this).prop('selected', !$(this).prop('selected'));
         $(this).trigger('change');
-    
+
         // fixes erratic scroll behavior in Chrome
         var scrollTop = el.parentNode.scrollTop;
         setTimeout(() => el.parentNode.scrollTo(0, scrollTop), 0);
-    
+
         return false;
     });
-    
+
     $('#{{ name }}_select_all').click(function() {
         $('#{{ name }}_selected option').prop('selected', true);
         $('#{{ name }}_selected').trigger('change');
     });
-    
+
     $('#{{ name }}_reset').click(function() {
         $('#{{ name }}_selected option:selected').prop('selected', false);
         $('#{{ name }}_selected').trigger('change');
     });
-    
+
     $('#{{ name }}_search_box').keyup(function() {
         var keyword = document.getElementById("{{ name }}_search_box").value;
         var select = document.getElementById("{{ name }}_selected");

--- a/templates/nav-tabs.html.jinja2
+++ b/templates/nav-tabs.html.jinja2
@@ -66,7 +66,7 @@
             type="button"
             role="tab"
             aria-controls="nav-settings"
-            style="display: none;"
+            style="display: none"
             aria-selected="false">
         <p class="select-title">Seed Info</p>
     </button>

--- a/templates/overworld.html.jinja2
+++ b/templates/overworld.html.jinja2
@@ -361,7 +361,7 @@
                                    max="100"
                                    name="medal_cb_req"
                                    id="medal_cb_req"
-                                   style="width: 15%;"
+                                   style="width: 15%"
                                    class="form-control center-div"
                                    type="number"
                                    data-toggle="tooltip"
@@ -375,7 +375,7 @@
                                    max="40"
                                    name="medal_requirement"
                                    id="medal_requirement"
-                                   style="width: 15%;"
+                                   style="width: 15%"
                                    class="form-control center-div"
                                    type="number"
                                    data-toggle="tooltip"
@@ -413,7 +413,7 @@
                                    max="40"
                                    name="rareware_gb_fairies"
                                    id="rareware_gb_fairies"
-                                   style="width: 15%;"
+                                   style="width: 15%"
                                    class="form-control center-div"
                                    type="number"
                                    data-toggle="tooltip"
@@ -435,7 +435,7 @@
                     toggle_clicks()
                 }, 200);
             })
-            
+
             function toggle_clicks() {
                 if (document.getElementById("krool_random").checked === true) {
                     $("#krool_phase_count").slider("disable")

--- a/templates/settings.html.jinja2
+++ b/templates/settings.html.jinja2
@@ -33,7 +33,7 @@
             <div class="card bg-dark center rounded"
                  style="width: 90%;
                         height: 80%;
-                        min-height: 450px;">
+                        min-height: 450px">
                 <div id="spoiler_log_text"></div>
             </div>
         </div>

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -90,7 +90,7 @@ def generate_lo_rando_race_settings():
     data["helm_phase_count"] = 3  # usually 3
     data["krool_access"] = True  # usually True - this is the weirdly named key 8 required setting
     data["keys_random"] = False  # key count is random setting
-    data["krool_key_count"] = 8  # usually 5
+    data["krool_key_count"] = 5  # usually 5
     data["starting_random"] = False  # starting kong count is random setting
     data["starting_kongs_count"] = 2  # usually 2
 


### PR DESCRIPTION
The number of path hints per key you get is now based on how long the path is to that Key. This should cut down on useless hints, particularly when keys are in shops, and give extra help when most needed on long dependency chains.

Some other lint-related changes in here in the jinja.