### PR TITLE
Fixing a bug with filenames for custom music

### DIFF
--- a/static/js/initalize.js
+++ b/static/js/initalize.js
@@ -96,7 +96,7 @@ document
                 .async("Uint8Array")
                 .then(function (content) {
                   resolve({
-                    name: current_filename,
+                    name: current_filename.slice(0, -4),
                     file: content
                   })
                 });
@@ -109,7 +109,7 @@ document
                 .async("Uint8Array")
                 .then(function (content) {
                   resolve({
-                    name: current_filename,
+                    name: current_filename.slice(0, -4),
                     file: content
                   })
                 });
@@ -122,7 +122,7 @@ document
                 .async("Uint8Array")
                 .then(function (content) {
                   resolve({
-                    name: current_filename,
+                    name: current_filename.slice(0, -4),
                     file: content
                   })
                 });

--- a/static/js/initalize.js
+++ b/static/js/initalize.js
@@ -82,40 +82,63 @@ document
     var fileReader = new FileReader();
     fileReader.onload = function (fileLoadedEvent) {
       var new_zip = new JSZip();
-      new_zip.loadAsync(fileLoadedEvent.target.result).then(function () {
-        bgm = [];
-        bgm_names = [];
-        fanfares = [];
-        fanfare_names = [];
-        events = [];
-        event_names = [];
-        for (var file in new_zip.files) {
-          if (file.includes("bgm/") && file.slice(-4) == ".bin") {
-            new_zip
-              .file(file)
-              .async("Uint8Array")
-              .then(function (content) {
-                bgm.push(content)
-                bgm_names.push(file.slice(0, -4))
-              });
-          } else if (file.includes("fanfares/") && file.slice(-4) == ".bin") {
-            new_zip
-              .file(file)
-              .async("Uint8Array")
-              .then(function (content) {
-                fanfares.push(content)
-                fanfare_names.push(file.slice(0, -4))
-              });
-          } else if (file.includes("events/") && file.slice(-4) == ".bin") {
-            new_zip
-              .file(file)
-              .async("Uint8Array")
-              .then(function (content) {
-                events.push(content)
-                event_names.push(file.slice(0, -4))
-              });
+      new_zip.loadAsync(fileLoadedEvent.target.result).then(async function () {
+        let bgm_promises = [];
+        let fanfare_promises = [];
+        let event_promises = [];
+        for (var filename of Object.keys(new_zip.files)) {
+          if (filename.includes("bgm/") && filename.slice(-4) == ".bin") {
+            bgm_promises.push(new Promise((resolve, reject) => {
+              var current_filename = filename;
+              new_zip
+                .file(current_filename)
+                .async("Uint8Array")
+                .then(function (content) {
+                  resolve({
+                    name: current_filename,
+                    file: content
+                  })
+                });
+            }));
+          } else if (filename.includes("fanfares/") && filename.slice(-4) == ".bin") {
+            fanfare_promises.push(new Promise((resolve, reject) => {
+              var current_filename = filename;
+              new_zip
+                .file(current_filename)
+                .async("Uint8Array")
+                .then(function (content) {
+                  resolve({
+                    name: current_filename,
+                    file: content
+                  })
+                });
+            }));
+          } else if (filename.includes("events/") && filename.slice(-4) == ".bin") {
+            event_promises.push(new Promise((resolve, reject) => {
+              var current_filename = filename;
+              new_zip
+                .file(current_filename)
+                .async("Uint8Array")
+                .then(function (content) {
+                  resolve({
+                    name: current_filename,
+                    file: content
+                  })
+                });
+            }));
           }
         }
+        let bgm_files = await Promise.all(bgm_promises);
+        let fanfare_files = await Promise.all(fanfare_promises);
+        let event_files = await Promise.all(event_promises);
+
+        let bgm = bgm_files.map(x => x.file);
+        let bgm_names = bgm_files.map(x => x.name);
+        let fanfares = fanfare_files.map(x => x.file);
+        let fanfare_names = fanfare_files.map(x => x.name);
+        let events = event_files.map(x => x.file);
+        let event_names = event_files.map(x => x.name);
+
         cosmetics = { bgm: bgm, fanfares: fanfares, events: events };
         cosmetic_names = {bgm: bgm_names, fanfares: fanfare_names, events: event_names };
       });

--- a/static/js/initalize.js
+++ b/static/js/initalize.js
@@ -86,6 +86,7 @@ document
         let bgm_promises = [];
         let fanfare_promises = [];
         let event_promises = [];
+
         for (var filename of Object.keys(new_zip.files)) {
           if (filename.includes("bgm/") && filename.slice(-4) == ".bin") {
             bgm_promises.push(new Promise((resolve, reject) => {
@@ -128,6 +129,7 @@ document
             }));
           }
         }
+
         let bgm_files = await Promise.all(bgm_promises);
         let fanfare_files = await Promise.all(fanfare_promises);
         let event_files = await Promise.all(event_promises);


### PR DESCRIPTION
The music-loading function in initialize.js had an async-related issue where the filename was not preserved when loading in custom music files. This has been fixed by creating new Promises that store the filename in a separate variable upon creation.

The function now also uses `Promise.all` to ensure that there is no chance of a race condition unlinking files from filenames.