### PR TITLE
Logic fixes

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,14 +41,20 @@
     },
     {
       "label": "Lint Repo",
-      "dependsOn": ["Format Repo", "Validate Styles", "Validate Docstrings", "Validate Jinja2", "Validate C"],
-      "problemMatcher": [],
+      "dependsOn": [
+        "Format Repo",
+        "Validate Styles",
+        "Validate Docstrings",
+        "Validate Jinja2",
+        "Validate C"
+      ],
+      "problemMatcher": []
     },
     {
       "label": "Run Tests",
       "type": "shell",
       "command": "${command:python.interpreterPath} -m pytest -v --cov=${workspaceFolder}/ --cov-report html ${workspaceFolder}/tests",
-      "problemMatcher": [],
+      "problemMatcher": []
     },
     {
       "label": "Build BPS",
@@ -64,7 +70,7 @@
       "label": "Run Server",
       "type": "shell",
       "command": "${command:python.interpreterPath} ./NoCacheHTTPServer.py",
-      "problemMatcher": [],
-    },
+      "problemMatcher": []
+    }
   ]
 }

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1381,6 +1381,13 @@ def FillKongs(spoiler):
         # This matters specifically so the logic around Diddy's cage behaves properly
         if LocationList[Locations.DiddyKong].item is None:
             LocationList[Locations.DiddyKong].PlaceItem(Items.NoItem)
+        # And this matters specifically for the logic around the freeing the other kongs rewards
+        if LocationList[Locations.TinyKong].item is None:
+            LocationList[Locations.TinyKong].PlaceItem(Items.NoItem)
+        if LocationList[Locations.LankyKong].item is None:
+            LocationList[Locations.LankyKong].PlaceItem(Items.NoItem)
+        if LocationList[Locations.ChunkyKong].item is None:
+            LocationList[Locations.ChunkyKong].PlaceItem(Items.NoItem)
         spoiler.settings.update_valid_locations()
     # If kongs must be in Kong cages, we need to be more careful
     else:

