### PR TITLE
stray logic fixes and fill fixes

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -357,7 +357,7 @@ def compileHints(spoiler: Spoiler):
         Items.CreepyCastleKey: 0,
         Items.HideoutHelmKey: 0,
     }
-
+    # Calculate the number of key hints that need to be placed
     if spoiler.settings.shuffle_items and Types.Key in spoiler.settings.shuffled_location_types:
         valid_types.append(HintType.RequiredKeyHint)
         # Only hint keys that are in the Way of the Hoard
@@ -1761,11 +1761,11 @@ def GetRegionOfLocation(location_id):
     # Shop locations are tied to the level, not the shop regions
     if location.type == Types.Shop:
         for region in [reg for id, reg in RegionList.items() if reg.level == Levels.Shops]:
-            if location_id in [location_logic.id for location_logic in region.locations]:
+            if location_id in [location_logic.id for location_logic in region.locations if not location_logic.isAuxiliaryLocation]:
                 return region
     for region_id in Regions:
         region = RegionList[region_id]
         if region.level == location.level:
-            if location_id in [location_logic.id for location_logic in region.locations]:
+            if location_id in [location_logic.id for location_logic in region.locations if not location_logic.isAuxiliaryLocation]:
                 return region
     raise Exception("Unable to find Region for Location")  # This should never trigger!

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -559,8 +559,9 @@ def CalculateWothPaths(spoiler, WothLocations):
                 # If we remove anything, we have to check the whole list again
                 anything_removed = True
                 break
-    LogicVariables.pathMode = False  # Don't carry this pathMode flag beyond this method ever
-    spoiler.settings.open_lobbies = old_open_lobbies_temp  # Undo the open lobbies setting change too
+    if spoiler.settings.shuffle_loading_zones != "all":
+        LogicVariables.pathMode = False  # Don't carry this pathMode flag beyond this method ever
+        spoiler.settings.open_lobbies = old_open_lobbies_temp  # Undo the open lobbies setting change too
 
 
 def CalculateFoolish(spoiler, WothLocations):

--- a/randomizer/Lists/Item.py
+++ b/randomizer/Lists/Item.py
@@ -18,6 +18,7 @@ class Item:
         self.playthrough = playthrough
         self.type = type
         self.kong = kong
+        self.movetype = None
         self.rando_flag = None  # The flag the ROM reads to know if you have this item - set to -1 for progressive moves as those are special
         if type == Types.Shop:
             self.movetype = data[0]

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -148,7 +148,7 @@ LocationList = {
     Locations.IslesLankyPrisonOrangsprint: Location(Levels.DKIsles, "Isles Lanky Sprint Cage", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(Maps.KLumsy, 0x3, 429, Kongs.lanky)]),
     Locations.CameraAndShockwave: Location(Levels.DKIsles, "The Banana Fairy's Gift", Items.CameraAndShockwave, Types.Shockwave, Kongs.tiny, [124]),
     Locations.RarewareBanana: Location(Levels.DKIsles, "Returning the Banana Fairies", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.BananaFairyRoom, 0x1E, 301, Kongs.tiny)]),
-    Locations.IslesLankyInstrumentPad: Location(Levels.DKIsles, "Isles Lanky Trombone Pad", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(0, -1, 398, Kongs.lanky)]),
+    Locations.IslesLankyInstrumentPad: Location(Levels.DKIsles, "Isles Lanky Japes Instrument", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(0, -1, 398, Kongs.lanky)]),
     Locations.IslesTinyAztecLobby: Location(Levels.DKIsles, "Isles Tiny Aztec Lobby Barrel", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(0, -1, 402, Kongs.tiny)]),
     Locations.IslesDonkeyCagedBanana: Location(Levels.DKIsles, "Isles Donkey Coconut Cage", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.Isles, 0x4D, 419, Kongs.donkey)]),
     Locations.IslesDiddySnidesLobby: Location(Levels.DKIsles, "Isles Diddy Snides Spring Barrel", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(0, -1, 416, Kongs.diddy)]),

--- a/randomizer/LogicClasses.py
+++ b/randomizer/LogicClasses.py
@@ -8,11 +8,12 @@ from randomizer.Enums.Time import Time
 class LocationLogic:
     """Logic for a location."""
 
-    def __init__(self, id, logic, bonusBarrel=None):
+    def __init__(self, id, logic, bonusBarrel=None, isAuxiliary=False):
         """Initialize with given parameters."""
         self.id = id
         self.logic = logic  # Lambda function for accessibility
         self.bonusBarrel = bonusBarrel  # Uses MinigameType enum
+        self.isAuxiliaryLocation = isAuxiliary  # For when the Location needs to be in a region but not count as in the region (only used for rabbit race glitched as of now)
 
 
 class Event:

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -44,7 +44,7 @@ LogicRegions = {
 
     Regions.GiantMushroomArea: Region("Giant Mushroom Area", "Giant Mushroom Exterior", Levels.FungiForest, True, None, [
         LocationLogic(Locations.ForestDiddyTopofMushroom, lambda l: l.jetpack and l.isdiddy, MinigameType.BonusBarrel),
-        LocationLogic(Locations.ForestLankyRabbitRace, lambda l: (l.CanOStandTBSNoclip() and l.spawn_snags)),
+        LocationLogic(Locations.ForestLankyRabbitRace, lambda l: (l.CanOStandTBSNoclip() and l.spawn_snags), isAuxiliary=True),
     ], [
         Event(Events.HollowTreeGateOpened, lambda l: l.grape and l.lanky),
     ], [


### PR DESCRIPTION
- Fixed an issue with the rabbit race's region by making the glitch access an "auxiliary" location logic
- Slight name tweak to the Lanky GB instrument pad to differentiate it from the Lanky upper Isles rocketbarrel pad
- Fixed LZR + item rando issue