### PR TITLE
fix 100cb fill fails, always path hint key 8

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -387,11 +387,11 @@ def compileHints(spoiler: Spoiler):
         Items.CreepyCastleKey: 0,
         Items.HideoutHelmKey: 0,
     }
-    # Calculate the number of key hints that need to be placed
-    if spoiler.settings.shuffle_items and Types.Key in spoiler.settings.shuffled_location_types:
+    # Calculate the number of key hints that need to be placed. Any WotH keys should have paths that we should hint.
+    woth_key_ids = [LocationList[woth_loc].item for woth_loc in spoiler.woth_locations if ItemList[LocationList[woth_loc].item].type == Types.Key]
+    if len(woth_key_ids) > 0:  # spoiler.settings.shuffle_items and Types.Key in spoiler.settings.shuffled_location_types:
         valid_types.append(HintType.RequiredKeyHint)
         # Only hint keys that are in the Way of the Hoard
-        woth_key_ids = [LocationList[woth_loc].item for woth_loc in spoiler.woth_locations if ItemList[LocationList[woth_loc].item].type == Types.Key]
         key_location_ids = {}
         # Find the locations of the Keys
         for location_id, location in LocationList.items():
@@ -677,7 +677,10 @@ def compileHints(spoiler: Spoiler):
                 # If there are no doors available (pretty unlikely) then just get a random one. Tough luck.
                 else:
                     hint_location = getRandomHintLocation()
-                message = f"{key_item.name} can be acquired with {kong_name} in {level_name}."
+                if location.type == Types.Blueprint:
+                    message = f"{key_item.name} is held by a kasplat in {level_name}."
+                else:
+                    message = f"{key_item.name} can be acquired with {kong_name} in {level_name}."
                 hint_location.hint_type = HintType.RequiredKeyHint
                 UpdateHint(hint_location, message)
             # For later or complex Keys, place hints that hint the "path" to the key

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -475,8 +475,9 @@ def PareWoth(spoiler, PlaythroughLocations):
         # Don't want constant locations in woth and we can filter out some types of items as not being essential to the woth
         for loc in [
             loc
-            for loc in sphere.locations
-            if not LocationList[loc].constant and ItemList[LocationList[loc].item].type not in (Types.Banana, Types.BlueprintBanana, Types.Crown, Types.Medal, Types.Blueprint)
+            for loc in sphere.locations  # If the Helm Key is in Helm, we may still want path hints for it even though it's a constant item.
+            if (not LocationList[loc].constant or loc == Locations.HelmKey)
+            and ItemList[LocationList[loc].item].type not in (Types.Banana, Types.BlueprintBanana, Types.Crown, Types.Medal, Types.Blueprint)
         ]:
             WothLocations.append(loc)
     WothLocations.append(Locations.BananaHoard)  # The Banana Hoard is the endpoint of the Way of the Hoard

--- a/randomizer/Lists/CBLocations/AngryAztecCBLocations.py
+++ b/randomizer/Lists/CBLocations/AngryAztecCBLocations.py
@@ -5,57 +5,7 @@ from randomizer.Enums.Regions import Regions
 from randomizer.Lists.MapsAndExits import Maps
 from randomizer.Enums.Kongs import Kongs
 from randomizer.Enums.Levels import Levels
