### PR TITLE
Smaller Shops Setting

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -484,11 +484,13 @@ def compileHints(spoiler: Spoiler):
                     level_restriction = [spoiler.settings.level_order[1], spoiler.settings.level_order[2]]
                 else:
                     level_restriction = [level for level in all_levels if spoiler.settings.EntryGBs[level] <= spoiler.settings.EntryGBs[kong_location.level]]
+            hint_options = []
             # Attempt to find a door that will be accessible before the Kong
-            hint_options = getHintLocationsForAccessibleHintItems(spoiler.accessible_hints_for_location[kong_location_id])
+            if kong_location_id in spoiler.accessible_hints_for_location.keys():  # This will fail if the Kong is not WotH
+                hint_options = getHintLocationsForAccessibleHintItems(spoiler.accessible_hints_for_location[kong_location_id])  # This will return [] if there are no hint doors available
             if len(hint_options) > 0:
                 hint_location = random.choice(hint_options)
-            # If there are no doors available early (very rare) then just get a random one. Tough luck.
+            # If there are no doors available early (very rare) or the Kong is not WotH (obscenely rare) then just get a random one. Tough luck.
             else:
                 hint_location = getRandomHintLocation()
             freeing_kong_name = kong_list[kong_location.kong]
@@ -943,7 +945,11 @@ def compileHints(spoiler: Spoiler):
                 continue
             hinted_region_name = spoiler.foolish_region_names.pop()
             hint_location = getRandomHintLocation()
-            message = f"It would be foolish to explore the {hinted_region_name}."
+            if "Medal Rewards" in hinted_region_name:
+                cutoff = hinted_region_name.index(" Medal Rewards")
+                message = f"It would be foolish to collect colored bananas in {hinted_region_name[0:cutoff]}."
+            else:
+                message = f"It would be foolish to explore the {hinted_region_name}."
             hint_location.hint_type = HintType.FoolishRegion
             UpdateHint(hint_location, message)
 

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -573,7 +573,7 @@ def CalculateFoolish(spoiler, WothLocations):
         majorItems.append(Items.CameraAndShockwave)
     if spoiler.settings.shockwave_status == "shuffled_decoupled":
         majorItems.append(Items.Camera)
-        majorItems.append(Items.Shockwave)
+        # majorItems.append(Items.Shockwave)  # Shockwave foolish is virtually useless until we get rainbow coins in the pool
     for item in majorItems:
         # If this item is in the WotH, it can't possibly be foolish so we can skip it
         if item in wothItems:
@@ -618,12 +618,18 @@ def CalculateFoolish(spoiler, WothLocations):
     nonHintableNames = {"K. Rool Arena", "Snide", "Candy Generic", "Funky Generic", "Credits"}  # These regions never have anything useful so shouldn't be hinted
     if Types.Coin not in spoiler.settings.shuffled_location_types:
         nonHintableNames.add("Jetpac Game")  # If this is vanilla, it's never useful to hint
+    bossLocations = [location for id, location in LocationList.items() if location.type == Types.Key]
     # In order for a region to be foolish, it can contain none of these Major Items
     for id, region in RegionList.items():
         locations = [loc for loc in region.locations if loc.id in LocationList.keys()]
         # If this region DOES contain a major item, add it the name to the set of non-hintable hint regions
         if any([loc for loc in locations if LocationList[loc.id].item in majorItems]):
             nonHintableNames.add(region.hint_name)
+        # In addition to being empty, medal regions need the corresponding boss location to be empty to be hinted foolish - this lets us say "CBs are foolish" which is more helpful
+        elif "Medal Rewards" in region.hint_name:
+            bossLocation = [location for location in bossLocations if location.level == region.level][0]  # Matches only one
+            if bossLocation.item in majorItems:
+                nonHintableNames.add(region.hint_name)
     # The regions that are foolish are all regions not in this list (that have locations in them!)
     spoiler.foolish_region_names = list(set([region.hint_name for id, region in RegionList.items() if any(region.locations) and region.hint_name not in nonHintableNames]))
 
