### PR TITLE
Fixing the Pie Incident

### DIFF
--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -144,6 +144,34 @@ def AllItems(settings):
     return allItems
 
 
+def AllItemsForMovePlacement(settings):
+    """Return all shuffled items we need to assume for move placement."""
+    allItems = []
+    if Types.Blueprint in settings.shuffled_location_types:
+        allItems.extend(Blueprints(settings))
+    if Types.Banana in settings.shuffled_location_types:
+        allItems.extend(GoldenBananaItems())
+    if Types.Coin in settings.shuffled_location_types:
+        allItems.extend(CompanyCoinItems())
+    if Types.Crown in settings.shuffled_location_types:
+        allItems.extend(BattleCrownItems())
+    if Types.Key in settings.shuffled_location_types:
+        allItems.extend(Keys())
+    if Types.Medal in settings.shuffled_location_types:
+        allItems.extend(BananaMedalItems())
+    if Types.Kong in settings.shuffled_location_types:
+        allItems.extend(KongItems())
+    if Types.Bean in settings.shuffled_location_types:  # Could check for pearls as well
+        allItems.extend(MiscItemRandoItems())
+    if Types.Fairy in settings.shuffled_location_types:
+        allItems.extend(FairyItems())
+    if Types.RainbowCoin in settings.shuffled_location_types:
+        allItems.extend(RainbowCoinItems())
+    if Types.FakeItem in settings.shuffled_location_types:
+        allItems.extend(FakeItems())
+    return allItems
+
+
 def AllKongMoves():
     """Return all moves."""
     allMoves = []

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -122,7 +122,7 @@ class Location:
                 if location_id in RemovedShopLocations:
                     continue
                 if LocationList[location_id].kong == Kongs.any and LocationList[location_id].item == Items.NoItem:
-                    itemsInThisShop = len([location for location in ShopLocationReference[self.level][self.vendor] if LocationList[location].item not in (None, Items.NoItem)])
+                    itemsInThisShop = len([location for location in ShopLocationReference[self.level][self.vendor] if location not in RemovedShopLocations and LocationList[location].item not in (None, Items.NoItem)])
                     if itemsInThisShop == 0:
                         location_id.item = None
                 # Items.NoItem are only placed when locking out locations. If any exist, they're because this location caused them to be placed here

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -313,6 +313,8 @@ class LogicVarHolder:
         self.HelmChunky2 = self.HelmChunky2 or Items.HelmChunky2 in ownedItems
 
         self.Slam = 3 if self.settings.unlock_all_moves else sum(1 for x in ownedItems if x == Items.ProgressiveSlam) + STARTING_SLAM
+        if Items.ProgressiveSlam in self.banned_items:  # If slam is banned, prevent logic from owning a better slam
+            self.Slam = STARTING_SLAM
         self.AmmoBelts = 2 if self.settings.unlock_all_moves else sum(1 for x in ownedItems if x == Items.ProgressiveAmmoBelt)
         self.InstUpgrades = 3 if self.settings.unlock_all_moves else sum(1 for x in ownedItems if x == Items.ProgressiveInstrumentUpgrade)
 
@@ -680,7 +682,7 @@ class LogicVarHolder:
         # The only weird exception: vanilla Fungi Lobby hint doors only check for Chunky, not the current Kong, and all besides Chunky's needs grab
         if not self.settings.wrinkly_location_rando and not self.settings.remove_wrinkly_puzzles and region_id == RegionEnum.FungiForestLobby:
             return self.chunky and (location.kong == Kongs.chunky or (self.donkey and self.grab))
-        return self.settings.wrinkly_available or self.HasKong(location.kong)
+        return self.HasKong(location.kong)
 
     def CanBuy(self, location):
         """Check if there are enough coins to purchase this location."""
@@ -799,6 +801,80 @@ class LogicVarHolder:
     def BanItems(self, items):
         """Prevent an item from being picked up by the logic."""
         self.banned_items = items
