### PR TITLE
fix hint aversion, fix <4 starting move issue

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -714,6 +714,7 @@ def compileHints(spoiler: Spoiler):
                 continue
             # For early Keys 1-2, place one hint with their required Kong and the level they're in
             if key_id in (Items.JungleJapesKey, Items.AngryAztecKey) and level_order_matters and not spoiler.settings.hard_level_progression:
+                globally_hinted_location_ids.append(key_location_ids[key_id])
                 location = LocationList[key_location_ids[key_id]]
                 key_item = ItemList[key_id]
                 kong_index = location.kong
@@ -762,7 +763,7 @@ def compileHints(spoiler: Spoiler):
                     path_location_id = random.choice(hintable_location_ids)
                     # Soft reroll duplicate hints based on hint reroll parameters
                     rerolls = 0
-                    while rerolls < hint_reroll_cap and path_location_id in globally_hinted_location_ids and random.random() >= hint_reroll_chance:
+                    while rerolls < hint_reroll_cap and path_location_id in globally_hinted_location_ids and random.random() <= hint_reroll_chance:
                         path_location_id = random.choice(hintable_location_ids)
                         rerolls += 1
                     globally_hinted_location_ids.append(path_location_id)
@@ -796,7 +797,7 @@ def compileHints(spoiler: Spoiler):
                 path_location_id = random.choice(hintable_location_ids)
                 # Soft reroll duplicate hints based on hint reroll parameters
                 rerolls = 0
-                while rerolls < hint_reroll_cap and path_location_id in globally_hinted_location_ids and random.random() >= hint_reroll_chance:
+                while rerolls < hint_reroll_cap and path_location_id in globally_hinted_location_ids and random.random() <= hint_reroll_chance:
                     path_location_id = random.choice(hintable_location_ids)
                     rerolls += 1
                 globally_hinted_location_ids.append(path_location_id)
@@ -826,7 +827,7 @@ def compileHints(spoiler: Spoiler):
                 path_location_id = random.choice(hintable_location_ids)
                 # Soft reroll duplicate hints based on hint reroll parameters
                 rerolls = 0
-                while rerolls < hint_reroll_cap and path_location_id in globally_hinted_location_ids and random.random() >= hint_reroll_chance:
+                while rerolls < hint_reroll_cap and path_location_id in globally_hinted_location_ids and random.random() <= hint_reroll_chance:
                     path_location_id = random.choice(hintable_location_ids)
                     rerolls += 1
                 globally_hinted_location_ids.append(path_location_id)
@@ -1071,7 +1072,7 @@ def compileHints(spoiler: Spoiler):
             hinted_loc_id = random.choice(hintable_location_ids)
             # Soft reroll duplicate hints based on hint reroll parameters
             rerolls = 0
-            while rerolls < hint_reroll_cap and hinted_loc_id in globally_hinted_location_ids and random.random() >= hint_reroll_chance:
+            while rerolls < hint_reroll_cap and hinted_loc_id in globally_hinted_location_ids and random.random() <= hint_reroll_chance:
                 hinted_loc_id = random.choice(hintable_location_ids)
                 rerolls += 1
             globally_hinted_location_ids.append(hinted_loc_id)

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1180,6 +1180,7 @@ def Fill(spoiler):
     # Finally, check if game is beatable
     Reset()
     if not GetAccessibleLocations(spoiler.settings, [], SearchMode.CheckAllReachable):
+        print("Failed 101% check")
         raise Ex.GameNotBeatableException("Game not able to complete 101% after placing all items.")
     return
 
@@ -1531,10 +1532,10 @@ def FillKongsAndMoves(spoiler, placedTypes):
     # We can expect that all locations in this region are starting move locations or Training Barrels
     for locationLogic in RegionList[Regions.GameStart].locations:
         location = LocationList[locationLogic.id]
-        if location.item not in (None, Items.NoItem) or (location.item == Items.NoItem and not location.constant):
-            startingMoves.append(location.item)
-        else:
+        if location.item is None:
             locationsNeedingMoves.append(locationLogic.id)
+        elif location.item not in (None, Items.NoItem):
+            startingMoves.append(location.item)
     # Fill the empty starting locations
     if any(locationsNeedingMoves):
         newlyPlacedItems = []
@@ -1676,6 +1677,7 @@ def FillKongsAndMovesForLevelOrder(spoiler):
             # After setting B. Lockers and bosses, make sure the game is still 101%-able
             Reset()
             if not GetAccessibleLocations(spoiler.settings, [], SearchMode.CheckAllReachable):
+                print("Failed post-progression 101% check?")
                 raise Ex.GameNotBeatableException("Game not able to complete 101% after setting progression.")
             # Once progression requirements updated, no longer assume we need kongs freed for level progression
             spoiler.settings.kongs_for_progression = False

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -80,6 +80,8 @@ class Location:
 
     def PlaceItem(self, item):
         """Place item at this location."""
+        if self.item == Items.NoItem and item != Items.NoItem:
+            print("what the fuck??")
         self.item = item
         # If we're placing a real move here, lock out mutually exclusive shop locations
         if item != Items.NoItem and self.type == Types.Shop:

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -791,6 +791,9 @@ class LogicVarHolder:
                 # Require one of twirl or hunky chunky by level 7 to prevent non-hard-boss fill failures
                 if not self.settings.hard_bosses and order_of_level >= 7 and not (self.twirl or self.hunkyChunky):
                     return False
+                # Require both hunky chunky and twirl (or hard bosses) before Helm to prevent boss fill failures
+                if order_of_level > 7 and not self.hunkyChunky or (not self.twirl and not self.settings.hard_bosses):
+                    return False
         # If we have the moves, ensure we have enough kongs as well
         return self.HasEnoughKongs(level, forPreviousLevel=True)
 

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -181,6 +181,7 @@ class Spoiler:
         settings["Select Starting Keys"] = self.settings.select_keys
         if not self.settings.keys_random:
             settings["Number of Keys Required"] = self.settings.krool_key_count
+        settings["Starting Moves Count"] = self.settings.starting_moves_count
         settings["Fast Start"] = self.settings.fast_start_beginning_of_game
         settings["Helm Setting"] = self.settings.helm_setting.name
         settings["Quality of Life"] = self.settings.quality_of_life


### PR DESCRIPTION
Woops the > should have been a <, hint duplication aversion was not functional at all.

Other fixes
- Fixed an issue where training barrels that were supposed to be empty could still get items if you started with <4 moves.
- Fixed a boss fill issue when twirl or hunky was in Helm. They can no longer be in Helm in simple level order.