@@ -805,7 +811,7 @@ def AssumedFill(settings, itemsToPlace, ownedItems=None, inOrder=False):
                 reachable.remove(validReachable[0])  # Remove one so same location can't be "used" twice
             # If world is not valid, undo item placement and try next location
             if not valid:
-                LocationList[locationId].item = None
+                LocationList[locationId].UnplaceItem()
                 itemShuffled = False
                 continue
             # Debug code utility for very important items

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -83,6 +83,8 @@ class Location:
         # If we're placing a real move here, lock out mutually exclusive shop locations
         if item != Items.NoItem and self.type == Types.Shop:
             for location in ShopLocationReference[self.level][self.vendor]:
+                if location in RemovedShopLocations:
+                    continue
                 # If this is a shared spot, lock out kong-specific locations in this shop
                 if self.kong == Kongs.any and LocationList[location].kong != Kongs.any:
                     LocationList[location].PlaceItem(Items.NoItem)
@@ -109,6 +111,23 @@ class Location:
         """Place whatever this location's default (vanilla) item is at it."""
         self.PlaceItem(self.default)
         self.constant = True
+
+    def UnplaceItem(self):
+        """Unplace an item here, which may affect the placement of other items."""
+        self.item = None
+        # If this is a shop location, we may have locked out a location we now need to undo
+        if self.type == Types.Shop:
+            # Check other locations in this shop
+            for location in ShopLocationReference[self.level][self.vendor]:
+                if location in RemovedShopLocations:
+                    continue
+                if LocationList[location].kong == Kongs.any and location.item == Items.NoItem:
+                    itemsInThisShop = len([location for location in ShopLocationReference[self.level][self.vendor] if LocationList[location].item not in (None, Items.NoItem)])
+                    if itemsInThisShop == 0:
+                        location.item = None
+                # Items.NoItem are only placed when locking out locations. If any exist, they're because this location caused them to be placed here
+                elif location.item == Items.NoItem:
+                    location.item = None
 
 
 LocationList = {
@@ -810,163 +829,165 @@ SharedShopLocations = {
 # Dictionary to speed up lookups of related shop locations
 ShopLocationReference = {}
 ShopLocationReference[Levels.JungleJapes] = {}
-ShopLocationReference[Levels.JungleJapes][VendorType.Cranky] = {
+ShopLocationReference[Levels.JungleJapes][VendorType.Cranky] = [
     Locations.BaboonBlast,
     Locations.ChimpyCharge,
     Locations.Orangstand,
     Locations.MiniMonkey,
     Locations.HunkyChunky,
     Locations.SharedJapesPotion,
-}
-ShopLocationReference[Levels.JungleJapes][VendorType.Funky] = {
+]
+ShopLocationReference[Levels.JungleJapes][VendorType.Funky] = [
     Locations.CoconutGun,
     Locations.PeanutGun,
     Locations.GrapeGun,
     Locations.FeatherGun,
     Locations.PineappleGun,
     Locations.SharedJapesGun,
-}
+]
 ShopLocationReference[Levels.AngryAztec] = {}
-ShopLocationReference[Levels.AngryAztec][VendorType.Cranky] = {
+ShopLocationReference[Levels.AngryAztec][VendorType.Cranky] = [
     Locations.StrongKong,
     Locations.RocketbarrelBoost,
     Locations.LankyAztecPotion,
     Locations.TinyAztecPotion,
     Locations.ChunkyAztecPotion,
     Locations.SharedAztecPotion,
-}
-ShopLocationReference[Levels.AngryAztec][VendorType.Candy] = {
+]
+ShopLocationReference[Levels.AngryAztec][VendorType.Candy] = [
     Locations.Bongos,
     Locations.Guitar,
     Locations.Trombone,
     Locations.Saxophone,
     Locations.Triangle,
     Locations.SharedAztecInstrument,
-}
-ShopLocationReference[Levels.AngryAztec][VendorType.Funky] = {
+]
+ShopLocationReference[Levels.AngryAztec][VendorType.Funky] = [
     Locations.DonkeyAztecGun,
     Locations.DiddyAztecGun,
     Locations.LankyAztecGun,
     Locations.TinyAztecGun,
     Locations.ChunkyAztecGun,
     Locations.SharedAztecGun,
-}
+]
 ShopLocationReference[Levels.FranticFactory] = {}
-ShopLocationReference[Levels.FranticFactory][VendorType.Cranky] = {
+ShopLocationReference[Levels.FranticFactory][VendorType.Cranky] = [
     Locations.GorillaGrab,
     Locations.SimianSpring,
     Locations.BaboonBalloon,
     Locations.PonyTailTwirl,
     Locations.PrimatePunch,
     Locations.SharedFactoryPotion,
-}
-ShopLocationReference[Levels.FranticFactory][VendorType.Candy] = {
+]
+ShopLocationReference[Levels.FranticFactory][VendorType.Candy] = [
     Locations.DonkeyFactoryInstrument,
     Locations.DiddyFactoryInstrument,
     Locations.LankyFactoryInstrument,
     Locations.TinyFactoryInstrument,
     Locations.ChunkyFactoryInstrument,
     Locations.SharedFactoryInstrument,
-}
-ShopLocationReference[Levels.FranticFactory][VendorType.Funky] = {
+]
+ShopLocationReference[Levels.FranticFactory][VendorType.Funky] = [
     Locations.DonkeyFactoryGun,
     Locations.DiddyFactoryGun,
     Locations.LankyFactoryGun,
     Locations.TinyFactoryGun,
     Locations.ChunkyFactoryGun,
     Locations.AmmoBelt1,
-}
+]
 ShopLocationReference[Levels.GloomyGalleon] = {}
-ShopLocationReference[Levels.GloomyGalleon][VendorType.Cranky] = {
+ShopLocationReference[Levels.GloomyGalleon][VendorType.Cranky] = [
     Locations.DonkeyGalleonPotion,
     Locations.DiddyGalleonPotion,
     Locations.LankyGalleonPotion,
     Locations.TinyGalleonPotion,
     Locations.ChunkyGalleonPotion,
     Locations.SharedGalleonPotion,
-}
-ShopLocationReference[Levels.GloomyGalleon][VendorType.Candy] = {
+]
+ShopLocationReference[Levels.GloomyGalleon][VendorType.Candy] = [
     Locations.DonkeyGalleonInstrument,
     Locations.DiddyGalleonInstrument,
     Locations.LankyGalleonInstrument,
     Locations.TinyGalleonInstrument,
     Locations.ChunkyGalleonInstrument,
     Locations.MusicUpgrade1,
-}
-ShopLocationReference[Levels.GloomyGalleon][VendorType.Funky] = {
+]
+ShopLocationReference[Levels.GloomyGalleon][VendorType.Funky] = [
     Locations.DonkeyGalleonGun,
     Locations.DiddyGalleonGun,
     Locations.LankyGalleonGun,
     Locations.TinyGalleonGun,
     Locations.ChunkyGalleonGun,
     Locations.SharedGalleonGun,
-}
+]
 ShopLocationReference[Levels.FungiForest] = {}
-ShopLocationReference[Levels.FungiForest][VendorType.Cranky] = {
+ShopLocationReference[Levels.FungiForest][VendorType.Cranky] = [
     Locations.DonkeyForestPotion,
     Locations.DiddyForestPotion,
     Locations.LankyForestPotion,
     Locations.TinyForestPotion,
     Locations.ChunkyForestPotion,
     Locations.SuperSimianSlam,
-}
-ShopLocationReference[Levels.FungiForest][VendorType.Funky] = {
+]
+ShopLocationReference[Levels.FungiForest][VendorType.Funky] = [
     Locations.DonkeyForestGun,
     Locations.DiddyForestGun,
     Locations.LankyForestGun,
     Locations.TinyForestGun,
     Locations.ChunkyForestGun,
     Locations.HomingAmmo,
-}
+]
 ShopLocationReference[Levels.CrystalCaves] = {}
-ShopLocationReference[Levels.CrystalCaves][VendorType.Cranky] = {
+ShopLocationReference[Levels.CrystalCaves][VendorType.Cranky] = [
     Locations.DonkeyCavesPotion,
     Locations.DiddyCavesPotion,
     Locations.OrangstandSprint,
     Locations.Monkeyport,
     Locations.GorillaGone,
     Locations.SharedCavesPotion,
-}
-ShopLocationReference[Levels.CrystalCaves][VendorType.Candy] = {
+]
+ShopLocationReference[Levels.CrystalCaves][VendorType.Candy] = [
     Locations.DonkeyCavesInstrument,
     Locations.DiddyCavesInstrument,
     Locations.LankyCavesInstrument,
     Locations.TinyCavesInstrument,
     Locations.ChunkyCavesInstrument,
     Locations.ThirdMelon,
-}
-ShopLocationReference[Levels.CrystalCaves][VendorType.Funky] = {
+]
+ShopLocationReference[Levels.CrystalCaves][VendorType.Funky] = [
     Locations.DonkeyCavesGun,
     Locations.DiddyCavesGun,
     Locations.LankyCavesGun,
     Locations.TinyCavesGun,
     Locations.ChunkyCavesGun,
     Locations.AmmoBelt2,
-}
+]
 ShopLocationReference[Levels.CreepyCastle] = {}
-ShopLocationReference[Levels.CreepyCastle][VendorType.Cranky] = {
+ShopLocationReference[Levels.CreepyCastle][VendorType.Cranky] = [
     Locations.DonkeyCastlePotion,
     Locations.DiddyCastlePotion,
     Locations.LankyCastlePotion,
     Locations.TinyCastlePotion,
     Locations.ChunkyCastlePotion,
     Locations.SuperDuperSimianSlam,
-}
-ShopLocationReference[Levels.CreepyCastle][VendorType.Candy] = {
+]
+ShopLocationReference[Levels.CreepyCastle][VendorType.Candy] = [
     Locations.DonkeyCastleInstrument,
     Locations.DiddyCastleInstrument,
     Locations.LankyCastleInstrument,
     Locations.TinyCastleInstrument,
     Locations.ChunkyCastleInstrument,
     Locations.MusicUpgrade2,
-}
-ShopLocationReference[Levels.CreepyCastle][VendorType.Funky] = {
+]
+ShopLocationReference[Levels.CreepyCastle][VendorType.Funky] = [
     Locations.DonkeyCastleGun,
     Locations.DiddyCastleGun,
     Locations.LankyCastleGun,
     Locations.TinyCastleGun,
     Locations.ChunkyCastleGun,
     Locations.SniperSight,
-}
+]
 ShopLocationReference[Levels.DKIsles] = {}
-ShopLocationReference[Levels.DKIsles][VendorType.Cranky] = {Locations.DonkeyIslesPotion, Locations.DiddyIslesPotion, Locations.LankyIslesPotion, Locations.TinyIslesPotion, Locations.ChunkyIslesPotion, Locations.SimianSlam}
+ShopLocationReference[Levels.DKIsles][VendorType.Cranky] = [Locations.DonkeyIslesPotion, Locations.DiddyIslesPotion, Locations.LankyIslesPotion, Locations.TinyIslesPotion, Locations.ChunkyIslesPotion, Locations.SimianSlam]
+
+RemovedShopLocations = []

--- a/randomizer/LogicFiles/Shops.py
+++ b/randomizer/LogicFiles/Shops.py
@@ -87,7 +87,7 @@ LogicRegions = {
     Regions.FunkyCastle: Region("Funky Castle", "Castle Shops", Levels.Shops, False, None, [
         LocationLogic(Locations.SniperSight, lambda l: l.CanBuy(Locations.SniperSight)),
         LocationLogic(Locations.DonkeyCastleGun, lambda l: l.isdonkey and l.CanBuy(Locations.DonkeyCastleGun)),
-        LocationLogic(Locations.DiddyCastleGun, lambda l: l.isdiddy and l.CanBuy(Locations.DiddyCavesGun)),
+        LocationLogic(Locations.DiddyCastleGun, lambda l: l.isdiddy and l.CanBuy(Locations.DiddyCastleGun)),
         LocationLogic(Locations.LankyCastleGun, lambda l: l.islanky and l.CanBuy(Locations.LankyCastleGun)),
         LocationLogic(Locations.TinyCastleGun, lambda l: l.istiny and l.CanBuy(Locations.TinyCastleGun)),
         LocationLogic(Locations.ChunkyCastleGun, lambda l: l.ischunky and l.CanBuy(Locations.ChunkyCastleGun)),

--- a/randomizer/Prices.py
+++ b/randomizer/Prices.py
@@ -15,6 +15,7 @@ from randomizer.Lists.Location import (
     DonkeyMoveLocations,
     LankyMoveLocations,
     LocationList,
+    RemovedShopLocations,
     SharedMoveLocations,
     SharedShopLocations,
     TinyMoveLocations,
@@ -167,6 +168,8 @@ def GetMaxForKong(settings, kong):
         kongMoveLocations = ChunkyMoveLocations.copy()
 
     for location in kongMoveLocations:
+        if location in RemovedShopLocations:  # Ignore any shop locations that don't even exist anymore
+            continue
         item_id = LocationList[location].item
         if item_id is not None and item_id != Items.NoItem:
             if item_id == Items.ProgressiveSlam:

--- a/templates/difficulty.html.jinja2
+++ b/templates/difficulty.html.jinja2
@@ -216,6 +216,19 @@
                         Hard Enemies
                     </label>
                 </div>
+                <div class="form-check form-switch item-switch">
+                    <label data-toggle="tooltip"
+                           title="Item rando with shops only. Reduces the number of items offered in shops to a maximum of 3."
+                           style="text-align: left">
+                        <input class="form-check-input"
+                               type="checkbox"
+                               name="smaller_shops"
+                               id="smaller_shops"
+                               value="True"/>
+                        Smaller Shops
+                    </label>
+                </div>
+                <div class="spacer"></div>
             </div>
             <div class = "flex-container">
                 <div class="item-select">

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -130,6 +130,8 @@ def generate_lo_rando_race_settings():
     # "advanced_platforming", "b_locker_skips", "general_clips", "ledge_clips", "moonkicks", "phase_swimming", "phase_walking", "skew", "spawn_snags", "swim_through_shores", "tag_barrel_storage", "troff_n_scoff_skips"
     data["glitches_selected"] = [""]
 
+    data["smaller_shops"] = False  # could be true or false, unclear
+
     return data
 
 

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -3,7 +3,7 @@ from ui.generate_buttons import update_seed_text
 from ui.rando_options import (
     disable_barrel_modal,
     disable_enemy_modal,
-    disable_items_modal,
+    toggle_item_rando,
     disable_boss_rando,
     disable_colors,
     disable_music,
@@ -23,7 +23,7 @@ from ui.rando_options import (
     toggle_counts_boxes,
     toggle_medals_box,
     update_boss_required,
-    disable_coupled_camera_shockwave,
+    item_rando_list_changed,
     toggle_key_settings,
 )
 
@@ -42,7 +42,7 @@ max_randomized_blocker(None)
 max_randomized_troff(None)
 disable_barrel_modal(None)
 disable_enemy_modal(None)
-disable_items_modal(None)
+toggle_item_rando(None)
 disable_boss_rando(None)
 hide_rgb(None)
 toggle_medals_box(None)
@@ -53,5 +53,5 @@ max_doorone_requirement(None)
 max_doortwo_requirement(None)
 updateDoorOneNumAccess(None)
 updateDoorTwoNumAccess(None)
-disable_coupled_camera_shockwave(None)
+item_rando_list_changed(None)
 toggle_key_settings(None)

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -478,36 +478,73 @@ def disable_enemy_modal(evt):
 
 
 @bind("click", "shuffle_items")
-def disable_items_modal(evt):
-    """Disable Item Rando Selector when Item Rando is off."""
+def toggle_item_rando(evt):
+    """Enable and disable settings based on Item Rando being on/off."""
     disabled = True
     selector = js.document.getElementById("item_rando_list_modal")
+    item_rando_pool = document.getElementById("item_rando_list_selected").options
+    smaller_shops = document.getElementById("smaller_shops")
+    shockwave = document.getElementById("shockwave_status_shuffled")
+    shops_in_pool = False
+    nothing_selected = True
+    for option in item_rando_pool:
+        if option.value == "shop":
+            if option.selected:
+                shops_in_pool = True
+                break
+        if option.selected:
+            nothing_selected = False
+    if nothing_selected:
+        shops_in_pool = True
     if js.document.getElementById("shuffle_items").checked:
         disabled = False
     try:
         if disabled:
+            # Prevent item rando modal from opening and smaller shop setting
             selector.setAttribute("disabled", "disabled")
+            smaller_shops.setAttribute("disabled", "disabled")
+            smaller_shops.checked = False
+            shockwave.removeAttribute("disabled")
         else:
+            # Enable item rando modal, prevent shockwave/camera coupling, and enable smaller shops if it's in the pool
             selector.removeAttribute("disabled")
+            if shops_in_pool:
+                if shockwave.selected is True:
+                    document.getElementById("shockwave_status_shuffled_decoupled").selected = True
+                shockwave.setAttribute("disabled", "disabled")
+                smaller_shops.removeAttribute("disabled")
     except AttributeError:
         pass
 
 
 @bind("click", "item_rando_list_selected")
-def disable_coupled_camera_shockwave(evt):
-    """Change shockwave/camera selection to decoupled if shops are shuffled."""
-    disabled = False
-    selector = document.getElementById("item_rando_list_selected").options
+def item_rando_list_changed(evt):
+    """Enable and disable settings based on the Item Rando pool changing."""
+    item_rando_pool = document.getElementById("item_rando_list_selected").options
     shockwave = document.getElementById("shockwave_status_shuffled")
-    for option in selector:
-        if option.value == "shop" and option.selected:
-            if shockwave.selected is True:
-                document.getElementById("shockwave_status_shuffled_decoupled").selected = True
-            shockwave.setAttribute("disabled", "disabled")
-            disabled = True
-        else:
-            if not disabled:
-                shockwave.removeAttribute("disabled")
+    smaller_shops = document.getElementById("smaller_shops")
+    shops_in_pool = False
+    nothing_selected = True
+    for option in item_rando_pool:
+        if option.value == "shop":
+            if option.selected:
+                shops_in_pool = True
+                break
+        if option.selected:
+            nothing_selected = False
+    if nothing_selected:
+        shops_in_pool = True
+    if shops_in_pool:
+        # Prevent camera/shockwave from being coupled and enable smaller shops if shops are in the pool
+        if shockwave.selected is True:
+            document.getElementById("shockwave_status_shuffled_decoupled").selected = True
+        shockwave.setAttribute("disabled", "disabled")
+        smaller_shops.removeAttribute("disabled")
+    else:
+        # Enable coupled camera/shockwave and disable smaller shops if shops are not in the pool
+        shockwave.removeAttribute("disabled")
+        smaller_shops.setAttribute("disabled", "disabled")
+        smaller_shops.checked = False
 
 
 @bind("click", "apply_preset")


### PR DESCRIPTION
Adds a new setting "Smaller Shops" that randomly removes two kong locations from each shop. The kong locations removed are distributed evenly across kongs so all kongs have the same number of shop locations available.

Other fixes:
- Fixed one bad shop logic
- Fixed a possible issue where unplacing an item during the assumed fill might have to unplace other items
- Shockwave can no longer be hinted foolish so Keiper stops bullying me
- Medals are foolish hints have been upgraded into "colored bananas are foolish" hints by checking the corresponding boss location. The old medal region foolish hints are no longer found, which is to say you won't get a "medals are foolish" check, only colored bananas in an all-or-nothing way.
- Fixed obscenely rare case where hint generation would crash if a locked kong wasn't WotH
- Fixed what I think was a distribution issue preventing shared moves from being placed at BFI in item rando. Not sure if this was a problem at all but it should be good now.