### PR TITLE
Complex Fill Fixes

### DIFF
--- a/base-hack/Build/model_port.py
+++ b/base-hack/Build/model_port.py
@@ -295,8 +295,8 @@ def portActorToModelTwo(actor_index: int, input_file: str, output_file: str, bas
             header = int.from_bytes(fh.read(2), "big")
             layers = int.from_bytes(fh.read(2), "big")
             dyn_tex[header] = []
-            for l in range(layers):
-                for t in range(tex_count):
+            for layer in range(layers):
+                for tex in range(tex_count):
                     dyn_tex[header].append(int.from_bytes(fh.read(2), "big"))
         # Prune DL of bad instructions and segmented addresses
         for d in range(dl_count):

--- a/randomizer/LogicFiles/JungleJapes.py
+++ b/randomizer/LogicFiles/JungleJapes.py
@@ -33,7 +33,7 @@ LogicRegions = {
         LocationLogic(Locations.JapesBattleArena, lambda l: not l.settings.crown_placement_rando),
     ], [
         Event(Events.JapesEntered, lambda l: True),
-        Event(Events.JapesSpawnW5, lambda l: Events.JapesMountainTopGB in l.Events or l.settings.activate_all_bananaports),
+        Event(Events.JapesSpawnW5, lambda l: Events.JapesMountainTopGB in l.Events or l.settings.activate_all_bananaports == "all"),
         Event(Events.JapesFreeKongOpenGates, lambda l: l.CanOpenJapesGates()),
     ], [
         TransitionFront(Regions.JungleJapesMedals, lambda l: True),


### PR DESCRIPTION
- Changed complex key placement algorithm to Assumed. This led to a huge increase in available locations for keys to be placed. I suspect this will fix the feeling that keys are placed early and often in complex seeds.
- Added a tweak that should (on average) lower late B. Lockers in complex seeds without hard B. Lockers
- Fixed some bad logic on the Japes Mountain warp