### PR TITLE
fixed issue preventing key hints from appearing

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -567,6 +567,9 @@ def CalculateWothPaths(spoiler, WothLocations):
                 # This is a bit of a compromise, as you *might* see these moves WotH purely for coins/GBs but they won't be on paths
                 if location.item in (Items.Swim, Items.Vines, Items.PonyTailTwirl):
                     continue
+                # Keys that make it here are also always WotH
+                if location.item in ItemPool.Keys():
+                    continue
                 WothLocations.remove(locationId)
                 del spoiler.woth_paths[locationId]
                 # If we remove anything, we have to check the whole list again


### PR DESCRIPTION
Turns out the Banana Hoard path was very important to key hints, woops. This might impact other win cons but I'm shooting first and asking questions later.