### PR TITLE
Inaccessibility Rework

### DIFF
--- a/randomizer/Lists/Exceptions.py
+++ b/randomizer/Lists/Exceptions.py
@@ -107,3 +107,9 @@ class CoinFillFailureException(FillException):
     """Exception triggered when coin rando fails to correctly generate a valid set of groups."""
 
     pass
+
+
+class SettingsIncompatibleException(FillException):
+    """Exception triggered when conditions arise that are most likely a settings incompatibility."""
+
+    pass

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -41,6 +41,7 @@ class Location:
         self.kong = kong
         self.logically_relevant = logically_relevant  # This is True if this location is needed to derive the logic for another location
         self.placement_index = None
+        self.inaccessible = False
         if self.type == Types.Shop:
             self.movetype = data[0]
             self.index = data[1]

--- a/randomizer/ShuffleDoors.py
+++ b/randomizer/ShuffleDoors.py
@@ -143,7 +143,8 @@ def ShuffleVanillaDoors(spoiler):
                 vanilla_door_indexes.append(door_index)
         random.shuffle(vanilla_door_indexes)
         # One random vanilla T&S per level is locked to being a T&S
-        locked_tns_index = random.choice([idx for idx in vanilla_door_indexes if door_locations[level][idx].default_placed == "tns" and door_locations[level][idx].door_type != "wrinkly"])
+        locked_tns_options = [idx for idx in vanilla_door_indexes if door_locations[level][idx].default_placed == "tns" and door_locations[level][idx].door_type != "wrinkly"]
+        locked_tns_index = random.choice(locked_tns_options)
         locked_tns = door_locations[level][locked_tns_index]
         locked_tns.assignPortal()
         human_portal_doors[level_list[level]]["T&S #1"] = locked_tns.name
@@ -167,7 +168,7 @@ def ShuffleVanillaDoors(spoiler):
         placed_tns_count = 1
         for door_index in vanilla_door_indexes:
             vanilla_door = door_locations[level][door_index]
-            if vanilla_door.placed == "none" and vanilla_door.default_placed == "tns":
+            if vanilla_door.placed == "none" and vanilla_door.default_placed == "tns" and vanilla_door.door_type != "wrinkly":
                 placed_tns_count += 1
                 vanilla_door.assignPortal()
                 human_portal_doors[level_list[level]]["T&S #" + str(placed_tns_count)] = vanilla_door.name

--- a/randomizer/ShuffleKasplats.py
+++ b/randomizer/ShuffleKasplats.py
@@ -233,14 +233,15 @@ def KasplatShuffle(spoiler, LogicVariables):
                 # Verify world by assuring all locations are still reachable
                 Fill.Reset()
                 if not Fill.VerifyWorld(spoiler.settings):
-                    raise Ex.KasplatPlacementException
+                    if retries < 10:
+                        raise Ex.KasplatPlacementException
+                    else:
+                        # This is the first VerifyWorld check, and serves as the canary in the coal mine
+                        # If we get to this point in the code, the world itself is likely unstable from some combination of settings or bugs
+                        js.postMessage("Settings combination is likely unstable.")
+                        raise Ex.SettingsIncompatibleException
                 return
             except Ex.KasplatPlacementException:
-                if retries == 10:
-                    # This is the first VerifyWorld check, and serves as the canary in the coal mine
-                    # If we get to this point in the code, the world itself is likely unstable from some combination of settings or bugs
-                    js.postMessage("Settings combination is likely unstable.")
-                    raise Ex.KasplatAttemptCountExceeded
                 retries += 1
                 js.postMessage("Kasplat placement failed. Retrying. Tries: " + str(retries))
                 # We've added logic in kasplat location rando, now we need to remove it

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -342,6 +342,9 @@ class Spoiler:
                 item = Items.NoItem
             else:
                 item = ItemList[location.item]
+            # Empty PreGiven locations don't really exist and shouldn't show up in the spoiler log
+            if location.type == Types.PreGivenMove and location.item in (None, Items.NoItem):
+                continue
             # Separate Kong locations
             if location.type == Types.Kong:
                 humanspoiler["Items"]["Kongs"][location.name] = item.name
@@ -531,7 +534,20 @@ class Spoiler:
             humanspoiler["Shuffled Bananaport Levels"] = shuffled_warp_levels
             humanspoiler["Shuffled Bananaports"] = self.human_warp_locations
         if len(self.microhints) > 0:
-            humanspoiler["Direct Item Hints"] = self.microhints
+            human_microhints = {}
+            for name, hint in self.microhints.items():
+                filtered_hint = hint.replace("\x04", "")
+                filtered_hint = filtered_hint.replace("\x05", "")
+                filtered_hint = filtered_hint.replace("\x06", "")
+                filtered_hint = filtered_hint.replace("\x07", "")
+                filtered_hint = filtered_hint.replace("\x08", "")
+                filtered_hint = filtered_hint.replace("\x09", "")
+                filtered_hint = filtered_hint.replace("\x0a", "")
+                filtered_hint = filtered_hint.replace("\x0b", "")
+                filtered_hint = filtered_hint.replace("\x0c", "")
+                filtered_hint = filtered_hint.replace("\x0d", "")
+                human_microhints[name] = filtered_hint
+            humanspoiler["Direct Item Hints"] = human_microhints
         if len(self.hint_list) > 0:
             human_hint_list = {}
             # Here it filters out the coloring from the hints to make it actually readable in the spoiler log


### PR DESCRIPTION
Reworked smaller shops and starting moves to use a new `inaccessible` variable on the Location object. This has a couple implications:
- Immediately, it fixes that one stupid error where it would try to delete a nonexistent location from LocationList
- THE BIG ONE: seed generation is once again idempotent. You can now make multiple seeds locally without restarting everything.

Other fixes:
- Removed coloring characters from the microhints in the spoiler log
- Fixed an issue where no logic would never succeed fills
- Fixed an issue where vanilla door rando could have that one japes alcove T&S still be a T&S when it shouldn't because the indicator doesn't appear on it