### PR TITLE
Fill Reorganization

### DIFF
--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -104,7 +104,7 @@ def AllItems(settings):
     """Return all shuffled items."""
     allItems = []
     if Types.Blueprint in settings.shuffled_location_types:
-        allItems.extend(Blueprints(settings))
+        allItems.extend(Blueprints())
     if Types.Banana in settings.shuffled_location_types:
         allItems.extend(GoldenBananaItems())
     if Types.ToughBanana in settings.shuffled_location_types:
@@ -150,7 +150,7 @@ def AllItemsForMovePlacement(settings):
     """Return all shuffled items we need to assume for move placement."""
     allItems = []
     if Types.Blueprint in settings.shuffled_location_types:
-        allItems.extend(Blueprints(settings))
+        allItems.extend(Blueprints())
     if Types.Banana in settings.shuffled_location_types:
         allItems.extend(GoldenBananaItems())
     if Types.ToughBanana in settings.shuffled_location_types:
@@ -205,7 +205,15 @@ def AllMovesForOwnedKongs(kongs):
     return kongMoves
 
 
-def Blueprints(settings):
+def ShockwaveTypeItems(settings):
+    """Return the Shockwave-type items for the given settings."""
+    if settings.shockwave_status == "shuffled_decoupled":
+        return [Items.Camera, Items.Shockwave]
+    else:
+        return [Items.CameraAndShockwave]
+
+
+def Blueprints():
     """Return all blueprint items."""
     blueprints = [
         Items.DKIslesDonkeyBlueprint,
@@ -250,31 +258,6 @@ def Blueprints(settings):
         Items.CreepyCastleChunkyBlueprint,
     ]
     return blueprints
-
-
-def BlueprintAssumedItems():
-    """Items which are assumed to be owned while placing blueprints."""
-    return Keys() + KeyAssumedItems()
-
-
-def KeyAssumedItems():
-    """Items which are assumed to be owned while placing keys."""
-    return CompanyCoinItems() + CoinAssumedItems()
-
-
-def CoinAssumedItems():
-    """Items which are assumed to be owned while placing keys."""
-    return BattleCrownItems() + CrownAssumedItems()
-
-
-def CrownAssumedItems():
-    """Items which are assumed to be owned while placing keys."""
-    return BananaMedalItems() + MedalAssumedItems()
-
-
-def MedalAssumedItems():
-    """Items which are assumed to be owned while placing keys."""
-    return GoldenBananaItems()
 
 
 def Keys():
@@ -463,6 +446,50 @@ def JunkItems():
     lim = int(100 / len(items_to_place))
     for item_type in items_to_place:
         itemPool.extend(itertools.repeat(item_type, lim))
+    return itemPool
+
+
+def GetItemsNeedingToBeAssumed(settings, placed_types):
+    """Return a list of all items that will be assumed for immediate item placement."""
+    itemPool = []
+    unplacedTypes = [typ for typ in settings.shuffled_location_types if typ not in placed_types]
+    if Types.Banana in unplacedTypes:
+        itemPool.extend(GoldenBananaItems())
+    if Types.ToughBanana in unplacedTypes:
+        itemPool.extend(ToughGoldenBananaItems())
+    if Types.Shop in unplacedTypes:
+        itemPool.extend(AllKongMoves())
+    if Types.Blueprint in unplacedTypes:
+        itemPool.extend(Blueprints())
+    if Types.Fairy in unplacedTypes:
+        itemPool.extend(FairyItems())
+    if Types.Key in unplacedTypes:
+        itemPool.extend(Keys())
+    if Types.Crown in unplacedTypes:
+        itemPool.extend(BattleCrownItems())
+    if Types.Coin in unplacedTypes:
+        itemPool.extend(CompanyCoinItems())
+    if Types.TrainingBarrel in unplacedTypes:
+        itemPool.extend(TrainingBarrelAbilities())
+    if Types.Kong in unplacedTypes:
+        itemPool.extend(Kongs())
+    if Types.Medal in unplacedTypes:
+        itemPool.extend(BananaMedalItems())
+    if Types.Shockwave in unplacedTypes:
+        itemPool.extend(ShockwaveTypeItems(settings))
+    if Types.Bean in unplacedTypes:
+        itemPool.extend(MiscItemRandoItems())  # Covers Bean and Pearls
+    if Types.RainbowCoin in unplacedTypes:
+        itemPool.extend(RainbowCoinItems())
+    if Types.ToughBanana in unplacedTypes:
+        itemPool.extend(ToughGoldenBananaItems())
+    # Never logic-affecting items
+    # if Types.FakeItem in unplacedTypes:
+    #     itemPool.extend(FakeItems())
+    # if Types.JunkItem in unplacedTypes:
+    #     itemPool.extend(JunkItems())
+    # if Types.Hint in unplacedTypes: someday???
+    #     itemPool.extend(HintItems()) hints in the pool???
     return itemPool
 
 

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -41,7 +41,7 @@ def generate_lo_rando_race_settings():
     data["shockwave_status"] = "shuffled_decoupled"  # usually "vanilla", could be "shuffled" or "shuffled_decoupled" or "start_with"
     # If true, the above is always decoupled or vanilla
     data["shuffle_items"] = True  # Must be true to trigger the list selector below
-    # data["item_rando_list_selected"] = ["shop", "banana", "toughbanana" "crown", "blueprint", "key", "medal", "coin", "kong", "fairy", "rainbowcoin", "beanpearl", "fakeitem"]  # all options
+    # data["item_rando_list_selected"] = ["shop", "banana", "toughbanana", "crown", "blueprint", "key", "medal", "coin", "kong", "fairy", "rainbowcoin", "beanpearl", "fakeitem", "junkitem"]  # all options
 
     data["random_prices"] = "low"  # usually "medium, might need free, rarely vanilla"
     data["randomize_blocker_required_amounts"] = True  # usually True, if false set values below


### PR DESCRIPTION
The order of operations of the fill and the assumptions made during the fill got a bit out of whack, causing excessive (any amount is excessive to me) fill failures. 
To remedy this, this PR does the following:
- Trim and cut some debug code to avoid a possible crash if CB rando comes up with invalid CBs
- Create a generic method most PlaceItems methods will call to get the list of items to assume. This should help make it simpler to shuffle around item placement order.
- Rework assumptions for fairies and medals to always carefully place the number of those items that could logically lock something
- Place rainbow coins first and more carefully. I'm not certain this should help, but I think that assuming coins for too long could cause shops to fill up too fast?

All in all these changes will reduce many fill failures. The last known fill issue is around the BarrelShuffle method which desperately needs a rewrite anyway.