### PR TITLE
starting key issue fix, better snap win con

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
     {
       "label": "Validate Styles",
       "type": "shell",
-      "command": "${command:python.interpreterPath} -m pycodestyle --ignore E501,W605,W503,E203 ${workspaceFolder}",
+      "command": "${command:python.interpreterPath} -m pycodestyle --ignore E501,W605,W503,E203,E741 ${workspaceFolder}",
       "problemMatcher": []
     },
     {

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -301,12 +301,12 @@ def compileHints(spoiler: Spoiler):
     level_order_matters = spoiler.settings.logic_type != LogicType.nologic and spoiler.settings.shuffle_loading_zones != ShuffleLoadingZones.all
     # Determine what hint types are valid for these settings
     valid_types = [HintType.Joke]
-    if spoiler.settings.krool_phase_count < 5 and spoiler.settings.win_condition == WinCondition.beat_krool:
+    if (spoiler.settings.krool_phase_count < 5 or spoiler.settings.krool_random) and spoiler.settings.win_condition == WinCondition.beat_krool:
         valid_types.append(HintType.KRoolOrder)
         # If the seed doesn't funnel you into helm, guarantee one K. Rool order hint
         if Events.HelmKeyTurnedIn not in spoiler.settings.krool_keys_required or not spoiler.settings.key_8_helm:
             minned_hint_types.append(HintType.KRoolOrder)
-    if spoiler.settings.helm_setting != HelmSetting.skip_all and spoiler.settings.helm_phase_count < 5:
+    if spoiler.settings.helm_setting != HelmSetting.skip_all and (spoiler.settings.helm_phase_count < 5 or spoiler.settings.helm_random):
         valid_types.append(HintType.HelmOrder)
         minned_hint_types.append(HintType.HelmOrder)
     if spoiler.settings.move_rando not in (MoveRando.off, MoveRando.item_shuffle) and Types.Shop not in spoiler.settings.shuffled_location_types:
@@ -357,8 +357,8 @@ def compileHints(spoiler: Spoiler):
                 #     hint_distribution[HintType.RequiredWinConditionHint] += 1  # Dedicated Mini Monkey hint
                 # if Kongs.chunky in spoiler.settings.krool_order:
                 #     hint_distribution[HintType.RequiredWinConditionHint] += 1  # Dedicated Hunky Chunky hint
-            # All fairies seeds need help finding the camera (if you don't start with it) - variable amount of unique hints for it
-            if spoiler.settings.win_condition == WinCondition.all_fairies and spoiler.settings.shockwave_status != ShockwaveStatus.start_with:
+            # Some win conditions need help finding the camera (if you don't start with it) - variable amount of unique hints for it
+            if spoiler.settings.win_condition in (WinCondition.all_fairies, WinCondition.poke_snap) and spoiler.settings.shockwave_status != ShockwaveStatus.start_with:
                 valid_types.append(HintType.RequiredWinConditionHint)
                 camera_location_id = None
                 for id, loc in LocationList.items():
@@ -796,7 +796,7 @@ def compileHints(spoiler: Spoiler):
                 hint_location.hint_type = HintType.RequiredWinConditionHint
                 UpdateHint(hint_location, message)
         # All fairies seeds get 2 path hints for the camera
-        if spoiler.settings.win_condition == WinCondition.all_fairies:
+        if spoiler.settings.win_condition == WinCondition.all_fairies or spoiler.settings.win_condition == WinCondition.poke_snap:
             for location_id in spoiler.woth_paths.keys():
                 if LocationList[location_id].item == Items.Camera:
                     camera_location_id = location_id

--- a/randomizer/Lists/CrownLocations.py
+++ b/randomizer/Lists/CrownLocations.py
@@ -603,7 +603,7 @@ CrownLocations = {
         CrownLocation(map=Maps.CastleMausoleum, name="Creepy Castle - Lanky Crypt: Lanky Tunnel", x=1186, y=160, z=130, scale=0.4, region=Regions.Mausoleum),
         CrownLocation(map=Maps.CastleUpperCave, name="Creepy Castle - Tunnel: Near Pit", x=704, y=200, z=852, scale=0.4, region=Regions.UpperCave),
         CrownLocation(map=Maps.CastleUpperCave, name="Creepy Castle - Tunnel: Near Candy's", x=1104, y=300, z=2241, scale=0.4, region=Regions.UpperCave),
-        CrownLocation(map=Maps.CastleLibrary, name="Creepy Castle - Library: Enemy Gauntlet Room", x=289, y=190, z=530, scale=0.5, region=Regions.Library),
+        # CrownLocation(map=Maps.CastleLibrary, name="Creepy Castle - Library: Enemy Gauntlet Room", x=289, y=190, z=530, scale=0.5, region=Regions.Library), # Disabled - if you do the crown first the enemies don't spawn, locking you in
         CrownLocation(
             map=Maps.CastleLibrary,
             name="Creepy Castle - Library: Flying Book Room",

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -216,7 +216,7 @@ LocationList = {
     Locations.JapesLankyMedal: Location(Levels.JungleJapes, "Japes Lanky Medal", Items.BananaMedal, Types.Medal, Kongs.lanky),
     Locations.JapesTinyMedal: Location(Levels.JungleJapes, "Japes Tiny Medal", Items.BananaMedal, Types.Medal, Kongs.tiny),
     Locations.JapesChunkyMedal: Location(Levels.JungleJapes, "Japes Chunky Medal", Items.BananaMedal, Types.Medal, Kongs.chunky),
-    Locations.DiddyKong: Location(Levels.JungleJapes, "Diddy Kong", Items.Diddy, Types.Kong, Kongs.any, [MapIDCombo(0, -1, 6)], logically_relevant=True),
+    Locations.DiddyKong: Location(Levels.JungleJapes, "Diddy Kong's Cage", Items.Diddy, Types.Kong, Kongs.any, [MapIDCombo(0, -1, 6)], logically_relevant=True),
     Locations.JapesDonkeyFrontofCage: Location(Levels.JungleJapes, "Japes in Front of Diddy Cage", Items.GoldenBanana, Types.Banana, Kongs.any, [MapIDCombo(Maps.JungleJapes, 0x69, 4, Kongs.donkey)], logically_relevant=True),  # Can be assigned to other kongs
     Locations.JapesDonkeyFreeDiddy: Location(Levels.JungleJapes, "Japes Free Diddy Item", Items.GoldenBanana, Types.Banana, Kongs.any, [MapIDCombo(Maps.JungleJapes, 0x48, 5, Kongs.donkey)]),  # Can be assigned to other kongs
     Locations.JapesDonkeyCagedBanana: Location(Levels.JungleJapes, "Japes Donkey Floor Cage Banana", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.JungleJapes, 0x44, 20, Kongs.donkey)]),
@@ -258,7 +258,7 @@ LocationList = {
     Locations.AztecKasplatOnTinyTemple: Location(Levels.AngryAztec, "Aztec Kasplat On Tiny Temple", Items.AngryAztecDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.AngryAztec]),
     Locations.AztecTinyKlaptrapRoom: Location(Levels.AngryAztec, "Aztec Tiny Klaptrap Room", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.AztecTinyTemple, 0x7E, 65, Kongs.tiny)]),
     Locations.AztecChunkyKlaptrapRoom: Location(Levels.AngryAztec, "Aztec Chunky Klaptrap Room", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.AztecTinyTemple, 0x9, 64, Kongs.chunky)]),
