### PR TITLE
split up pathmode, boss fill fix

### DIFF
--- a/randomizer/Enums/Events.py
+++ b/randomizer/Enums/Events.py
@@ -84,6 +84,7 @@ class Events(IntEnum):
     CavesSmallBoulderButton = auto()
     CavesLargeBoulderButton = auto()
     GiantKoshaDefeated = auto()
+    CavesMonkeyportAccess = auto()
 
     # Creepy Castle Events
     CastleTreeOpened = auto()

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -49,7 +49,15 @@ class LogicVarHolder:
         if settings is None:
             return
         self.settings = settings
-        self.pathMode = False  # See CalculateWothPaths method for details
+
+        # Some restrictions are added to the item placement fill for the sake of reducing indirect errors. We can overlook these restrictions once we know the fill is valid.
+        self.assumeFillSuccess = False
+        # See CalculateWothPaths method for details on these assumptions
+        self.assumeAztecEntry = False
+        self.assumeLevel4Entry = False
+        self.assumeUpperIslesAccess = False
+        self.assumeKRoolAccess = False
+
         self.startkong = self.settings.starting_kong
         # Glitch Logic
         enable_glitch_logic = self.settings.logic_type == "glitch"
@@ -733,12 +741,12 @@ class LogicVarHolder:
     def IsLevelEnterable(self, level):
         """Check if level entry requirement is met."""
         # "pathMode" is so WotH paths can always enter levels regardless of owned items
-        if not self.pathMode:
+        if not self.assumeFillSuccess:
             level_order_matters = not self.settings.hard_level_progression and self.settings.shuffle_loading_zones in ("none", "levels")
             # If level order matters...
             if level_order_matters:
                 # Levels have some special requirements depending on where they fall in the level order
-                order_of_level = 0
+                order_of_level = 8  # If order_of_level remains unchanged in the coming loop, then the level is Helm which is always 8th
                 order_of_aztec = 0
                 for level_order in self.settings.level_order:
                     if self.settings.level_order[level_order] == level:

