### PR TITLE
Fixing settings string to handle negative numbers

### DIFF
--- a/randomizer/Enums/Settings.py
+++ b/randomizer/Enums/Settings.py
@@ -725,11 +725,11 @@ class SettingsStringDataType(IntEnum):
     """Enum for mapping settings to data types for encryption/decryption."""
 
     bool = auto()
-    # Can represent up to 16 values.
+    # Can represent up to 16 values (-8 to 7).
     int4 = auto()
-    # Can represent up to 256 values.
+    # Can represent up to 256 values (-128 to 127).
     int8 = auto()
-    # Can represent up to 65,536 values.
+    # Can represent up to 65,536 values (-32,768 to 32,767).
     int16 = auto()
     str = auto()
     list = auto()
@@ -811,7 +811,7 @@ SettingsStringTypeMap = {
     SettingsStringEnum.keys_random: SettingsStringDataType.bool,
     SettingsStringEnum.kong_rando: SettingsStringDataType.bool,
     SettingsStringEnum.krool_access: SettingsStringDataType.bool,
-    SettingsStringEnum.krool_key_count: SettingsStringDataType.int4,
+    SettingsStringEnum.krool_key_count: SettingsStringDataType.int8,
     SettingsStringEnum.krool_phase_count: SettingsStringDataType.int4,
     SettingsStringEnum.krool_phase_order_rando: SettingsStringDataType.bool,
     SettingsStringEnum.krool_random: SettingsStringDataType.bool,
@@ -877,6 +877,6 @@ SettingsStringListTypeMap = {
     SettingsStringEnum.item_rando_list_selected: SettingsStringDataType.int8,
     SettingsStringEnum.minigames_list_selected: SettingsStringDataType.int8,
     SettingsStringEnum.misc_changes_selected: SettingsStringDataType.int8,
-    SettingsStringEnum.starting_keys_list_selected: SettingsStringDataType.int4,
+    SettingsStringEnum.starting_keys_list_selected: SettingsStringDataType.int8,
     SettingsStringEnum.warp_level_list_selected: SettingsStringDataType.int8,
 }

--- a/randomizer/SettingStrings.py
+++ b/randomizer/SettingStrings.py
@@ -13,6 +13,25 @@ index_to_letter = {i: letters[i] for i in range(64)}
 letter_to_index = {letters[i]: i for i in range(len(letters))}
 
 
+def int_to_bin_string(num, bytesize):
+    """Converts an integer to a binary representation.
+
+    This function is needed to handle negative numbers.
+    """
+    return format(num if num >= 0 else (1 << bytesize) + num, f'0{bytesize}b').zfill(bytesize)
+
+
+def bin_string_to_int(bin_str, bytesize):
+    """Converts a binary string to an integer.
+
+    This function is needed to handle negative numbers.
+    """
+    if bin_str[0] == "1":
+        return int(bin_str, 2) - (1 << bytesize)
+    else:
+        return int(bin_str, 2)
+
+
 def encrypt_settings_string_enum(dict_data: dict):
     """Take a dictionary and return an enum-based encrypted string.
 
@@ -70,11 +89,11 @@ def encrypt_settings_string_enum(dict_data: dict):
         if key_data_type == SettingsStringDataType.bool:
             bitstring += "1" if value else "0"
         elif key_data_type == SettingsStringDataType.int4:
-            bitstring += bin(value)[2:].zfill(4)
+            bitstring += int_to_bin_string(value, 4)
         elif key_data_type == SettingsStringDataType.int8:
-            bitstring += bin(value)[2:].zfill(8)
+            bitstring += int_to_bin_string(value, 8)
         elif key_data_type == SettingsStringDataType.int16:
-            bitstring += bin(value)[2:].zfill(16)
+            bitstring += int_to_bin_string(value, 16)
         elif key_data_type == SettingsStringDataType.list:
             bitstring += f"{len(value):08b}"
             key_list_data_type = SettingsStringListTypeMap[key_enum]
@@ -84,11 +103,11 @@ def encrypt_settings_string_enum(dict_data: dict):
                 if key_list_data_type == SettingsStringDataType.bool:
                     bitstring += "1" if item else "0"
                 elif key_list_data_type == SettingsStringDataType.int4:
-                    bitstring += bin(item)[2:].zfill(4)
+                    bitstring += int_to_bin_string(item, 4)
                 elif key_list_data_type == SettingsStringDataType.int8:
-                    bitstring += bin(item)[2:].zfill(8)
+                    bitstring += int_to_bin_string(item, 8)
                 elif key_list_data_type == SettingsStringDataType.int16:
-                    bitstring += bin(item)[2:].zfill(16)
+                    bitstring += int_to_bin_string(item, 16)
                 else:
                     enum_values = [member.value for member in key_list_data_type]
                     index = enum_values.index(item.value)
@@ -146,13 +165,13 @@ def decrypt_settings_string_enum(encrypted_string: str):
             settings_dict[key_name] = True if bitstring[bit_index] == "1" else False
             bit_index += 1
         elif key_data_type == SettingsStringDataType.int4:
-            settings_dict[key_name] = int(bitstring[bit_index : bit_index + 4], 2)
+            settings_dict[key_name] = bin_string_to_int(bitstring[bit_index : bit_index + 4], 4)
             bit_index += 4
         elif key_data_type == SettingsStringDataType.int8:
-            settings_dict[key_name] = int(bitstring[bit_index : bit_index + 8], 2)
+            settings_dict[key_name] = bin_string_to_int(bitstring[bit_index : bit_index + 8], 8)
             bit_index += 8
         elif key_data_type == SettingsStringDataType.int16:
-            settings_dict[key_name] = int(bitstring[bit_index : bit_index + 16], 2)
+            settings_dict[key_name] = bin_string_to_int(bitstring[bit_index : bit_index + 16], 16)
             bit_index += 16
         elif key_data_type == SettingsStringDataType.list:
             list_length = int(bitstring[bit_index : bit_index + 8], 2)
@@ -164,13 +183,13 @@ def decrypt_settings_string_enum(encrypted_string: str):
                     settings_dict[key_name].append(True if bitstring[bit_index] == "1" else False)
                     bit_index += 1
                 elif key_list_data_type == SettingsStringDataType.int4:
-                    settings_dict[key_name].append(int(bitstring[bit_index : bit_index + 4], 2))
+                    settings_dict[key_name] = bin_string_to_int(bitstring[bit_index : bit_index + 4], 4)
                     bit_index += 4
                 elif key_list_data_type == SettingsStringDataType.int8:
-                    settings_dict[key_name].append(int(bitstring[bit_index : bit_index + 8], 2))
+                    settings_dict[key_name] = bin_string_to_int(bitstring[bit_index : bit_index + 8], 8)
                     bit_index += 8
                 elif key_list_data_type == SettingsStringDataType.int16:
-                    settings_dict[key_name].append(int(bitstring[bit_index : bit_index + 16], 2))
+                    settings_dict[key_name] = bin_string_to_int(bitstring[bit_index : bit_index + 16], 16)
                     bit_index += 16
                 else:
                     enum_values = [member.value for member in key_list_data_type]

--- a/randomizer/SettingStrings.py
+++ b/randomizer/SettingStrings.py
@@ -14,15 +14,15 @@ letter_to_index = {letters[i]: i for i in range(len(letters))}
 
 
 def int_to_bin_string(num, bytesize):
-    """Converts an integer to a binary representation.
+    """Convert an integer to a binary representation.
 
     This function is needed to handle negative numbers.
     """
-    return format(num if num >= 0 else (1 << bytesize) + num, f'0{bytesize}b').zfill(bytesize)
+    return format(num if num >= 0 else (1 << bytesize) + num, f"0{bytesize}b").zfill(bytesize)
 
 
 def bin_string_to_int(bin_str, bytesize):
-    """Converts a binary string to an integer.
+    """Convert a binary string to an integer.
 
     This function is needed to handle negative numbers.
     """


### PR DESCRIPTION
This PR handles negative numbers in the settings string by using two's complement negation.

It also changes a couple of settings from `int4` to `int8`. One of these was due to the loss of higher values, as a result of now including negative numbers. The other was an oversight.