### PR TITLE
Shuffled Warps Minor Cleanup

### DIFF
--- a/randomizer/ShuffleWarps.py
+++ b/randomizer/ShuffleWarps.py
@@ -23,12 +23,11 @@ def verifySelectedWarps(selected_warps):
     if len(selected_warps) == 0:
         for warp in VanillaBananaportSelector:
             selected_warps.append(warp["value"])
-    return selected_warps
 
 
 def ShuffleWarps(bananaport_replacements, human_ports, selected_warps):
     """Shuffles warps between themselves."""
-    selected_warps = verifySelectedWarps(selected_warps)
+    verifySelectedWarps(selected_warps)
     map_list = getShuffleMaps()
     for warp_map in map_list:
         if warp_map.name not in selected_warps:
@@ -78,7 +77,7 @@ def getWarpFromSwapIndex(index):
 
 def ShuffleWarpsCrossMap(bananaport_replacements, human_ports, is_coupled, selected_warps):
     """Shuffles warps with the cross-map setting."""
-    selected_warps = verifySelectedWarps(selected_warps)
+    verifySelectedWarps(selected_warps)
     for warp in BananaportVanilla.values():
         warp.cross_map_placed = False
         bananaport_replacements.append(0)

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -284,6 +284,7 @@ def set_preset_options():
     toggle_counts_boxes(None)
     toggle_b_locker_boxes(None)
     toggle_logic_type(None)
+    toggle_bananaport_selector(None)
     updateDoorOneNumAccess(None)
     updateDoorTwoNumAccess(None)
 


### PR DESCRIPTION
- fixed the "Shuffled Bananaports" gear not being disabled by default when initially loading the page with "Vanilla" warps selected
- fixed a nigh-insignificant syntax oversight with "verifySelectedWarps()" where I forgot Python was a pass-by-assignment language