-    Locations.TinyKong: Location(Levels.AngryAztec, "Tiny Kong", Items.Tiny, Types.Kong, Kongs.any, [MapIDCombo(0, -1, 66)], logically_relevant=True),
+    Locations.TinyKong: Location(Levels.AngryAztec, "Tiny Kong's Cage", Items.Tiny, Types.Kong, Kongs.any, [MapIDCombo(0, -1, 66)], logically_relevant=True),
     Locations.AztecDiddyFreeTiny: Location(Levels.AngryAztec, "Aztec Free Tiny Item", Items.GoldenBanana, Types.Banana, Kongs.any, [MapIDCombo(Maps.AztecTinyTemple, 0x5B, 67, Kongs.diddy)]),  # Can be assigned to other kongs
     Locations.AztecLankyVulture: Location(Levels.AngryAztec, "Aztec Lanky Vulture Shooting", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(0, -1, 68, Kongs.lanky)]),
     Locations.AztecBattleArena: Location(Levels.AngryAztec, "Aztec Battle Arena", Items.BattleCrown, Types.Crown, Kongs.any, [MapIDCombo(Maps.AztecCrown, -1, 610)]),
@@ -275,7 +275,7 @@ LocationList = {
     Locations.AztecChunky5DoorTemple: Location(Levels.AngryAztec, "Aztec Chunky 5 Door Temple", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(0, -1, 59, Kongs.chunky)]),
     Locations.AztecKasplatChunky5DT: Location(Levels.AngryAztec, "Aztec Kasplat Inside Chunky's 5-Door Temple", Items.AngryAztecChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.AztecChunky5DTemple]),
     Locations.AztecTinyBeetleRace: Location(Levels.AngryAztec, "Aztec Tiny Beetle Race", Items.GoldenBanana, Types.ToughBanana, Kongs.tiny, [MapIDCombo(Maps.AztecTinyRace, 0x48, 75, Kongs.tiny)]),
