### PR TITLE
Fix Warp Lambdas

### DIFF
--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -472,7 +472,7 @@ def GetItemsNeedingToBeAssumed(settings, placed_types):
     if Types.TrainingBarrel in unplacedTypes:
         itemPool.extend(TrainingBarrelAbilities())
     if Types.Kong in unplacedTypes:
-        itemPool.extend(Kongs())
+        itemPool.extend(Kongs(settings))
     if Types.Medal in unplacedTypes:
         itemPool.extend(BananaMedalItems())
     if Types.Shockwave in unplacedTypes:

--- a/randomizer/Lists/Warps.py
+++ b/randomizer/Lists/Warps.py
@@ -25,6 +25,7 @@ class BananaportData:
         self.swap_index = swap_index
         self.restricted = restricted  # Defined by whether all kongs can access the bananaport without tag anywhere or bananaports
         self.event = event
+        self.event_logic = lambda l: event in l.Events
         self.cross_map_placed = False
         vanilla_pair_index = swap_index % 2
         if vanilla_pair_index == 0:

--- a/randomizer/ShuffleWarps.py
+++ b/randomizer/ShuffleWarps.py
@@ -140,4 +140,4 @@ def LinkWarps():
         destination_warp_data = getWarpFromSwapIndex(warp_data.tied_index)
         if warp_data.region_id != destination_warp_data.region_id:
             source_region = Logic.Regions[warp_data.region_id]
-            source_region.exits.append(TransitionFront(destination_warp_data.region_id, lambda l: destination_warp_data.event in l.Events))
+            source_region.exits.append(TransitionFront(destination_warp_data.region_id, destination_warp_data.event_logic))


### PR DESCRIPTION
Created warp lambda logics as a variable on the warp data class instead of being built as the locationlogics were created. This makes the logic actually respect the event logic.
Also changed kongs-outside-cages fills to assumed algo and cleaned up that flow. It wasn't assuming keys were owned too, which may have heavily impacted kong placement potential.