--- a/randomizer/Lists/Warps.py
+++ b/randomizer/Lists/Warps.py
@@ -171,7 +171,7 @@ BananaportVanilla = {
     Warps.IslesRing1: BananaportData(name="DK Isles: Ring (1)", map_id=Maps.Isles, region_id=Regions.IslesMain, obj_id_vanilla=0x10, vanilla_warp=0, swap_index=0),
     Warps.IslesKLumsy: BananaportData(name="DK Isles: Outside K. Lumsy's Prison", map_id=Maps.Isles, region_id=Regions.IslesMain, obj_id_vanilla=0x11, vanilla_warp=0, swap_index=1),
     Warps.IslesRing2: BananaportData(name="DK Isles: Ring (2)", map_id=Maps.Isles, region_id=Regions.IslesMain, obj_id_vanilla=0x12, vanilla_warp=1, swap_index=2),
-    Warps.IslesAztecLobby: BananaportData(name="DK Isles: Outside Aztec Lobby", map_id=Maps.Isles, region_id=Regions.IslesMain, obj_id_vanilla=0x13, vanilla_warp=1, swap_index=3),
+    Warps.IslesAztecLobby: BananaportData(name="DK Isles: Outside Aztec Lobby", map_id=Maps.Isles, region_id=Regions.IslesMainUpper, obj_id_vanilla=0x13, vanilla_warp=1, swap_index=3),
     Warps.IslesRing3: BananaportData(name="DK Isles: Ring (3)", map_id=Maps.Isles, region_id=Regions.IslesMain, obj_id_vanilla=0x16, vanilla_warp=2, swap_index=5),
     Warps.IslesWaterfall: BananaportData(name="DK Isles: Waterfall", map_id=Maps.Isles, region_id=Regions.IslesMain, obj_id_vanilla=0x14, vanilla_warp=2, swap_index=4),
     Warps.IslesRing4: BananaportData(name="DK Isles: Ring (4)", map_id=Maps.Isles, region_id=Regions.IslesMain, obj_id_vanilla=0x17, vanilla_warp=3, swap_index=6),

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -516,8 +516,10 @@ class LogicVarHolder:
         return False
 
     def CanFreeTiny(self):
-        """Check if kong at Tiny location can be freed,r equires either chimpy charge or primate punch."""
-        if self.settings.tiny_freeing_kong == Kongs.diddy:
+        """Check if kong at Tiny location can be freed, requires either chimpy charge or primate punch."""
+        if LocationList[Locations.TinyKong].item == Items.NoItem:
+            return self.IsKong(self.settings.tiny_freeing_kong)
+        elif self.settings.tiny_freeing_kong == Kongs.diddy:
             return self.charge and self.isdiddy
         elif self.settings.tiny_freeing_kong == Kongs.chunky:
             return self.punch and self.ischunky
@@ -529,13 +531,15 @@ class LogicVarHolder:
         """Check if the Llama spit can be triggered."""
         return self.HasInstrument(self.settings.lanky_freeing_kong)
 
-    def CanFreeLanky(self, require_gun):
+    def CanFreeLanky(self):
         """Check if kong at Lanky location can be freed, requires freeing kong to have its gun and instrument."""
-        return (self.HasGun(self.settings.lanky_freeing_kong) or not require_gun) and ((self.swim and self.HasInstrument(self.settings.lanky_freeing_kong)) or self.phasewalk or self.CanPhaseswim())
+        return (self.HasGun(self.settings.lanky_freeing_kong) or LocationList[Locations.LankyKong].item == Items.NoItem) and (
+            (self.swim and self.HasInstrument(self.settings.lanky_freeing_kong)) or self.phasewalk or self.CanPhaseswim()
+        )
 
     def CanFreeChunky(self):
         """Check if kong at Chunky location can be freed."""
-        return self.Slam and self.IsKong(self.settings.chunky_freeing_kong)
+        return (LocationList[Locations.ChunkyKong].item == Items.NoItem or self.Slam) and self.IsKong(self.settings.chunky_freeing_kong)
 
     def UpdateCurrentRegionAccess(self, region):
         """Set access of current region."""

--- a/randomizer/LogicFiles/AngryAztec.py
+++ b/randomizer/LogicFiles/AngryAztec.py
@@ -170,8 +170,8 @@ LogicRegions = {
     ),
 
     Regions.LlamaTemple: Region("Llama Temple", "Llama Temple", Levels.AngryAztec, True, -1, [
-        LocationLogic(Locations.LankyKong, lambda l: l.CanFreeLanky(True)),
-        LocationLogic(Locations.AztecDonkeyFreeLanky, lambda l: l.CanFreeLanky(False)),
+        LocationLogic(Locations.LankyKong, lambda l: l.CanFreeLanky()),
+        LocationLogic(Locations.AztecDonkeyFreeLanky, lambda l: l.CanFreeLanky()),
         LocationLogic(Locations.AztecLankyLlamaTempleBarrel, lambda l: l.trombone and ((l.handstand and l.islanky) or (l.settings.free_trade_items and ((l.twirl and l.istiny and l.advanced_platforming) or l.CanMoonkick()))), MinigameType.BonusBarrel),
         LocationLogic(Locations.AztecLankyMatchingGame, lambda l: l.grape and l.Slam and l.lanky),
         LocationLogic(Locations.AztecBananaFairyLlamaTemple, lambda l: l.camera),

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -253,7 +253,7 @@ LogicRegions = {
         TransitionFront(Regions.ThornvineArea, lambda l: True, Transitions.ForestBarnToMain),
     ]),
 
-    Regions.WormArea: Region("Worm Area", "Beanstalk Area", Levels.FungiForest, True, -1, [
+    Regions.WormArea: Region("Worm Area", "Forest Center and Beanstalk", Levels.FungiForest, True, -1, [
         LocationLogic(Locations.ForestTinyBeanstalk, lambda l: l.saxophone and l.mini and l.istiny and l.Beans >= 1),
         LocationLogic(Locations.ForestChunkyApple, lambda l: Events.WormGatesOpened in l.Events and l.hunkyChunky and l.ischunky and l.barrels),
     ], [], [


### PR DESCRIPTION
-Fixed a bug where Vines would be required for reaching the Aztec Lobby, regardless of pre-activated Isles warps
-Fixed a bug where part of the "Forest Center and Beanstalk" was incorrectly named "Beanstalk Area" 
-Fixed a bug where too many kong-freeing moves were logically required in order to get the kong-freeing reward from an empty cage