### PR TITLE
Sunset foolish moves, possibly fix LZR

### DIFF
--- a/randomizer/Lists/DoorLocations.py
+++ b/randomizer/Lists/DoorLocations.py
@@ -45,7 +45,6 @@ class DoorData:
             self.logic = lambda l: True
         else:
             self.logic = logic
-        self.logic = logic
         self.placed = placed
         self.default_kong = default_kong
         self.default_placed = placed  # info about what door_type a door location is in vanilla

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -553,7 +553,7 @@ class LogicVarHolder:
     def CanFreeTiny(self):
         """Check if kong at Tiny location can be freed, requires either chimpy charge or primate punch."""
         if LocationList[Locations.TinyKong].item == Items.NoItem:
-            return self.IsKong(self.settings.tiny_freeing_kong)
+            return self.IsKong(self.settings.tiny_freeing_kong) or self.settings.free_trade_items
         elif self.settings.tiny_freeing_kong == Kongs.diddy:
             return self.charge and self.isdiddy
         elif self.settings.tiny_freeing_kong == Kongs.chunky:
@@ -574,7 +574,12 @@ class LogicVarHolder:
 
     def CanFreeChunky(self):
         """Check if kong at Chunky location can be freed."""
-        return (LocationList[Locations.ChunkyKong].item == Items.NoItem or self.CanSlamSwitch(Levels.FranticFactory, 1)) and self.IsKong(self.settings.chunky_freeing_kong)
+        # If the cage is empty, the item is just lying on the ground
+        if LocationList[Locations.ChunkyKong].item == Items.NoItem:
+            return self.IsKong(self.settings.chunky_freeing_kong) or self.settings.free_trade_items
+        # Otherwise you need the right slam level (usually 1)
+        else:
+            return self.CanSlamSwitch(Levels.FranticFactory, 1) and self.IsKong(self.settings.chunky_freeing_kong)
 
     def UpdateCurrentRegionAccess(self, region):
         """Set access of current region."""

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -65,7 +65,7 @@ LogicRegions = {
         TransitionFront(Regions.CabinIsle, lambda l: l.settings.open_lobbies or Events.GalleonKeyTurnedIn in l.Events or l.CanMoonkick()),
         TransitionFront(Regions.CreepyCastleLobby, lambda l: l.settings.open_lobbies or Events.ForestKeyTurnedIn in l.Events, Transitions.IslesMainToCastleLobby),
         TransitionFront(Regions.KremIsleTopLevel, lambda l: l.tbs),
-        TransitionFront(Regions.KRool, lambda l: l.CanAccessKRool()),
+        TransitionFront(Regions.KRool, lambda l: l.CanAccessKRool() or l.pathMode),
     ]),
 
     Regions.IslesMainUpper: Region("Isles Main Upper", "DK Isle", Levels.DKIsles, False, None, [
@@ -73,6 +73,7 @@ LogicRegions = {
     ], [
         Event(Events.IslesDiddyBarrelSpawn, lambda l: l.chunky and l.trombone and l.lanky and l.barrels),
     ], [
+        TransitionFront(Regions.IslesMain, lambda l: True),
         TransitionFront(Regions.AngryAztecLobby, lambda l: l.settings.open_lobbies or Events.JapesKeyTurnedIn in l.Events or l.phasewalk, Transitions.IslesMainToAztecLobby),
         TransitionFront(Regions.CrystalCavesLobby, lambda l: (l.settings.open_lobbies or Events.ForestKeyTurnedIn in l.Events) and (l.isdonkey or l.ischunky or (l.istiny and l.twirl) or ((l.isdiddy or l.islanky) and l.advanced_platforming) or l.CanMoonkick()), Transitions.IslesMainToCavesLobby),
     ]),

--- a/randomizer/LogicFiles/FranticFactory.py
+++ b/randomizer/LogicFiles/FranticFactory.py
@@ -102,7 +102,7 @@ LogicRegions = {
         LocationLogic(Locations.ChunkyKong, lambda l: l.CanFreeChunky()),
         LocationLogic(Locations.NintendoCoin, lambda l: Events.ArcadeLeverSpawned in l.Events and l.grab and l.isdonkey and (l.GetCoins(Kongs.donkey) >= 2)),
         LocationLogic(Locations.FactoryDonkeyDKArcade, lambda l: (not l.settings.fast_gbs and (Events.ArcadeLeverSpawned in l.Events and l.grab and l.isdonkey)) or (l.CanOStandTBSNoclip() and l.spawn_snags)),
-        LocationLogic(Locations.FactoryLankyFreeChunky, lambda l: l.CanSlamSwitch(Levels.FranticFactory, 1) and l.HasKong(l.settings.chunky_freeing_kong)),
+        LocationLogic(Locations.FactoryLankyFreeChunky, lambda l: l.CanFreeChunky()),
         LocationLogic(Locations.FactoryTinybyArcade, lambda l: (l.mini and l.tiny) or l.phasewalk),
         LocationLogic(Locations.FactoryChunkyDarkRoom, lambda l: ((l.punch and l.CanSlamSwitch(Levels.FranticFactory, 1)) or l.generalclips) and l.ischunky),
         LocationLogic(Locations.RainbowCoin_Location02, lambda l: l.punch and l.shockwave),

--- a/randomizer/LogicFiles/GloomyGalleon.py
+++ b/randomizer/LogicFiles/GloomyGalleon.py
@@ -156,6 +156,7 @@ LogicRegions = {
         Event(Events.ShipyardEnguarde, lambda l: l.lanky),
     ], [
         TransitionFront(Regions.GloomyGalleonMedals, lambda l: True),
+        TransitionFront(Regions.Shipyard, lambda l: True),
         TransitionFront(Regions.TreasureRoom, lambda l: Events.ShipyardTreasureRoomOpened in l.Events or l.CanPhaseswim()),
         TransitionFront(Regions.Submarine, lambda l: ((l.mini or l.CanSTS()) and l.istiny) or l.CanPhaseswim(), Transitions.GalleonShipyardToSubmarine),
         TransitionFront(Regions.Mechafish, lambda l: Events.MechafishSummoned in l.Events and l.isdiddy),

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -28,7 +28,7 @@ def generate_lo_rando_race_settings():
     data["random_medal_requirement"] = False
     data["medal_requirement"] = 15  # vanilla is 15
     data["medal_cb_req"] = 75  # vanilla is 75
-    data["kasplat_rando_setting"] = "vanilla_locations"  # usually vanilla_locations but i like location_shuffle
+    data["kasplat_rando_setting"] = "vanilla_locations"  # usually vanilla_locations but i like location_shuffle, RARELY set to off
     data["kong_rando"] = True  # usually True - FORCED True if level_order shuffle
 
     data["bananaport_rando"] = "off"  # usually "off", could be "in_level" "crossmap_coupled" "crossmap_decoupled"
@@ -66,7 +66,7 @@ def generate_lo_rando_race_settings():
     data["troff_6"] = 500
     data["troff_text"] = 400  # usually 400?
 
-    data["level_randomization"] = "level_order"  # usually "level_order" may need to test with "loadingzone" or "loadingzonesdecoupled"
+    data["level_randomization"] = "loadingzone"  # usually "level_order" may need to test with "loadingzone" or "loadingzonesdecoupled"
 
     data["damage_amount"] = "default"
     data["no_healing"] = False
@@ -132,6 +132,7 @@ def generate_lo_rando_race_settings():
     data["microhints_enabled"] = "base"  # off/base/all
     data["smaller_shops"] = True  # likely to be True in item rando, many settings force it to be false
     data["alter_switch_allocation"] = False  # likely to be True, easier to test things when false
+    data["random_starting_region"] = True  # likely to be False
 
     return data
 


### PR DESCRIPTION
- Removed Foolish move hints. I can't think of a reasonable way to get around the issues I bring up in comments. The code is all there if we want to resurrect it. As it stands, I can't guarantee that both sides of an either/or would be not foolish. Foolish move hints have been converted to more foolish region hints.
- Fixed an issue where the logic might expect you to get a slam for the item in Chunky's cage even when it's empty
- Converted K. Rool path hints to a "truer" path. It will now hint *anything* required to K. Rool. To compensate, you should see a greater number of these hints than before, up to 5 depending on the phases involved and the length of the path.
- Fixed some logic issues that would affect some (most?) random starting locations and would likely cause issues with LZR.