+        # Also remove logical ownership of each item - this covers cases where you start with the move flag (not the training barrels, just raw start with like the camera/shockwave setting)
+        for item in items:
+            if item == Items.Vines:
+                self.vines = False
+            elif item == Items.Swim:
+                self.swim = False
+            elif item == Items.Barrels:
+                self.barrels = False
+            elif item == Items.Oranges:
+                self.oranges = False
+            elif item == Items.BaboonBlast:
+                self.blast = False
+            elif item == Items.StrongKong:
+                self.strongKong = False
+            elif item == Items.GorillaGrab:
+                self.grab = False
+            elif item == Items.ChimpyCharge:
+                self.charge = False
+            elif item == Items.RocketbarrelBoost:
+                self.jetpack = False
+            elif item == Items.SimianSpring:
+                self.spring = False
+            elif item == Items.Orangstand:
+                self.handstand = False
+            elif item == Items.BaboonBalloon:
+                self.balloon = False
+            elif item == Items.OrangstandSprint:
+                self.sprint = False
+            elif item == Items.MiniMonkey:
+                self.mini = False
+            elif item == Items.PonyTailTwirl:
+                self.twirl = False
+            elif item == Items.Monkeyport:
+                self.monkeyport = False
+            elif item == Items.HunkyChunky:
+                self.hunkyChunky = False
+            elif item == Items.PrimatePunch:
+                self.punch = False
+            elif item == Items.GorillaGone:
+                self.gorillaGone = False
+            elif item == Items.Coconut:
+                self.coconut = False
+            elif item == Items.Peanut:
+                self.peanut = False
+            elif item == Items.Grape:
+                self.grape = False
+            elif item == Items.Feather:
+                self.feather = False
+            elif item == Items.Pineapple:
+                self.pineapple = False
+            elif item == Items.HomingAmmo:
+                self.homing = False
+            elif item == Items.SniperSight:
+                self.scope = False
+            elif item == Items.Bongos:
+                self.bongos = False
+            elif item == Items.Guitar:
+                self.guitar = False
+            elif item == Items.Trombone:
+                self.trombone = False
+            elif item == Items.Saxophone:
+                self.saxophone = False
+            elif item == Items.Triangle:
+                self.triangle = False
+            elif item == Items.CameraAndShockwave:
+                self.camera = False
+                self.shockwave = False
+            elif item == Items.Camera:
+                self.camera = False
+            elif item == Items.Shockwave:
+                self.shockwave = False
+            elif item == Items.ProgressiveSlam:
+                self.Slam = STARTING_SLAM
+                # Banned slams are also handled with care in Update() specially
 
     def HasAllItems(self):
         """Return if you have all progression items."""

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -139,6 +139,7 @@ class Spoiler:
         settings["Open Levels"] = self.settings.open_levels
         settings["Auto Complete Bonus Barrels"] = self.settings.bonus_barrel_auto_complete
         settings["Complex Level Order"] = self.settings.hard_level_progression
+        settings["Progressive Switch Strength"] = self.settings.alter_switch_allocation
         settings["Hard Bosses"] = self.settings.hard_bosses
         settings["Hard Shooting"] = self.settings.hard_shooting
         settings["Free Trade Agreement"] = self.settings.free_trade_setting

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -120,7 +120,7 @@ def generate_lo_rando_race_settings():
     data["win_condition"] = "beat_krool"  # lots of options: all_keys | get_key_8 | beat_krool | all_medals | all_fairies | all_blueprints | poke_snap
     data["wrinkly_location_rando"] = False  # likely to be False
     data["tns_location_rando"] = False  # likely to be False
-    data["key_8_helm"] = True  # likely to be True? unclear as of yet
+    data["key_8_helm"] = True  # likely to be True in most settings
     data["misc_changes_selected"] = []  # a whole suite of things it includes
 
     data["hard_level_progression"] = False  # likely to be False
@@ -131,6 +131,7 @@ def generate_lo_rando_race_settings():
     data["glitches_selected"] = [""]
     data["microhints_enabled"] = "base"  # off/base/all
     data["smaller_shops"] = True  # likely to be True in item rando, many settings force it to be false
+    data["alter_switch_allocation"] = False  # likely to be True, easier to test things when false
 
     return data
 


### PR DESCRIPTION
Fix for the Pie Incident:
- Move placement needed to always assume GBs, Blueprints, Fairies, etc. (depending on what's in the item pool) in order to correctly place items

Other fixes here:
- Kongless hint doors now has no logic tied to it
- Moves you start with are now correctly hinted foolish if they are foolish. This only matters for items you start with besides the moves in the training barrels. Right now this is only useful for Camera & Shockwave but it could apply to other moves if we get around to some way to start with arbitrary moves.
- Put switch strength shuffle in the spoiler log