-
-
-class ColoredBananaGroup:
-    """Stores data for each group of colored bananas."""
-
-    def __init__(self, *, group=0, name="No Location", map_id=0, konglist=[], region=None, logic=None, vanilla=False, locations=[]):
-        """Initialize with given parameters."""
-        self.group = group
-        self.name = name
-        self.map = map_id
-        self.kongs = konglist
-        self.locations = locations  # 5 numbers: {int amount, float scale, int x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-
-
-class Balloon:
-    """Stores data for each balloon."""
-
-    def __init__(self, *, id=0, name="No Location", map_id=0, speed=0, konglist=[], region=None, logic=None, vanilla=False, points=[]):
-        """Initialize with given parameters."""
-        self.id = id
-        self.name = name
-        self.map = map_id
-        self.speed = speed
-        self.kongs = konglist
-        self.points = points  # 4 numbers: {int point id, x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-        self.spawnPoint = self.setSpawnPoint(points)
-
-    def setSpawnPoint(self, points=[]):
-        """Set the spawn point of a balloon based on its path."""
-        spawnX = 0
-        spawnY = 0
-        spawnZ = 0
-        for p in points:
-            spawnX += p[0]
-            spawnY += p[1]
-            spawnZ += p[2]
-        spawnX /= len(points)
-        spawnY /= len(points)
-        spawnY -= 100  # Most balloons are at least 100 units off the ground
-        spawnZ /= len(points)
-        return [int(spawnX), int(spawnY), int(spawnZ)]
+from randomizer.LogicClasses import Balloon, ColoredBananaGroup
 
 
 ColoredBananaGroupList = [

--- a/randomizer/Lists/CBLocations/CreepyCastleCBLocations.py
+++ b/randomizer/Lists/CBLocations/CreepyCastleCBLocations.py
@@ -2,61 +2,10 @@
 
 from randomizer.Enums.Events import Events
 from randomizer.Enums.Regions import Regions
-from randomizer.Lists.CBLocations.AngryAztecCBLocations import BalloonList, ColoredBananaGroupList
 from randomizer.Lists.MapsAndExits import Maps
 from randomizer.Enums.Kongs import Kongs
 from randomizer.Enums.Levels import Levels
-
-
-class ColoredBananaGroup:
-    """Stores data for each group of colored bananas."""
-
-    def __init__(self, *, group=0, name="No Location", map_id=0, konglist=[], region=None, logic=None, vanilla=False, locations=[]):
-        """Initialize with given parameters."""
-        self.group = group
-        self.name = name
-        self.map = map_id
-        self.kongs = konglist
-        self.locations = locations  # 5 numbers: {int amount, float scale, int x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-
-
-class Balloon:
-    """Stores data for each balloon."""
-
-    def __init__(self, *, id=0, name="No Location", map_id=0, speed=0, konglist=[], region=None, logic=None, vanilla=False, points=[]):
-        """Initialize with given parameters."""
-        self.id = id
-        self.name = name
-        self.map = map_id
-        self.speed = speed
-        self.kongs = konglist
-        self.points = points  # 3 numbers: [int x, y, z]
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-        self.spawnPoint = self.setSpawnPoint(points)
-
-    def setSpawnPoint(self, points=[]):
-        """Set the spawn point of a balloon based on its path."""
-        spawnX = 0
-        spawnY = 0
-        spawnZ = 0
-        for p in points:
-            spawnX += p[0]
-            spawnY += p[1]
-            spawnZ += p[2]
-        spawnX /= len(points)
-        spawnY /= len(points)
-        spawnY -= 100  # Most balloons are at least 100 units off the ground
-        spawnZ /= len(points)
-        return [int(spawnX), int(spawnY), int(spawnZ)]
+from randomizer.LogicClasses import Balloon, ColoredBananaGroup
 
 
 ColoredBananaGroupList = [
@@ -1254,7 +1203,7 @@ ColoredBananaGroupList = [
     #     map_id=Maps.CastleMausoleum,
     #     name="On Goo hands",
     #     konglist=[Kongs.tiny],
-    #     region=Regions.Mausoleum,
+    #     lregion=Regions.Mausoleum,
     #     logic=lambda l: l.CanSlamSwitch(Levels.CreepyCastle, 3) and l.twirl,
     #     locations=[[5, 1.0, 1178, 190, 2048], [5, 1.0, 1348, 190, 2310], [5, 1.0, 987, 190, 2297]],
     # ),

--- a/randomizer/Lists/CBLocations/CrystalCavesCBLocations.py
+++ b/randomizer/Lists/CBLocations/CrystalCavesCBLocations.py
@@ -2,62 +2,10 @@
 
 from randomizer.Enums.Events import Events
 from randomizer.Enums.Regions import Regions
-from randomizer.Lists.CBLocations.AngryAztecCBLocations import BalloonList, ColoredBananaGroupList
 from randomizer.Lists.MapsAndExits import Maps
 from randomizer.Enums.Kongs import Kongs
 from randomizer.Enums.Levels import Levels
-
-
-class ColoredBananaGroup:
-    """Stores data for each group of colored bananas."""
-
-    def __init__(self, *, group=0, name="No Location", map_id=0, konglist=[], region=None, logic=None, vanilla=False, locations=[]):
-        """Initialize with given parameters."""
-        self.group = group
-        self.name = name
-        self.map = map_id
-        self.kongs = konglist
-        self.locations = locations  # 5 numbers: {int amount, float scale, int x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-
-
-class Balloon:
-    """Stores data for each balloon."""
-
-    def __init__(self, *, id=0, name="No Location", map_id=0, speed=0, konglist=[], region=None, logic=None, vanilla=False, points=[]):
-        """Initialize with given parameters."""
-        self.id = id
-        self.name = name
-        self.map = map_id
-        self.speed = speed
-        self.kongs = konglist
-        self.points = points  # 4 numbers: {int point id, x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-        self.spawnPoint = self.setSpawnPoint(points)
-
-    def setSpawnPoint(self, points=[]):
-        """Set the spawn point of a balloon based on its path."""
-        spawnX = 0
-        spawnY = 0
-        spawnZ = 0
-        for p in points:
-            spawnX += p[0]
-            spawnY += p[1]
-            spawnZ += p[2]
-        spawnX /= len(points)
-        spawnY /= len(points)
-        spawnY -= 100  # Most balloons are at least 100 units off the ground
-        spawnZ /= len(points)
-        return [int(spawnX), int(spawnY), int(spawnZ)]
-
+from randomizer.LogicClasses import Balloon, ColoredBananaGroup
 
 WATER_HEIGHT = 30
 

--- a/randomizer/Lists/CBLocations/FranticFactoryCBLocations.py
+++ b/randomizer/Lists/CBLocations/FranticFactoryCBLocations.py
@@ -2,61 +2,9 @@
 
 from randomizer.Enums.Events import Events
 from randomizer.Enums.Regions import Regions
-from randomizer.Lists.CBLocations.AngryAztecCBLocations import ColoredBananaGroupList
 from randomizer.Lists.MapsAndExits import Maps
 from randomizer.Enums.Kongs import Kongs
-from randomizer.Enums.Levels import Levels
-
-
-class ColoredBananaGroup:
-    """Stores data for each group of colored bananas."""
-
-    def __init__(self, *, group=0, name="No Location", map_id=0, konglist=[], region=None, logic=None, vanilla=False, locations=[]):
-        """Initialize with given parameters."""
-        self.group = group
-        self.name = name
-        self.map = map_id
-        self.kongs = konglist
-        self.locations = locations  # 5 numbers: {int amount, float scale, int x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-
-
-class Balloon:
-    """Stores data for each balloon."""
-
-    def __init__(self, *, id=0, name="No Location", map_id=0, speed=0, konglist=[], region=None, logic=None, vanilla=False, points=[]):
-        """Initialize with given parameters."""
-        self.id = id
-        self.name = name
-        self.map = map_id
-        self.speed = speed
-        self.kongs = konglist
-        self.points = points  # 4 numbers: {int point id, x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-        self.spawnPoint = self.setSpawnPoint(points)
-
-    def setSpawnPoint(self, points=[]):
-        """Set the spawn point of a balloon based on its path."""
-        spawnX = 0
-        spawnY = 0
-        spawnZ = 0
-        for p in points:
-            spawnX += p[0]
-            spawnY += p[1]
-            spawnZ += p[2]
-        spawnX /= len(points)
-        spawnY /= len(points)
-        spawnY -= 100  # Most balloons are at least 100 units off the ground
-        spawnZ /= len(points)
-        return [int(spawnX), int(spawnY), int(spawnZ)]
+from randomizer.LogicClasses import Balloon, ColoredBananaGroup
 
 
 ColoredBananaGroupList = [
@@ -516,7 +464,7 @@ ColoredBananaGroupList = [
     #     map_id=Maps.FranticFactory,
     #     name="On vines to Beaver Bother barrel",
     #     konglist=[Kongs.diddy],
-    #     region=Regions.ChunkyRoomPlatform,
+    #     lregion=Regions.ChunkyRoomPlatform,
     #     logic=lambda l: l.CanSlamSwitch(Levels.FranticFactory, 1) and l.vines,
     #     locations=[[5, 1.0, 1327, 160, 839], [5, 1.0, 1237, 178, 840]],
     # ),
@@ -1603,7 +1551,7 @@ BalloonList = [
         map_id=Maps.FranticFactory,
         name="Chunky R&D room",
         speed=4,
-        konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
+        konglist=[Kongs.chunky],
         region=Regions.RandD,
         points=[[5086, 1580, 1562], [4830, 1560, 1948]],
     ),

--- a/randomizer/Lists/CBLocations/FungiForestCBLocations.py
+++ b/randomizer/Lists/CBLocations/FungiForestCBLocations.py
@@ -2,61 +2,10 @@
 
 from randomizer.Enums.Events import Events
 from randomizer.Enums.Regions import Regions
-from randomizer.Lists.CBLocations.AngryAztecCBLocations import BalloonList, ColoredBananaGroupList
 from randomizer.Lists.MapsAndExits import Maps
 from randomizer.Enums.Kongs import Kongs
 from randomizer.Enums.Levels import Levels
-
-
-class ColoredBananaGroup:
-    """Stores data for each group of colored bananas."""
-
-    def __init__(self, *, group=0, name="No Location", map_id=0, konglist=[], region=None, logic=None, vanilla=False, locations=[]):
-        """Initialize with given parameters."""
-        self.group = group
-        self.name = name
-        self.map = map_id
-        self.kongs = konglist
-        self.locations = locations  # 5 numbers: {int amount, float scale, int x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-
-
-class Balloon:
-    """Stores data for each balloon."""
-
-    def __init__(self, *, id=0, name="No Location", map_id=0, speed=0, konglist=[], region=None, logic=None, vanilla=False, points=[]):
-        """Initialize with given parameters."""
-        self.id = id
-        self.name = name
-        self.map = map_id
-        self.speed = speed
-        self.kongs = konglist
-        self.points = points  # 4 numbers: {int point id, x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-        self.spawnPoint = self.setSpawnPoint(points)
-
-    def setSpawnPoint(self, points=[]):
-        """Set the spawn point of a balloon based on its path."""
-        spawnX = 0
-        spawnY = 0
-        spawnZ = 0
-        for p in points:
-            spawnX += p[0]
-            spawnY += p[1]
-            spawnZ += p[2]
-        spawnX /= len(points)
-        spawnY /= len(points)
-        spawnY -= 100  # Most balloons are at least 100 units off the ground
-        spawnZ /= len(points)
-        return [int(spawnX), int(spawnY), int(spawnZ)]
+from randomizer.LogicClasses import Balloon, ColoredBananaGroup
 
 
 ColoredBananaGroupList = [

--- a/randomizer/Lists/CBLocations/GloomyGalleonCBLocations.py
+++ b/randomizer/Lists/CBLocations/GloomyGalleonCBLocations.py
@@ -2,60 +2,9 @@
 
 from randomizer.Enums.Events import Events
 from randomizer.Enums.Regions import Regions
-from randomizer.Lists.CBLocations.AngryAztecCBLocations import BalloonList, ColoredBananaGroupList
 from randomizer.Lists.MapsAndExits import Maps
 from randomizer.Enums.Kongs import Kongs
-
-
-class ColoredBananaGroup:
-    """Stores data for each group of colored bananas."""
-
-    def __init__(self, *, group=0, name="No Location", map_id=0, konglist=[], region=None, logic=None, vanilla=False, locations=[]):
-        """Initialize with given parameters."""
-        self.group = group
-        self.name = name
-        self.map = map_id
-        self.kongs = konglist
-        self.locations = locations  # 5 numbers: {int amount, float scale, int x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-
-
-class Balloon:
-    """Stores data for each balloon."""
-
-    def __init__(self, *, id=0, name="No Location", map_id=0, speed=0, konglist=[], region=None, logic=None, vanilla=False, points=[]):
-        """Initialize with given parameters."""
-        self.id = id
-        self.name = name
-        self.map = map_id
-        self.speed = speed
-        self.kongs = konglist
-        self.points = points  # 4 numbers: {int point id, x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-        self.spawnPoint = self.setSpawnPoint(points)
-
-    def setSpawnPoint(self, points=[]):
-        """Set the spawn point of a balloon based on its path."""
-        spawnX = 0
-        spawnY = 0
-        spawnZ = 0
-        for p in points:
-            spawnX += p[0]
-            spawnY += p[1]
-            spawnZ += p[2]
-        spawnX /= len(points)
-        spawnY /= len(points)
-        spawnY -= 100  # Most balloons are at least 100 units off the ground
-        spawnZ /= len(points)
-        return [int(spawnX), int(spawnY), int(spawnZ)]
+from randomizer.LogicClasses import Balloon, ColoredBananaGroup
 
 
 ColoredBananaGroupList = [

--- a/randomizer/Lists/CBLocations/JungleJapesCBLocations.py
+++ b/randomizer/Lists/CBLocations/JungleJapesCBLocations.py
@@ -5,57 +5,7 @@ from randomizer.Enums.Regions import Regions
 from randomizer.Lists.MapsAndExits import Maps
 from randomizer.Enums.Kongs import Kongs
 from randomizer.Enums.Levels import Levels
-
-
-class ColoredBananaGroup:
-    """Stores data for each group of colored bananas."""
-
-    def __init__(self, *, group=0, name="No Location", map_id=0, konglist=[], region=None, logic=None, vanilla=False, locations=[]):
-        """Initialize with given parameters."""
-        self.group = group
-        self.name = name
-        self.map = map_id
-        self.kongs = konglist
-        self.locations = locations  # 5 numbers: {int amount, float scale, int x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-
-
-class Balloon:
-    """Stores data for each balloon."""
-
-    def __init__(self, *, id=0, name="No Location", map_id=0, speed=0, konglist=[], region=None, logic=None, vanilla=False, points=[]):
-        """Initialize with given parameters."""
-        self.id = id
-        self.name = name
-        self.map = map_id
-        self.speed = speed
-        self.kongs = konglist
-        self.points = points  # 4 numbers: {int point id, x, y, z}
-        self.region = region
-        if logic is None:
-            self.logic = lambda l: True
-        else:
-            self.logic = logic
-        self.spawnPoint = self.setSpawnPoint(points)
-
-    def setSpawnPoint(self, points=[]):
-        """Set the spawn point of a balloon based on its path."""
-        spawnX = 0
-        spawnY = 0
-        spawnZ = 0
-        for p in points:
-            spawnX += p[0]
-            spawnY += p[1]
-            spawnZ += p[2]
-        spawnX /= len(points)
-        spawnY /= len(points)
-        spawnY -= 100  # Most balloons are at least 100 units off the ground
-        spawnZ /= len(points)
-        return [int(spawnX), int(spawnY), int(spawnZ)]
+from randomizer.LogicClasses import Balloon, ColoredBananaGroup
 
 
 ColoredBananaGroupList = [
@@ -953,7 +903,7 @@ ColoredBananaGroupList = [
     #     map_id=Maps.JungleJapes,
     #     name="Tiny's caged GB",
     #     konglist=[Kongs.tiny],
-    #     region=Regions.JungleJapesMain,
+    #     lregion=Regions.JungleJapesMain,
     #     logic=lambda l: Events.JapesTinySwitch in l.Events and l.CanSlamSwitch(Levels.JungleJapes, 1),
     #     locations=[[5, 1.0, 1335, 285, 1974], [5, 1.0, 1300, 285, 1946]],
     # ),  # Temporarily disabled
@@ -962,7 +912,7 @@ ColoredBananaGroupList = [
     #     map_id=Maps.JungleJapes,
     #     name="Lanky's caged GB",
     #     konglist=[Kongs.lanky],
-    #     region=Regions.JungleJapesMain,
+    #     lregion=Regions.JungleJapesMain,
     #     logic=lambda l: Events.JapesLankySwitch in l.Events and l.CanSlamSwitch(Levels.JungleJapes, 1),
     #     locations=[[5, 1.0, 1140, 525, 2346], [5, 1.0, 1186, 525, 2326]],
     # ),  # Temporarily disabled
@@ -979,7 +929,7 @@ ColoredBananaGroupList = [
     #     map_id=Maps.JungleJapes,
     #     name="Diddy's Caged GB",
     #     konglist=[Kongs.diddy],
-    #     region=Regions.JungleJapesMain,
+    #     lregion=Regions.JungleJapesMain,
     #     logic=lambda l: Events.JapesDiddySwitch1 in l.Events and l.CanSlamSwitch(Levels.JungleJapes, 1),
     #     locations=[[5, 1.0, 2305, 525, 2101], [5, 1.0, 2310, 525, 2142]],
     # ),  # Temporarily disabled
@@ -988,7 +938,7 @@ ColoredBananaGroupList = [
     #     map_id=Maps.JungleJapes,
     #     name="Chunky's Caged GB",
     #     konglist=[Kongs.chunky],
-    #     region=Regions.JungleJapesMain,
+    #     lregion=Regions.JungleJapesMain,
     #     logic=lambda l: Events.JapesChunkySwitch in l.Events and l.CanSlamSwitch(Levels.JungleJapes, 1),
     #     locations=[[5, 1.0, 2335, 685, 2207], [5, 1.0, 2362, 685, 2253]],
     # ),  # Temporarily disabled

--- a/randomizer/Lists/Exceptions.py
+++ b/randomizer/Lists/Exceptions.py
@@ -95,3 +95,9 @@ class BossOutOfLocationsException(FillException):
     """Exception triggered when there are no valid levels to put a boss."""
 
     pass
+
+
+class CBFillFailureException(FillException):
+    """Exception triggered when CB rando fails to correctly generate a valid set of groups."""
+
+    pass

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -231,7 +231,7 @@ LocationList = {
     Locations.AztecDiddy5DoorTemple: Location(Levels.AngryAztec, "Aztec Diddy 5 Door Temple", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(Maps.AztecDiddy5DTemple, 0x6, 56, Kongs.diddy)]),
     Locations.AztecLanky5DoorTemple: Location(Levels.AngryAztec, "Aztec Lanky 5 Door Temple", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(0, -1, 60, Kongs.lanky)]),
     Locations.AztecTiny5DoorTemple: Location(Levels.AngryAztec, "Aztec Tiny 5 Door Temple", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.AztecTiny5DTemple, 0x6, 58, Kongs.tiny)]),
-    Locations.AztecBananaFairyTinyTemple: Location(Levels.AngryAztec, "Aztec Tiny Temple Banana Fairy", Items.BananaFairy, Types.Fairy, Kongs.any, [MapIDCombo(Maps.AztecTiny5DTemple, -1, 601)]),
+    Locations.AztecBananaFairyTinyTemple: Location(Levels.AngryAztec, "Aztec Tiny 5 Door Temple Banana Fairy", Items.BananaFairy, Types.Fairy, Kongs.any, [MapIDCombo(Maps.AztecTiny5DTemple, -1, 601)]),
     Locations.AztecChunky5DoorTemple: Location(Levels.AngryAztec, "Aztec Chunky 5 Door Temple", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(0, -1, 59, Kongs.chunky)]),
     Locations.AztecKasplatChunky5DT: Location(Levels.AngryAztec, "Aztec Kasplat Inside Chunky's 5-Door Temple", Items.AngryAztecChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.AztecChunky5DTemple]),
     Locations.AztecTinyBeetleRace: Location(Levels.AngryAztec, "Aztec Tiny Beetle Race", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.AztecTinyRace, 0x48, 75, Kongs.tiny)]),

--- a/randomizer/LogicClasses.py
+++ b/randomizer/LogicClasses.py
@@ -198,3 +198,56 @@ class Sphere:
         self.seedBeaten = False
         self.availableGBs = 0
         self.locations = []
+
+
+class ColoredBananaGroup:
+    """Stores data for each group of colored bananas."""
+
+    def __init__(self, *, group=0, name="No Location", map_id=0, konglist=[], region=None, logic=None, vanilla=False, locations=[]):
+        """Initialize with given parameters."""
+        self.group = group
+        self.name = name
+        self.map = map_id
+        self.kongs = konglist
+        self.locations = locations  # 5 numbers: {int amount, float scale, int x, y, z}
+        self.region = region
+        if logic is None:
+            self.logic = lambda l: True
+        else:
+            self.logic = logic
+        self.selected = False
+
+
+class Balloon:
+    """Stores data for each balloon."""
+
+    def __init__(self, *, id=0, name="No Location", map_id=0, speed=0, konglist=[], region=None, logic=None, vanilla=False, points=[]):
+        """Initialize with given parameters."""
+        self.id = id
+        self.name = name
+        self.map = map_id
+        self.speed = speed
+        self.kongs = konglist
+        self.points = points  # 3 numbers: [int x, y, z]
+        self.region = region
+        if logic is None:
+            self.logic = lambda l: True
+        else:
+            self.logic = logic
+        self.spawnPoint = self.setSpawnPoint(points)
+        self.selected = False
+
+    def setSpawnPoint(self, points=[]):
+        """Set the spawn point of a balloon based on its path."""
+        spawnX = 0
+        spawnY = 0
+        spawnZ = 0
+        for p in points:
+            spawnX += p[0]
+            spawnY += p[1]
+            spawnZ += p[2]
+        spawnX /= len(points)
+        spawnY /= len(points)
+        spawnY -= 100  # Most balloons are at least 100 units off the ground
+        spawnZ /= len(points)
+        return [int(spawnX), int(spawnY), int(spawnZ)]

--- a/randomizer/ShuffleBosses.py
+++ b/randomizer/ShuffleBosses.py
@@ -146,7 +146,7 @@ def ShuffleBossesBasedOnOwnedItems(settings, ownedKongs: dict, ownedMoves: dict)
             forestBossOptions.remove(factoryBossIndex)
         # Then place Dogadon 2 (if Mad Jack was placed first)
         if forestBossKong is None:
-            bossTryingToBePlaced = "Dogadon 2"
+            bossTryingToBePlaced = "Dogadon 2 (second)"
             forestBossIndex = random.choice(forestBossOptions)
             forestBossKong = Kongs.chunky
 

--- a/randomizer/ShuffleCBs.py
+++ b/randomizer/ShuffleCBs.py
@@ -8,6 +8,7 @@ import randomizer.Lists.CBLocations.GloomyGalleonCBLocations
 import randomizer.Lists.CBLocations.FungiForestCBLocations
 import randomizer.Lists.CBLocations.CrystalCavesCBLocations
 import randomizer.Lists.CBLocations.CreepyCastleCBLocations
+import randomizer.Lists.Exceptions as Ex
 import randomizer.CollectibleLogicFiles.JungleJapes
 import randomizer.CollectibleLogicFiles.AngryAztec
 import randomizer.CollectibleLogicFiles.FranticFactory
@@ -20,6 +21,8 @@ from randomizer.Enums.Levels import Levels
 from randomizer.Spoiler import Spoiler
 from randomizer.Enums.Kongs import Kongs
 import random
+import js
+
 
 max_balloons = 105
 max_singles = 780  # 793 Singles in Vanilla, under-representing this to help with the calculation formula
@@ -66,114 +69,130 @@ level_data = {
 
 def ShuffleCBs(spoiler: Spoiler):
     """Shuffle CBs selected from location files."""
-    total_balloons = 0
-    total_singles = 0
-    total_bunches = 0
-    cb_data = []
-    for level_index, level in enumerate(level_data):
-        # First, disable all vanilla placed colored bananas
-        for region in level_data[level]["logic"]:
-            for collectible in level_data[level]["logic"][region]:
-                if collectible.type in [Collectibles.balloon, Collectibles.bunch, Collectibles.banana]:
-                    collectible.enabled = False
-        level_placement = []
-        global_divisor = 6 - level_index
-        kong_specific_left = {Kongs.donkey: 100, Kongs.diddy: 100, Kongs.lanky: 100, Kongs.tiny: 100, Kongs.chunky: 100}
-        # Balloons
-        # Pick random amount of balloons assigned to level
-        balloons_left = max_balloons - total_balloons
-        balloon_lower = max(int(balloons_left / (7 - level_index)) - 3, 0)  # Select lower bound for randomization as max between 0, and balloons left distributed amongst the remaining levels minus 3
-        if global_divisor == 0:
-            # Last Level
-            balloon_upper = balloons_left
-        else:
-            balloon_upper = min(int(balloons_left / (7 - level_index)) + 3, int(balloons_left / global_divisor))
-        balloon_lst = level_data[level]["balloons"].copy()
-        selected_balloon_count = min(random.randint(min(balloon_lower, balloon_upper), max(balloon_lower, balloon_upper)), len(balloon_lst))
-        # selected_balloon_count = 22 # Test all balloon locations
-        random.shuffle(balloon_lst)  # TODO: Maybe make this more advanced?
-        # selects all balloons
-        placed_balloons = 0
-        for balloon in balloon_lst:
-            if placed_balloons < selected_balloon_count:
-                balloon_kongs = balloon.kongs.copy()
-                for kong in kong_specific_left:
-                    if kong_specific_left[kong] < 10 and kong in balloon_kongs:  # Not enough Colored Bananas to place a balloon:
-                        balloon_kongs.remove(kong)  # Remove kong from permitted list
-                if len(balloon_kongs) > 0:  # Has a kong who can be assigned to this balloon
-                    selected_kong = random.choice(balloon_kongs)
-                    kong_specific_left[selected_kong] -= 10  # Remove CBs for Balloon
-                    level_placement.append({"id": balloon.id, "name": balloon.name, "kong": selected_kong, "level": level, "type": "balloons", "map": balloon.map})
-                    placed_balloons += 1
-                    level_data[level]["logic"][balloon.region].append(Collectible(Collectibles.balloon, selected_kong, balloon.logic, None, 1))
-        # Model Two CBs
-        bunches_left = max_bunches - total_bunches
-        singles_left = max_singles - total_singles
-        bunches_lower = max(int(bunches_left / (7 - level_index)) - 5, 0)
-        singles_lower = max(int(singles_left / (7 - level_index)) - 10, 0)
-        if global_divisor == 0:
-            bunches_upper = bunches_left
-            singles_upper = min(singles_left, int((5 * (1127 - total_bunches - total_singles) - sum(kong_specific_left)) / 4))  # Places a hard cap of 1127 total singles+bunches
-        else:
-            bunches_upper = min(int(bunches_left / (7 - level_index)) + 15, int(bunches_left / global_divisor))
-            singles_upper = min(int(singles_left / (7 - level_index)) + 10, int(singles_left / global_divisor))
-        groupIds = list(range(1, len(level_data[level]["cb"]) + 1))
-        random.shuffle(groupIds)
-        selected_bunch_count = random.randint(min(bunches_lower, bunches_upper), max(bunches_lower, bunches_upper))
-        selected_single_count = random.randint(min(singles_lower, singles_upper), max(singles_lower, singles_upper))
-        placed_bunches = 0
-        placed_singles = 0
-        for groupId in groupIds:
-            group_weight = 0
-            bunches_in_group = 0
-            singles_in_group = 0
-            colored_banana_groups = [group for group in level_data[level]["cb"] if group.group == groupId]
-            cb_kongs = list(kong_specific_left.keys())
-            for group in colored_banana_groups:
-                cb_kongs = list(set(cb_kongs) & set(group.kongs.copy()))
-                for loc in group.locations:
-                    group_weight += loc[0]
-                    bunches_in_group += int(loc[0] == 5)
-                    singles_in_group += int(loc[0] == 1)
-            for kong in kong_specific_left:
-                if kong in cb_kongs:
-                    # If this kong doesn't have space for this group, remove it. Also if this kong is close to cap, don't use this kong unless it's the last one.
-                    if kong_specific_left[kong] < group_weight or (len(cb_kongs) > 1 and kong_specific_left[kong] <= 10 and (kong_specific_left[kong] - group_weight) > 0):
-                        cb_kongs.remove(kong)
-            if len(cb_kongs) > 0 and selected_single_count >= placed_singles + singles_in_group and selected_bunch_count >= placed_bunches + bunches_in_group:
-                selected_kong = random.choice(cb_kongs)
-                kong_specific_left[selected_kong] -= group_weight  # Remove CBs for kong
-                # When a kong hits 0 remaining in this level, we no longer need to consider it
-                if kong_specific_left[selected_kong] == 0:
-                    del kong_specific_left[selected_kong]
-                for group in colored_banana_groups:
-                    # Calculate the number of bananas we have to place by lesser group so different bananas in the same group can have different logic
-                    bunches_in_lesser_group = 0
-                    singles_in_lesser_group = 0
-                    for loc in group.locations:
-                        bunches_in_lesser_group += int(loc[0] == 5)
-                        singles_in_lesser_group += int(loc[0] == 1)
-                    if bunches_in_lesser_group > 0:
-                        level_data[level]["logic"][group.region].append(Collectible(Collectibles.bunch, selected_kong, group.logic, None, bunches_in_lesser_group))
-                    if singles_in_lesser_group > 0:
-                        level_data[level]["logic"][group.region].append(Collectible(Collectibles.banana, selected_kong, group.logic, None, singles_in_lesser_group))
-                    level_placement.append({"group": group.group, "name": group.name, "kong": selected_kong, "level": level, "type": "cb", "map": group.map, "locations": group.locations})
-                placed_bunches += bunches_in_group
-                placed_singles += singles_in_group
-            # If all kongs have 0 unplaced, we're done here
-            if len(kong_specific_left.keys()) == 0:
-                break
+    retries = 0
+    while True:
+        try:
+            total_balloons = 0
+            total_singles = 0
+            total_bunches = 0
+            cb_data = []
+            for level_index, level in enumerate(level_data):
+                # First, remove all placed colored bananas
+                for region in level_data[level]["logic"]:
+                    for region in level_data[level]["logic"]:
+                        level_data[level]["logic"][region] = [
+                            collectible for collectible in level_data[level]["logic"][region] if collectible.type not in [Collectibles.balloon, Collectibles.bunch, Collectibles.banana]
+                        ]
+                level_placement = []
+                global_divisor = 6 - level_index
+                kong_specific_left = {Kongs.donkey: 100, Kongs.diddy: 100, Kongs.lanky: 100, Kongs.tiny: 100, Kongs.chunky: 100}
+                # Balloons
+                # Pick random amount of balloons assigned to level
+                balloons_left = max_balloons - total_balloons
+                balloon_lower = max(
+                    int(balloons_left / (7 - level_index)) - 3, 0
+                )  # Select lower bound for randomization as max between 0, and balloons left distributed amongst the remaining levels minus 3
+                if global_divisor == 0:
+                    # Last Level
+                    balloon_upper = balloons_left
+                else:
+                    balloon_upper = min(int(balloons_left / (7 - level_index)) + 3, int(balloons_left / global_divisor))
+                balloon_lst = level_data[level]["balloons"].copy()
+                selected_balloon_count = min(random.randint(min(balloon_lower, balloon_upper), max(balloon_lower, balloon_upper)), len(balloon_lst))
+                # selected_balloon_count = 22 # Test all balloon locations
+                random.shuffle(balloon_lst)  # TODO: Maybe make this more advanced?
+                # selects all balloons
+                placed_balloons = 0
+                for balloon in balloon_lst:
+                    if placed_balloons < selected_balloon_count:
+                        balloon_kongs = balloon.kongs.copy()
+                        for kong in kong_specific_left:
+                            if kong_specific_left[kong] < 10 and kong in balloon_kongs:  # Not enough Colored Bananas to place a balloon:
+                                balloon_kongs.remove(kong)  # Remove kong from permitted list
+                        if len(balloon_kongs) > 0:  # Has a kong who can be assigned to this balloon
+                            selected_kong = random.choice(balloon_kongs)
+                            kong_specific_left[selected_kong] -= 10  # Remove CBs for Balloon
+                            level_placement.append({"id": balloon.id, "name": balloon.name, "kong": selected_kong, "level": level, "type": "balloons", "map": balloon.map})
+                            placed_balloons += 1
+                            level_data[level]["logic"][balloon.region].append(Collectible(Collectibles.balloon, selected_kong, balloon.logic, None, 1))
+                # Model Two CBs
+                bunches_left = max_bunches - total_bunches
+                singles_left = max_singles - total_singles
+                bunches_lower = max(int(bunches_left / (7 - level_index)) - 5, 0)
+                singles_lower = max(int(singles_left / (7 - level_index)) - 10, 0)
+                if global_divisor == 0:
+                    bunches_upper = bunches_left
+                    singles_upper = min(singles_left, int((5 * (1127 - total_bunches - total_singles) - sum(kong_specific_left)) / 4))  # Places a hard cap of 1127 total singles+bunches
+                else:
+                    bunches_upper = min(int(bunches_left / (7 - level_index)) + 15, int(bunches_left / global_divisor))
+                    singles_upper = min(int(singles_left / (7 - level_index)) + 10, int(singles_left / global_divisor))
+                groupIds = list(range(1, len(level_data[level]["cb"]) + 1))
+                random.shuffle(groupIds)
+                selected_bunch_count = random.randint(min(bunches_lower, bunches_upper), max(bunches_lower, bunches_upper))
+                selected_single_count = random.randint(min(singles_lower, singles_upper), max(singles_lower, singles_upper))
+                placed_bunches = 0
+                placed_singles = 0
+                for groupId in groupIds:
+                    group_weight = 0
+                    bunches_in_group = 0
+                    singles_in_group = 0
+                    colored_banana_groups = [group for group in level_data[level]["cb"] if group.group == groupId]
+                    cb_kongs = list(kong_specific_left.keys())
+                    for group in colored_banana_groups:
+                        cb_kongs = list(set(cb_kongs) & set(group.kongs.copy()))
+                        for loc in group.locations:
+                            group_weight += loc[0]
+                            bunches_in_group += int(loc[0] == 5)
+                            singles_in_group += int(loc[0] == 1)
+                    for kong in kong_specific_left:
+                        if kong in cb_kongs:
+                            # If this kong doesn't have space for this group, remove it. Also if this kong is close to cap, don't use this kong unless it's the last one.
+                            if kong_specific_left[kong] < group_weight or (len(cb_kongs) > 1 and kong_specific_left[kong] <= 10 and (kong_specific_left[kong] - group_weight) > 0):
+                                cb_kongs.remove(kong)
+                    if len(cb_kongs) > 0 and selected_single_count >= placed_singles + singles_in_group and selected_bunch_count >= placed_bunches + bunches_in_group:
+                        selected_kong = random.choice(cb_kongs)
+                        kong_specific_left[selected_kong] -= group_weight  # Remove CBs for kong
+                        # When a kong hits 0 remaining in this level, we no longer need to consider it
+                        if kong_specific_left[selected_kong] == 0:
+                            del kong_specific_left[selected_kong]
+                        for group in colored_banana_groups:
+                            # Calculate the number of bananas we have to place by lesser group so different bananas in the same group can have different logic
+                            bunches_in_lesser_group = 0
+                            singles_in_lesser_group = 0
+                            for loc in group.locations:
+                                bunches_in_lesser_group += int(loc[0] == 5)
+                                singles_in_lesser_group += int(loc[0] == 1)
+                            if bunches_in_lesser_group > 0:
+                                level_data[level]["logic"][group.region].append(Collectible(Collectibles.bunch, selected_kong, group.logic, None, bunches_in_lesser_group))
+                            if singles_in_lesser_group > 0:
+                                level_data[level]["logic"][group.region].append(Collectible(Collectibles.banana, selected_kong, group.logic, None, singles_in_lesser_group))
+                            level_placement.append({"group": group.group, "name": group.name, "kong": selected_kong, "level": level, "type": "cb", "map": group.map, "locations": group.locations})
+                        placed_bunches += bunches_in_group
+                        placed_singles += singles_in_group
+                    # If all kongs have 0 unplaced, we're done here
+                    if len(kong_specific_left.keys()) == 0:
+                        break
 
-        # Placement is valid
-        total_balloons += placed_balloons
-        total_bunches += placed_bunches
-        total_singles += placed_singles
-        cb_data.extend(level_placement.copy())
-        for x in kong_specific_left:
-            if kong_specific_left[x] > 0:
-                print(f"WARNING: {kong_specific_left[x]} bananas unassigned for {x.name} in {level.name}")
-            elif kong_specific_left[x] < 0:
-                print(f"WARNING: {-kong_specific_left[x]} too many bananas assigned for {x.name} in {level.name}")
-    if total_bunches + total_singles > 1127:
-        print(f"WARNING: {total_bunches + total_singles} banana objects placed, exceeding cap of 1127")
-    spoiler.cb_placements = cb_data
+                # Placement is valid
+                total_balloons += placed_balloons
+                total_bunches += placed_bunches
+                total_singles += placed_singles
+                cb_data.extend(level_placement.copy())
+                for x in kong_specific_left:
+                    if kong_specific_left[x] > 0:
+                        print(f"WARNING: {kong_specific_left[x]} bananas unassigned for {x.name} in {level.name}")
+                        raise Ex.CBFillFailureException
+                    elif kong_specific_left[x] < 0:
+                        print(f"WARNING: {-kong_specific_left[x]} too many bananas assigned for {x.name} in {level.name}")
+                        raise Ex.CBFillFailureException
+            if total_bunches + total_singles > 1127:
+                print(f"WARNING: {total_bunches + total_singles} banana objects placed, exceeding cap of 1127")
+                raise Ex.CBFillFailureException
+            spoiler.cb_placements = cb_data
+            return
+        except Ex.CBFillFailureException:
+            if retries >= 10:
+                js.postMessage("CB Randomizer failed to fill. REPORT THIS TO THE DEVS!!")
+                raise Ex.CBFillFailureException
+            retries += 1
+            js.postMessage("CB Randomizer failed to fill. Tries: " + str(retries))

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -132,7 +132,8 @@ def generate_lo_rando_race_settings():
     data["microhints_enabled"] = "base"  # off/base/all
     data["smaller_shops"] = True  # likely to be True in item rando, many settings force it to be false
     data["alter_switch_allocation"] = False  # likely to be True, easier to test things when false
-    data["random_starting_region"] = True  # likely to be False
+    data["random_starting_region"] = False  # likely to be False
+    data["random_fairies"] = False  # likely to be False
 
     return data
 


### PR DESCRIPTION
The CB rando filler wouldn't always put 100 cbs for each kong in each level. Now it won't proceed until it has. Failure is relatively unlikely and the fill process is very fast, so I just slapped a retry loop on it until it came up with a valid combination.

Also fixed:
- Key 8 in Helm will get path hints even if keys aren't in the pool
- Adjusted the early key hints to match the "held by a kasplat" phrasing