--- a/randomizer/LogicFiles/AngryAztec.py
+++ b/randomizer/LogicFiles/AngryAztec.py
@@ -25,7 +25,7 @@ LogicRegions = {
     ], [
         TransitionFront(Regions.AngryAztecMedals, lambda l: True),
         TransitionFront(Regions.AngryAztecLobby, lambda l: True, Transitions.AztecToIsles),
-        TransitionFront(Regions.BetweenVinesByPortal, lambda l: l.pathMode or l.vines or (l.istiny and l.twirl) or l.phasewalk),
+        TransitionFront(Regions.BetweenVinesByPortal, lambda l: l.assumeAztecEntry or l.vines or (l.istiny and l.twirl) or l.phasewalk),
     ]),
 
     Regions.BetweenVinesByPortal: Region("Angry Aztec Between Vines By Portal", "Various Aztec Tunnels", Levels.AngryAztec, False, None, [
@@ -33,7 +33,7 @@ LogicRegions = {
     ], [], [
         TransitionFront(Regions.AngryAztecMedals, lambda l: True),
         TransitionFront(Regions.AngryAztecStart, lambda l: l.vines or (l.istiny and l.twirl) or l.phasewalk),
-        TransitionFront(Regions.AngryAztecOasis, lambda l: l.pathMode or l.vines or (l.istiny and l.twirl) or l.phasewalk),
+        TransitionFront(Regions.AngryAztecOasis, lambda l: l.assumeAztecEntry or l.vines or (l.istiny and l.twirl) or l.phasewalk),
     ]),
 
     Regions.AztecTunnelBeforeOasis: Region("Angry Aztec Tunnel Before Oasis", "Various Aztec Tunnels", Levels.AngryAztec, False, None, [

--- a/randomizer/LogicFiles/CrystalCaves.py
+++ b/randomizer/LogicFiles/CrystalCaves.py
@@ -55,7 +55,9 @@ LogicRegions = {
 
     Regions.CavesBlueprintCave: Region("Caves Blueprint Cave", "Main Caves Area", Levels.CrystalCaves, False, None, [
         LocationLogic(Locations.CavesKasplatNearFunky, lambda l: not l.settings.kasplat_rando),
-    ], [], [
+    ], [
+        Event(Events.CavesMonkeyportAccess, lambda l: l.istiny and l.monkeyport)
+    ], [
         TransitionFront(Regions.CrystalCavesMedals, lambda l: True),
         TransitionFront(Regions.CrystalCavesMain, lambda l: (l.mini and l.istiny) or l.phasewalk or l.CanSkew(True))
     ]),
@@ -109,7 +111,7 @@ LogicRegions = {
     ]),
 
     Regions.IglooArea: Region("Igloo Area", "Igloo Area", Levels.CrystalCaves, True, None, [
-        LocationLogic(Locations.CavesTinyMonkeyportIgloo, lambda l: (((l.monkeyport and l.mini and l.twirl) or l.CanPhaseswim()) and l.istiny) or (l.CanPhaseswim() and l.settings.free_trade_items)),  # GB is in this region but the rest is not
+        LocationLogic(Locations.CavesTinyMonkeyportIgloo, lambda l: ((Events.CavesMonkeyportAccess in l.Events or l.CanPhaseswim()) and l.istiny) or (l.CanPhaseswim() and l.settings.free_trade_items)),  # GB is in this region but the rest is not
         LocationLogic(Locations.CavesChunkyTransparentIgloo, lambda l: ((Events.CavesLargeBoulderButton in l.Events or l.generalclips or l.CanPhaseswim()) and l.chunky) or ((l.generalclips or l.CanPhaseswim()) and l.settings.free_trade_items)),
         LocationLogic(Locations.CavesKasplatOn5DI, lambda l: not l.settings.kasplat_rando),
     ], [], [

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -61,11 +61,11 @@ LogicRegions = {
         TransitionFront(Regions.BananaFairyRoom, lambda l: (l.mini and l.istiny) or l.phasewalk or l.CanSTS(), Transitions.IslesMainToFairy),
         TransitionFront(Regions.JungleJapesLobby, lambda l: l.settings.open_lobbies or Events.KLumsyTalkedTo in l.Events or l.phasewalk or l.CanSTS(), Transitions.IslesMainToJapesLobby),
         TransitionFront(Regions.KremIsle, lambda l: True),
-        TransitionFront(Regions.IslesMainUpper, lambda l: l.vines or l.CanMoonkick() or l.pathMode),
+        TransitionFront(Regions.IslesMainUpper, lambda l: l.vines or l.CanMoonkick() or l.assumeUpperIslesAccess),
         TransitionFront(Regions.CabinIsle, lambda l: l.settings.open_lobbies or Events.GalleonKeyTurnedIn in l.Events or l.CanMoonkick()),
         TransitionFront(Regions.CreepyCastleLobby, lambda l: l.settings.open_lobbies or Events.ForestKeyTurnedIn in l.Events, Transitions.IslesMainToCastleLobby),
         TransitionFront(Regions.KremIsleTopLevel, lambda l: l.tbs),
-        TransitionFront(Regions.KRool, lambda l: l.CanAccessKRool() or l.pathMode),
+        TransitionFront(Regions.KRool, lambda l: l.CanAccessKRool() or l.assumeKRoolAccess),
     ]),
 
     Regions.IslesMainUpper: Region("Isles Main Upper", "DK Isle", Levels.DKIsles, False, None, [
@@ -138,7 +138,7 @@ LogicRegions = {
         LocationLogic(Locations.IslesDonkeyCagedBanana, lambda l: (l.coconut and l.isdonkey) or ((l.CanSkew(True) and l.CanSTS()) and (l.isdonkey or l.settings.free_trade_items))),
     ], [], [
         TransitionFront(Regions.KremIsle, lambda l: True),
-        TransitionFront(Regions.GloomyGalleonLobbyEntrance, lambda l: (l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events or l.CanPhaseswim()) and (l.swim or l.pathMode), Transitions.IslesMainToGalleonLobby),
+        TransitionFront(Regions.GloomyGalleonLobbyEntrance, lambda l: (l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events or l.CanPhaseswim()) and (l.swim or l.assumeLevel4Entry), Transitions.IslesMainToGalleonLobby),
         TransitionFront(Regions.IslesSnideRoom, lambda l: True, Transitions.IslesMainToSnideRoom),
         TransitionFront(Regions.FranticFactoryLobby, lambda l: l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events or (l.CanSkew(True) and l.CanSTS()), Transitions.IslesMainToFactoryLobby),
     ]),


### PR DESCRIPTION
Couple things here:
- Split up pathmode into different assumptions. This should solve a couple problems and generally be more flexible. The specific issue I intended to resolve was giving LZR seeds good K. Rool paths.
- Fixed a recurring fill failure that occurred when barrels (or barrels locking items) were placed in Helm in simple level order.
- Fixed some logic with the Caves MP Igloo, mostly covering for when warps are active and shuffled in Caves.