### PR TITLE
Some fixes

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -675,6 +675,23 @@ def CalculateFoolish(spoiler, WothLocations):
         majorItems.append(Items.BananaFairy)
     if Types.Crown in spoiler.settings.shuffled_location_types and requires_crowns:
         majorItems.append(Items.BattleCrown)
+    # The contents of some locations can make entire classes of items not foolish
+    # Loop through these locations until no new items are added to the list of major items
+    newFoolishItems = True
+    while newFoolishItems:
+        newFoolishItems = False
+        if Types.Medal in spoiler.settings.shuffled_location_types and LocationList[Locations.RarewareCoin].item in majorItems and Items.BananaMedal not in majorItems:
+            majorItems.append(Items.BananaMedal)
+            newFoolishItems = True
+        if Types.Fairy in spoiler.settings.shuffled_location_types and LocationList[Locations.RarewareBanana].item in majorItems and Items.BananaFairy not in majorItems:
+            majorItems.append(Items.BananaFairy)
+            newFoolishItems = True
+        if Types.Pearl in spoiler.settings.shuffled_location_types and LocationList[Locations.GalleonTinyPearls].item in majorItems and Items.Pearl not in majorItems:
+            majorItems.append(Items.Pearl)
+            newFoolishItems = True
+        if Types.Bean in spoiler.settings.shuffled_location_types and LocationList[Locations.ForestTinyBeanstalk].item in majorItems and Items.Bean not in majorItems:
+            majorItems.append(Items.Bean)
+            newFoolishItems = True
 
     nonHintableNames = {"K. Rool Arena", "Snide", "Candy Generic", "Funky Generic", "Credits"}  # These regions never have anything useful so shouldn't be hinted
     if Types.Coin not in spoiler.settings.shuffled_location_types:
@@ -1430,16 +1447,23 @@ def FillKongs(spoiler):
         Reset()
         PlaceItems(spoiler.settings, "assumed", kongItems, assumedItems)
         # If we didn't put an item in a kong location, then it gets a NoItem
-        # This matters specifically so the logic around Diddy's cage behaves properly
+        # This matters specifically so the logic around items inside Kong cages (VERY important for Diddy's cage) behaves properly
         if LocationList[Locations.DiddyKong].item is None:
             LocationList[Locations.DiddyKong].PlaceItem(Items.NoItem)
-        # And this matters specifically for the logic around the freeing the other kongs rewards
+        else:
+            LocationList[Locations.DiddyKong].kong = spoiler.settings.diddy_freeing_kong  # If any Kong cage DOES have a kong, update the location's assigned Kong
         if LocationList[Locations.TinyKong].item is None:
             LocationList[Locations.TinyKong].PlaceItem(Items.NoItem)
+        else:
+            LocationList[Locations.TinyKong].kong = spoiler.settings.tiny_freeing_kong
         if LocationList[Locations.LankyKong].item is None:
             LocationList[Locations.LankyKong].PlaceItem(Items.NoItem)
+        else:
+            LocationList[Locations.LankyKong].kong = spoiler.settings.lanky_freeing_kong
         if LocationList[Locations.ChunkyKong].item is None:
             LocationList[Locations.ChunkyKong].PlaceItem(Items.NoItem)
+        else:
+            LocationList[Locations.ChunkyKong].kong = spoiler.settings.chunky_freeing_kong
         spoiler.settings.update_valid_locations()
     # If kongs must be in Kong cages, we need to be more careful
     else:

--- a/randomizer/Lists/CrownLocations.py
+++ b/randomizer/Lists/CrownLocations.py
@@ -142,7 +142,7 @@ CrownLocations = {
             z=740,
             scale=0.25,
             region=Regions.AngryAztecOasis,
-            logic=lambda l: (l.coconut or l.phasewalk) and ((l.strongKong and l.isdonkey) or l.settings.damage_amount == "default"),
+            logic=lambda l: l.phasewalk or (l.coconut and ((l.strongKong and l.isdonkey) or (l.twirl and l.istiny))),
         ),
         CrownLocation(map=Maps.AngryAztec, name="Angry Aztec: Oasis", x=2151, y=120, z=983, scale=0.35, region=Regions.AngryAztecOasis),
         CrownLocation(map=Maps.AngryAztec, name="Angry Aztec: Behind Tiny Temple", x=3345, y=153, z=507, scale=0.3, region=Regions.AngryAztecOasis),

--- a/randomizer/Lists/KasplatLocations.py
+++ b/randomizer/Lists/KasplatLocations.py
@@ -265,10 +265,10 @@ KasplatLocationList = {
         KasplatLocation(
             name="Aztec Kasplat: Behind the DK Stone Door",
             map_id=Maps.AngryAztec,
-            kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
+            kong_lst=[Kongs.donkey, Kongs.tiny],
             coords=[1363, 162, 738],
             region=Regions.AztecTunnelBeforeOasis,
-            additional_logic=lambda l: (l.coconut or l.phasewalk) and ((l.strongKong and l.isdonkey) or l.settings.damage_amount == "default"),
+            additional_logic=lambda l: l.phasewalk or (l.coconut and ((l.strongKong and l.isdonkey) or (l.twirl and l.istiny))),
             vanilla=True,
         ),
         KasplatLocation(

--- a/randomizer/LogicFiles/AngryAztec.py
+++ b/randomizer/LogicFiles/AngryAztec.py
@@ -39,8 +39,7 @@ LogicRegions = {
     ]),
 
     Regions.AztecTunnelBeforeOasis: Region("Angry Aztec Tunnel Before Oasis", "Various Aztec Tunnels", Levels.AngryAztec, False, None, [
-        # Damage checks in logic are cringe but we need this to make vanilla kasplat rando interesting in Aztec
-        LocationLogic(Locations.AztecKasplatSandyBridge, lambda l: not l.settings.kasplat_rando and (l.coconut or l.phasewalk) and ((l.strongKong and l.isdonkey) or l.settings.damage_amount == "default")),
+        LocationLogic(Locations.AztecKasplatSandyBridge, lambda l: not l.settings.kasplat_rando and (l.phasewalk or (l.coconut and ((l.strongKong and l.isdonkey) or (l.twirl and l.istiny))))),
     ], [], [
         TransitionFront(Regions.AngryAztecMedals, lambda l: True),
         TransitionFront(Regions.BetweenVinesByPortal, lambda l: l.vines or (l.istiny and l.twirl) or l.phasewalk),


### PR DESCRIPTION
- Foolish hints now take into account when you have something on specific checks. If you have a major item on Rareware GB, Jetpac, Mermaid, or Beanstalk, then Fairies, Medals, Pearls, and the Bean will not be foolish, respectively. This does loop on itself so if you have the bean on Mermaid and Ostand on the Beanstalk, neither the bean nor pearls will be in foolish regions. This means, for example, if you find a medal in a foolish region, then Jetpac is dead.
- Changed the logic around the Aztec stone door Kasplat (and the crown that's in there) to no longer logically allow a damage boost. This means it's now a DK/Tiny kasplat needing either Strong Kong or Twirl.
- Fixed an issue where Kong location hints could still say "Any Kong" because the locations weren't being updated if a Kong was actually placed there.