### PR TITLE
Kong Item Rando Hints

### DIFF
--- a/randomizer/CollectibleLogicFiles/CreepyCastle.py
+++ b/randomizer/CollectibleLogicFiles/CreepyCastle.py
@@ -32,7 +32,7 @@ LogicRegions = {
         Collectible(Collectibles.coin, Kongs.donkey, lambda l: True, None, 5),
     ],
     Regions.CastleTree: [
-        Collectible(Collectibles.bunch, Kongs.donkey, lambda l: True, None, 1),  # On plank in water
+        Collectible(Collectibles.bunch, Kongs.donkey, lambda l: l.coconut, None, 1),  # On plank in water
         Collectible(Collectibles.balloon, Kongs.donkey, lambda l: l.coconut, None, 1),  # By BP
         Collectible(Collectibles.bunch, Kongs.chunky, lambda l: True, None, 1),  # By punchable wall
         Collectible(Collectibles.balloon, Kongs.chunky, lambda l: (l.punch or l.phasewalk) and l.pineapple, None, 1),  # In Chunky's room

--- a/randomizer/Enums/HintType.py
+++ b/randomizer/Enums/HintType.py
@@ -15,6 +15,7 @@ class HintType(IntEnum):
     KongLocation = auto()
     MedalsRequired = auto()
     Entrance = auto()
+    RequiredKongHint = auto()
     RequiredKeyHint = auto()
     RequiredWinConditionHint = auto()
     FullShopWithItems = auto()

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -555,7 +555,11 @@ def CalculateFoolish(spoiler, WothLocations):
             continue
         # Check the item to see if it locks *any* progression (even non-critical)
         Reset()
-        LogicVariables.BanItem(item)  # Ban this item from being picked up
+        # Because of how much overlap there is between these two, either they're both foolish or neither is
+        if item in (Items.HomingAmmo, Items.SniperSight):
+            LogicVariables.BanItems([Items.HomingAmmo, Items.SniperSight])
+        else:
+            LogicVariables.BanItems([item])  # Ban this item from being picked up
         GetAccessibleLocations(spoiler.settings, [], SearchMode.GetReachable)  # Check what's reachable
         if LogicVariables.HasAllItems():  # If you still have all the items, this one blocks no progression and is foolish
             foolishItems.append(item)
@@ -1469,33 +1473,11 @@ def FillKongsAndMoves(spoiler):
         if spoiler.settings.training_barrels == "shuffled":
             emptyTrainingBarrels = [loc for loc in TrainingBarrelLocations if LocationList[loc].item is None]
             if len(emptyTrainingBarrels) > 0:
-                # Find the list of shops that have a kong move in them
+                # Find the list of locations that have a kong move in them
                 kongMoveLocationsList = []
-                for location in DonkeyMoveLocations:
-                    item_at_location = LocationList[location].item
-                    if item_at_location is not None and item_at_location != Items.NoItem:
-                        kongMoveLocationsList.append(location)
-                for location in DiddyMoveLocations:
-                    item_at_location = LocationList[location].item
-                    if item_at_location is not None and item_at_location != Items.NoItem:
-                        kongMoveLocationsList.append(location)
-                for location in LankyMoveLocations:
-                    item_at_location = LocationList[location].item
-                    if item_at_location is not None and item_at_location != Items.NoItem:
-                        kongMoveLocationsList.append(location)
-                for location in TinyMoveLocations:
-                    item_at_location = LocationList[location].item
-                    if item_at_location is not None and item_at_location != Items.NoItem:
-                        kongMoveLocationsList.append(location)
-                for location in ChunkyMoveLocations:
-                    item_at_location = LocationList[location].item
-                    if item_at_location is not None and item_at_location != Items.NoItem:
-                        kongMoveLocationsList.append(location)
-                # If no shops have a kong move (can happen in item rando), then we gotta dig deeper for moves - this can place some shared moves earlier but that's cool too
-                if len(kongMoveLocationsList) == 0:
-                    for location_id, location in LocationList.items():
-                        if location.item in ItemPool.AllKongMoves():
-                            kongMoveLocationsList.append(location_id)
+                for location_id, location in LocationList.items():
+                    if location.item in ItemPool.AllKongMoves() and location_id not in TrainingBarrelLocations:
+                        kongMoveLocationsList.append(location_id)
                 # Worth noting that moving a move to the training barrels will always make it more accessible, and thus doesn't need any additional logic
                 for emptyBarrel in emptyTrainingBarrels:
                     # Pick a random Kong move to put in the training barrel. This should be both more interesting than a shared move and lead to fewer empty shops.

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -76,7 +76,7 @@ class LogicVarHolder:
         """
         self.latest_owned_items = []
         self.found_test_item = False
-        self.banned_item = None
+        self.banned_items = []
 
         self.donkey = Kongs.donkey in self.settings.starting_kong_list
         self.diddy = Kongs.diddy in self.settings.starting_kong_list
@@ -223,9 +223,9 @@ class LogicVarHolder:
 
     def Update(self, ownedItems):
         """Update logic variables based on owned items."""
-        # Except for the banned item - this item isn't allowed to be used by the logic
-        while self.banned_item in ownedItems:
-            ownedItems.remove(self.banned_item)
+        # Except for banned items - these items aren't allowed to be used by the logic
+        ownedItems = [item for item in ownedItems if item not in self.banned_items]
+
         self.latest_owned_items = ownedItems
         self.found_test_item = self.found_test_item or Items.TestItem in ownedItems
 
@@ -699,15 +699,15 @@ class LogicVarHolder:
         required_level = min(ceil(self.settings.medal_requirement / 4), 6)
         return have_enough_medals and self.IsLevelEnterable(required_level)
 
-    def BanItem(self, item):
+    def BanItems(self, items):
         """Prevent an item from being picked up by the logic."""
-        self.banned_item = item
+        self.banned_items = items
 
     def HasAllItems(self):
         """Return if you have all progression items."""
         # You may now own the banned item
-        self.latest_owned_items.append(self.banned_item)
-        self.banned_item = None
+        self.latest_owned_items.extend(self.banned_items)
+        self.banned_items = []
         self.Update(self.latest_owned_items)
         # If you didn't beat the game, you obviously don't have all the progression items - this covers the possible need for camera and each key
         if not self.WinConditionMet():


### PR DESCRIPTION
Finally implements hints for Kong items in item rando. Each kong is hinted once with the freeing kong and level. It should put the hint in or before the level the Kong is in. It's a pretty lazy implementation of hint door choice but that's mainly because the hint door logic rework is coming.

Other minor fixes:
- Camera path hints now follow the same rules as path hints for keys
- Homing and Sniper are merged when considering foolishness
- Quick cb logic fix in Castle