-    Locations.LankyKong: Location(Levels.AngryAztec, "Lanky Kong", Items.Lanky, Types.Kong, Kongs.any, [MapIDCombo(0, -1, 70)], logically_relevant=True),
+    Locations.LankyKong: Location(Levels.AngryAztec, "Lanky Kong's Cage", Items.Lanky, Types.Kong, Kongs.any, [MapIDCombo(0, -1, 70)], logically_relevant=True),
     Locations.AztecDonkeyFreeLanky: Location(Levels.AngryAztec, "Aztec Free Lanky Item", Items.GoldenBanana, Types.Banana, Kongs.any, [MapIDCombo(Maps.AztecLlamaTemple, 0x6C, 77, Kongs.donkey)]),  # Can be assigned to other kongs
     Locations.AztecLankyLlamaTempleBarrel: Location(Levels.AngryAztec, "Aztec Lanky Llama Temple Barrel", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(0, -1, 73, Kongs.lanky)]),
     Locations.AztecLankyMatchingGame: Location(Levels.AngryAztec, "Aztec Lanky Matching Game", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(Maps.AztecLlamaTemple, 0x2B, 72, Kongs.lanky)]),
@@ -304,7 +304,7 @@ LocationList = {
     Locations.FactoryTinyCarRace: Location(Levels.FranticFactory, "Factory Tiny Car Race", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.FactoryTinyRace, 0x62, 139, Kongs.tiny)]),
     Locations.FactoryDiddyChunkyRoomBarrel: Location(Levels.FranticFactory, "Factory Diddy Storage Room Barrel", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(0, -1, 134, Kongs.diddy)]),
     Locations.FactoryDonkeyPowerHut: Location(Levels.FranticFactory, "Factory Donkey Power Hut", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.FactoryPowerHut, 0x2, 112, Kongs.donkey)]),
-    Locations.ChunkyKong: Location(Levels.FranticFactory, "Chunky Kong", Items.Chunky, Types.Kong, Kongs.any, [MapIDCombo(0, -1, 117)], logically_relevant=True),
+    Locations.ChunkyKong: Location(Levels.FranticFactory, "Chunky Kong's Cage", Items.Chunky, Types.Kong, Kongs.any, [MapIDCombo(0, -1, 117)], logically_relevant=True),
     Locations.NintendoCoin: Location(Levels.FranticFactory, "DK Arcade Round 2", Items.NintendoCoin, Types.Coin, Kongs.donkey, [MapIDCombo(Maps.FranticFactory, 0x13E, 132)]),
     Locations.FactoryDonkeyDKArcade: Location(Levels.FranticFactory, "Factory Donkey DK Arcade Round 1", Items.GoldenBanana, Types.ToughBanana, Kongs.donkey, [MapIDCombo(Maps.FranticFactory, 0x108, 130, Kongs.donkey), MapIDCombo(Maps.FactoryBaboonBlast, 0, 130, Kongs.donkey)]),
     Locations.FactoryLankyFreeChunky: Location(Levels.FranticFactory, "Factory Free Chunky Item", Items.GoldenBanana, Types.Banana, Kongs.any, [MapIDCombo(Maps.FranticFactory, 0x78, 118, Kongs.lanky)]),  # Can be assigned to other kongs

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -202,7 +202,23 @@ class LogicVarHolder:
         ]
         for keyEvent in keyEvents:
             if keyEvent not in self.settings.krool_keys_required:
