### PR TITLE
Vanilla Door Shuffle

### DIFF
--- a/randomizer/Enums/Settings.py
+++ b/randomizer/Enums/Settings.py
@@ -529,9 +529,9 @@ class MinigameBarrels(IntEnum):
     selected = auto()
 
 
-# A dictionary that maps setting names to the associated enum for that specific
-# setting. This only applies to select-based settings. The key for each enum
-# must exactly match the HTML name of the associated select.
+# ALL SELECT-BASED SETTINGS NEED AN ENTRY HERE!
+# A dictionary that maps setting names to the associated enum for that specific setting.
+# The key for each enum must exactly match the HTML name of the associated select.
 SettingsMap = {
     # Randomizer
     "enemies_selected": Enemies,
@@ -584,12 +584,14 @@ SettingsMap = {
 
 
 class SettingsStringEnum(IntEnum):
-    """Maps setting names to key values, for use in the ssettings string.
+    """Maps setting names to key values, for use in the settings string.
 
     Changing any of the existing values will cause generated settings strings
         to break. Only add new values.
 
-    Next available value: 132
+    ALL SETTINGS NEED AN ENTRY HERE!
+
+    Next available value: 133
     """
 
     activate_all_bananaports = 1
@@ -723,6 +725,7 @@ class SettingsStringEnum(IntEnum):
     wrinkly_hints = 129
     wrinkly_location_rando = 130
     coin_rando = 131
+    vanilla_door_rando = 132
 
 
 class SettingsStringDataType(IntEnum):
@@ -739,6 +742,7 @@ class SettingsStringDataType(IntEnum):
     list = auto()
 
 
+# ALL SETTINGS NEED AN ENTRY HERE!
 # This maps settings to the data types that will be used to encode them in the
 # settings string. Any enum-based settings should use that enum as their data
 # type, to shrink the payload as much as possible.
@@ -868,6 +872,7 @@ SettingsStringTypeMap = {
     SettingsStringEnum.troff_5: SettingsStringDataType.int16,
     SettingsStringEnum.troff_6: SettingsStringDataType.int16,
     SettingsStringEnum.troff_text: SettingsStringDataType.int16,
+    SettingsStringEnum.vanilla_door_rando: SettingsStringDataType.bool,
     SettingsStringEnum.warp_level_list_selected: SettingsStringDataType.list,
     SettingsStringEnum.warp_to_isles: SettingsStringDataType.bool,
     SettingsStringEnum.win_condition: WinCondition,
@@ -876,6 +881,7 @@ SettingsStringTypeMap = {
     SettingsStringEnum.wrinkly_location_rando: SettingsStringDataType.bool,
 }
 
+# ALL LIST SETTINGS NEED AN ENTRY HERE!
 # Another map for list settings, for the underlying data type of the list.
 SettingsStringListTypeMap = {
     SettingsStringEnum.enemies_selected: Enemies,

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -491,6 +491,14 @@ def GetItemsNeedingToBeAssumed(settings, placed_types):
     #     itemPool.extend(JunkItems())
     # if Types.Hint in unplacedTypes: someday???
     #     itemPool.extend(HintItems()) hints in the pool???
+    # If shops are not part of the larger item pool and are not placed, we may still need to assume them
+    # It is worth noting that TrainingBarrel and Shockwave type items are contingent on Shop type items being in the item rando pool
+    if Types.Shop not in settings.shuffled_location_types and Types.Shop not in placed_types and settings.move_rando != MoveRando.off:
+        itemPool.extend(AllKongMoves())
+        if settings.training_barrels == TrainingBarrels.shuffled:
+            itemPool.extend(TrainingBarrelAbilities().copy())
+        if settings.shockwave_status == ShockwaveStatus.shuffled_decoupled:
+            itemPool.extend(ShockwaveTypeItems(settings))
     return itemPool
 
 

--- a/randomizer/Lists/DoorLocations.py
+++ b/randomizer/Lists/DoorLocations.py
@@ -151,7 +151,9 @@ door_locations = {
             logic=lambda l: True,
             placed="tns",
         ),  # T&S Door in Diddy Cave
-        # DoorData(name="Jungle Japes: Near Painting Room", map=Maps.JungleJapes, logicregion=Regions.JungleJapesMain, location=[722.473, 538.0, 2386.608, 141.0], group=3, placed="tns"),  # T&S Door in Near Painting Room. Omitted because the indicator is weird
+        DoorData(
+            name="Jungle Japes: Near Painting Room", map=Maps.JungleJapes, logicregion=Regions.JungleJapesMain, location=[722.473, 538.0, 2386.608, 141.0], group=3, placed="tns", door_type="wrinkly"
+        ),  # T&S Door in Near Painting Room. Ironically cannot be a T&S because the indicator is weird
         DoorData(
             name="Jungle Japes: Fairy Cave",
             map=Maps.JungleJapes,
@@ -2020,6 +2022,7 @@ door_locations = {
             map=Maps.CrystalCavesLobby,
             logicregion=Regions.CrystalCavesLobby,
             location=[731.84, 280.5, 704.935, 120.0],
+            kong_lst=[Kongs.diddy],
             group=1,
             moveless=False,
             logic=lambda l: l.isdiddy and l.jetpack,
@@ -2107,7 +2110,7 @@ door_locations = {
         ),  # T&S Portal on Sprint Cabin
         DoorData(
             name="Crystal Caves: Near 5DI", map=Maps.CrystalCaves, logicregion=Regions.IglooArea, location=[120.997, 50.167, 1182.974, 75.146], group=5, logic=lambda l: True, placed="tns"
-        ),  # T&S Portal near 5DI (Custom)
+        ),  # T&S Portal near 5DI (Custom but treated as vanilla)
         DoorData(name="Crystal Caves: Outside Lanky's Cabin", map=Maps.CrystalCaves, logicregion=Regions.CabinArea, location=[2400.0, 276.0, 1892.5, 21.75], group=2, logic=lambda l: True),
         DoorData(name="Crystal Caves: Outside Chunky's Cabin", map=Maps.CrystalCaves, logicregion=Regions.CabinArea, location=[3515.65, 175.0, 1893.0, 273.7], group=2, logic=lambda l: True),
         DoorData(name="Crystal Caves: Outside Diddy's Lower Cabin", map=Maps.CrystalCaves, logicregion=Regions.CabinArea, location=[3697.5, 260.0, 1505.0, 291.0], group=2, logic=lambda l: True),

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -843,15 +843,15 @@ class LogicVarHolder:
         """Check if you meet the logical requirements to obtain the Rareware Coin."""
         have_enough_medals = self.BananaMedals >= self.settings.medal_requirement
         # Make sure you have access to enough levels to fit the locations in. This isn't super precise and doesn't need to be.
-        required_level = max(2, min(ceil(self.settings.medal_requirement / 4), 6))  # At least level 3 to give space for medal placements, at most level 6 to allow shenanigans
-        return have_enough_medals and self.IsLevelEnterable(required_level)
+        required_level_order = max(2, min(ceil(self.settings.medal_requirement / 4), 6))  # At least level 2 to give space for medal placements, at most level 6 to allow shenanigans
+        return have_enough_medals and self.HasFillRequirementsForLevel(self.settings.level_order[required_level_order])
 
     def CanGetRarewareGB(self):
         """Check if you meet the logical requirements to obtain the Rareware GB."""
         have_enough_fairies = self.BananaFairies >= self.settings.rareware_gb_fairies
         is_correct_kong = self.istiny or self.settings.free_trade_items
-        required_level = max(2, min(ceil(self.settings.rareware_gb_fairies / 2), 5))  # At least level 2 to give space for fairy placements, at most level 5 to allow shenanigans
-        return have_enough_fairies and is_correct_kong and self.IsLevelEnterable(required_level)
+        required_level_order = max(2, min(ceil(self.settings.rareware_gb_fairies / 2), 5))  # At least level 2 to give space for fairy placements, at most level 5 to allow shenanigans
+        return have_enough_fairies and is_correct_kong and self.HasFillRequirementsForLevel(self.settings.level_order[required_level_order])
 
     def BanItems(self, items):
         """Prevent an item from being picked up by the logic."""

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -433,6 +433,7 @@ class Settings:
         self.hard_enemies = False
         self.wrinkly_location_rando = False
         self.tns_location_rando = False
+        self.vanilla_door_rando = False
         self.minigames_list_selected = []
         self.item_rando_list_selected = []
         self.misc_changes_selected = []
@@ -480,6 +481,11 @@ class Settings:
 
     def resolve_settings(self):
         """Resolve settings which are not directly set through the UI."""
+        # If we're using the vanilla door shuffle, turn both wrinkly and tns rando on
+        if self.vanilla_door_rando:
+            self.wrinkly_location_rando = True
+            self.tns_location_rando = True
+
         # Move Location Rando
         if self.move_rando == MoveRando.start_with:
             self.unlock_all_moves = True

--- a/static/presets/default.json
+++ b/static/presets/default.json
@@ -123,6 +123,7 @@
     "troff_5": 6,
     "troff_6": 7,
     "troff_text": 300,
+    "vanilla_door_rando": false,
     "warp_level_list_selected": [],
     "warp_to_isles": true,
     "win_condition": "beat_krool",

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -110,6 +110,7 @@
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip" title="Wrinkly Door Locations are randomized">
                         <input class="form-check-input"
+                                id="wrinkly_location_rando"
                                 type="checkbox"
                                 name="wrinkly_location_rando"
                                 value="True"/>
@@ -119,10 +120,22 @@
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip" title="T&S Portal Locations are randomized">
                         <input class="form-check-input"
+                                id="tns_location_rando"
                                 type="checkbox"
                                 name="tns_location_rando"
                                 value="True"/>
                         Troff 'n' Scoff Portals
+                    </label>
+                </div>
+                <div class="form-check form-switch item-switch">
+                    <label data-toggle="tooltip"
+                            title="Wrinkly Doors and T&S Portals are shuffled among the vanilla locations.">
+                        <input class="form-check-input"
+                                id="vanilla_door_rando"
+                                type="checkbox"
+                                name="vanilla_door_rando"
+                                value="True"/>
+                        Vanilla Door Shuffle
                     </label>
                 </div>
                 <div class="form-check form-switch item-switch">
@@ -135,7 +148,6 @@
                         Battle Crowns
                     </label>
                 </div>
-                <div class="spacer"></div>
             </div>
             <div class="flex-container">
                 <div class="item-select">

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -141,6 +141,7 @@ def generate_lo_rando_race_settings():
     data["win_condition"] = WinCondition.beat_krool  # lots of options: all_keys | get_key8 | beat_krool | all_medals | all_fairies | all_blueprints | poke_snap
     data["wrinkly_location_rando"] = False  # likely to be False
     data["tns_location_rando"] = False  # likely to be False
+    data["vanilla_door_rando"] = True  # unclear, likely prefer True? easier to debug when False
     data["key_8_helm"] = True  # likely to be True in most settings
     data["misc_changes_selected"] = []  # a whole suite of things it includes
 
@@ -152,7 +153,7 @@ def generate_lo_rando_race_settings():
     data["glitches_selected"] = []
     data["microhints_enabled"] = MicrohintsEnabled.all  # off/base/all
     data["smaller_shops"] = True  # likely to be True in item rando, many settings force it to be false
-    data["alter_switch_allocation"] = True  # likely to be True, easier to test things when false
+    data["alter_switch_allocation"] = False  # likely to be True, easier to test things when false
     data["random_starting_region"] = False  # likely to be False
     data["random_fairies"] = False  # likely to be False
 

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -26,6 +26,7 @@ from ui.rando_options import (
     item_rando_list_changed,
     toggle_key_settings,
     disable_helm_hurry,
+    toggle_vanilla_door_rando,
 )
 
 # Call the generate_buttons function just to force loading of the file
@@ -57,3 +58,4 @@ updateDoorTwoNumAccess(None)
 item_rando_list_changed(None)
 toggle_key_settings(None)
 disable_helm_hurry(None)
+toggle_vanilla_door_rando(None)

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -861,3 +861,19 @@ def disable_helm_hurry(evt):
             selector.removeAttribute("disabled")
     except AttributeError:
         pass
+
+
+@bind("click", "vanilla_door_rando")
+def toggle_vanilla_door_rando(evt):
+    """Force Wrinkly and T&S Rando to be on when Vanilla Door Rando is on."""
+    vanilla_door_shuffle = js.document.getElementById("vanilla_door_rando")
+    wrinkly_rando = js.document.getElementById("wrinkly_location_rando")
+    tns_rando = js.document.getElementById("tns_location_rando")
+    if vanilla_door_shuffle.checked:
+        wrinkly_rando.checked = True
+        wrinkly_rando.setAttribute("disabled", "disabled")
+        tns_rando.checked = True
+        tns_rando.setAttribute("disabled", "disabled")
+    else:
+        wrinkly_rando.removeAttribute("disabled")
+        tns_rando.removeAttribute("disabled")

--- a/wiki-lists/DOORS.MD
+++ b/wiki-lists/DOORS.MD
@@ -12,6 +12,7 @@
 | Jungle Japes Lobby | Jungle Japes: Lobby - Far Right | Wrinkly |  | 
 | Jungle Japes Lobby | Jungle Japes: Lobby - Close Left | Wrinkly |  | 
 | Jungle Japes | Jungle Japes: Diddy Cave | Both |  | 
+| Jungle Japes | Jungle Japes: Near Painting Room | Wrinkly |  | 
 | Jungle Japes | Jungle Japes: Fairy Cave | Both |  | 
 | Jungle Japes | Jungle Japes: Next to Diddy Cage - right | Both |  | 
 | Jungle Japes | Jungle Japes: Alcove Above Diddy Tunnel - right | Wrinkly |  | 


### PR DESCRIPTION
Added vanilla door shuffle per the requirements. If this setting is on, then it overrides your Wrinkly/T&S door rando setting.
https://docs.google.com/document/d/1XSr7MUVh29J4LLVZ2ECrRn1jgVpeAuRcDR764uZ3XIs/edit

Also included are some big fill fixes:
- Fixed logic around the Rareware GB and Coin locations (major fill fail reason)
- Moved Rainbow Coin placement to be even before Kongs and Moves (another likely major fill fail reason)
- Implemented some optimizations to the fill to hopefully speed things up (even though I had to slow one thing down)
- Foolish hints now respect helm doors (except for GBs)