-                self.Events.append(keyEvent)
+                # This is horrifyingly bad to go keys -> events -> keys but the patcher is expecting events in krool_keys_required and I'm not touching the math there to fix it
+                if keyEvent == Events.JapesKeyTurnedIn:
+                    self.JapesKey = True
+                elif keyEvent == Events.AztecKeyTurnedIn:
+                    self.AztecKey = True
+                elif keyEvent == Events.FactoryKeyTurnedIn:
+                    self.FactoryKey = True
+                elif keyEvent == Events.GalleonKeyTurnedIn:
+                    self.GalleonKey = True
+                elif keyEvent == Events.ForestKeyTurnedIn:
+                    self.ForestKey = True
+                elif keyEvent == Events.CavesKeyTurnedIn:
+                    self.CavesKey = True
+                elif keyEvent == Events.CastleKeyTurnedIn:
+                    self.CastleKey = True
+                elif keyEvent == Events.HelmKeyTurnedIn:
+                    self.HelmKey = True
 
         activated_warp_maps = []
         if self.settings.activate_all_bananaports == ActivateAllBananaports.all:
@@ -816,10 +832,11 @@ class LogicVarHolder:
 
     def WinConditionMet(self):
         """Check if the current game state has met the win condition."""
-        if (
-            self.settings.win_condition == WinCondition.beat_krool or self.settings.win_condition == WinCondition.poke_snap
-        ):  # Photo taking doesn't have a clear wincon so this'll do until something better is concocted
+        if self.settings.win_condition == WinCondition.beat_krool:
             return Events.KRoolDefeated in self.Events
+        # Photo taking doesn't have a perfect wincon so this'll do until something better is concocted
+        if self.settings.win_condition == WinCondition.poke_snap:
+            return Events.KRoolDefeated in self.Events and self.camera
         elif self.settings.win_condition == WinCondition.get_key8:
             return self.HelmKey
         elif self.settings.win_condition == WinCondition.all_fairies:

--- a/wiki-lists/CROWNS.MD
+++ b/wiki-lists/CROWNS.MD
@@ -279,7 +279,6 @@
 | Castle Mausoleum | Creepy Castle - Lanky Crypt: Lanky Tunnel |  | 
 | Castle Upper Cave | Creepy Castle - Tunnel: Near Pit |  | 
 | Castle Upper Cave | Creepy Castle - Tunnel: Near Candy's |  | 
-| Castle Library | Creepy Castle - Library: Enemy Gauntlet Room |  | 
 | Castle Library | Creepy Castle - Library: Flying Book Room | (l.CanSlamSwitch(Levels.CreepyCastle, 3) and l.isdonkey and (l.strongKong or l.settings.damage_amount == DamageAmount.default)) or l.phasewalk | 
 | Castle Museum | Creepy Castle - Museum: Near Race |  | 
 | Castle Museum | Creepy Castle - Museum: Behind Pillar | (l.monkeyport and l.istiny) or l.phasewalk | 


### PR DESCRIPTION
- Fixed an issue where Kongs/keys could be placed in too-late levels depending on the keys you start with
- Removed a problematic crown location from castle library
- Allow K. Rool/Helm order hints to appear if the number of phases/rooms is random and rolls 5
- Rename Kong cage locations to improve hint readability
- Improved Kremling Kapture hints - you now get path hints to the camera and the win condition is changed to K. Rool + camera