### PR TITLE
Krool hint phases, Fix bad keys, Settings string test

### DIFF
--- a/randomizer/CollectibleLogicFiles/CreepyCastle.py
+++ b/randomizer/CollectibleLogicFiles/CreepyCastle.py
@@ -42,7 +42,7 @@ LogicRegions = {
     ],
     Regions.Library: [
         Collectible(Collectibles.bunch, Kongs.donkey, lambda l: True, None, 1),  # In switch room
-        Collectible(Collectibles.bunch, Kongs.donkey, lambda l: l.CanSlamSwitch(Levels.CreepyCastle, 3) or l.phasewalk, None, 2),  # In haunted books corridor
+        Collectible(Collectibles.bunch, Kongs.donkey, lambda l: (l.CanSlamSwitch(Levels.CreepyCastle, 3) or l.phasewalk) and l.strongKong, None, 2),  # In haunted books corridor
 
     ],
     Regions.Ballroom: [

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -144,6 +144,8 @@ hint_list = [
 ]
 
 kong_list = ["\x04Donkey\x04", "\x05Diddy\x05", "\x06Lanky\x06", "\x07Tiny\x07", "\x08Chunky\x08", "\x04Any kong\x04"]
+colorless_kong_list = ["Donkey", "Diddy", "Lanky", "Tiny", "Chunky"]
+kong_colors = ["\x04", "\x05", "\x06", "\x07", "\x08", "\x04"]
 
 kong_cryptic = [
     ["The kong who is bigger, faster and potentially stronger too", "The kong who fires in spurts", "The kong with a tie", "The kong who slaps their instrument to the jungle beat"],
@@ -769,7 +771,7 @@ def compileHints(spoiler: Spoiler):
 
     # Some win conditions need very specific items that we really should hint
     if hint_distribution[HintType.RequiredWinConditionHint] > 0:
-        # To aid K. Rool goals, always hint Rocketbarrel, Mini Monkey, and Hunky Chunky if they are needed to beat K. Rool
+        # To aid K. Rool goals create a number of path hints to help find items required specifically for K. Rool
         if spoiler.settings.win_condition == WinCondition.beat_krool:
             path = spoiler.woth_paths[Locations.BananaHoard]
             already_chosen_krool_path_locations = []
@@ -785,14 +787,18 @@ def compileHints(spoiler: Spoiler):
                 already_chosen_krool_path_locations.append(path_location_id)
                 region = GetRegionOfLocation(path_location_id)
                 hinted_location_text = level_colors[region.level] + region.hint_name + level_colors[region.level]
+                # Determine what phases this item could be for
+                phases_needing_this_item = [kong for kong in spoiler.krool_paths.keys() if path_location_id in spoiler.krool_paths[kong]]
+                hinted_kong = random.choice(phases_needing_this_item)
+                kong_color = kong_colors[hinted_kong]
                 # Every hint door is available before K. Rool so we can pick randomly
                 hint_location = getRandomHintLocation()
                 if path_location_id in TrainingBarrelLocations or path_location_id in PreGivenLocations:
                     # Starting moves could be a lot of things - instead of being super vague we'll hint the specific item directly.
                     hinted_item_name = ItemList[LocationList[path_location_id].item].name
-                    message = f"Your \x0btraining with {hinted_item_name}\x0b is on the path to \x08aiding your fight against K. Rool\x08."
+                    message = f"Your \x0btraining with {hinted_item_name}\x0b is on the path to {kong_color}aiding {colorless_kong_list[hinted_kong]}'s fight against K. Rool{kong_color}."
                 else:
-                    message = f"An item in the {hinted_location_text} is on the path to \x08aiding your fight against K. Rool\x08."
+                    message = f"An item in the {hinted_location_text} is on the path to {kong_color}aiding {colorless_kong_list[hinted_kong]}'s fight against K. Rool{kong_color}."
                 hint_location.hint_type = HintType.RequiredWinConditionHint
                 UpdateHint(hint_location, message)
         # All fairies seeds get 2 path hints for the camera

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -557,6 +557,10 @@ def CalculateWothPaths(spoiler, WothLocations):
     # Prep the dictionary that will contain the path for the key item
     for locationId in WothLocations:
         spoiler.woth_paths[locationId] = [locationId]  # The endpoint is on its own path
+    # If K. Rool is the win condition, prepare phase-specific paths as well
+    if spoiler.settings.win_condition == WinCondition.beat_krool:
+        for phase in spoiler.settings.krool_order:
+            spoiler.krool_paths[phase] = []
     for locationId in WothLocations:
         # Remove the item from the location
         location = LocationList[locationId]
@@ -574,6 +578,18 @@ def CalculateWothPaths(spoiler, WothLocations):
             # If it is no longer accessible, then this location is on the path of that other location
             if other_location not in accessible:
                 spoiler.woth_paths[other_location].append(locationId)
+        # If the win condition is K. Rool, also add this location to those paths as applicable
+        if spoiler.settings.win_condition == WinCondition.beat_krool:
+            if Kongs.donkey in spoiler.settings.krool_order and Events.KRoolDonkey not in LogicVariables.Events:
+                spoiler.krool_paths[Kongs.donkey].append(locationId)
+            if Kongs.diddy in spoiler.settings.krool_order and Events.KRoolDiddy not in LogicVariables.Events:
+                spoiler.krool_paths[Kongs.diddy].append(locationId)
+            if Kongs.lanky in spoiler.settings.krool_order and Events.KRoolLanky not in LogicVariables.Events:
+                spoiler.krool_paths[Kongs.lanky].append(locationId)
+            if Kongs.tiny in spoiler.settings.krool_order and Events.KRoolTiny not in LogicVariables.Events:
+                spoiler.krool_paths[Kongs.tiny].append(locationId)
+            if Kongs.chunky in spoiler.settings.krool_order and Events.KRoolChunky not in LogicVariables.Events:
+                spoiler.krool_paths[Kongs.chunky].append(locationId)
         # Put the item back for future calculations
         location.PlaceItem(item_id)
     # After everything is calculated, get rid of paths for false WotH locations

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -703,7 +703,7 @@ LocationList = {
     Locations.RainbowCoin_Location01: Location(Levels.AngryAztec, "Aztec Dirt Patch (Chunky Temple)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.AztecChunky5DTemple, -1, 0x29F)]),  # Chunky 5DT
     Locations.RainbowCoin_Location02: Location(Levels.FranticFactory, "Factory Dirt Patch (Dark Room)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.FranticFactory, -1, 0x2A0)]),  # Dark Room
     Locations.RainbowCoin_Location03: Location(Levels.DKIsles, "Isles Dirt Patch (Fungi Island)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.Isles, -1, 0x2A1)]),  # Fungi Entrance
-    Locations.RainbowCoin_Location04: Location(Levels.DKIsles, "Isles Dirt Patch (Waterfall)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.Isles, -1, 0x2A2)]),  # Caves Slope
+    Locations.RainbowCoin_Location04: Location(Levels.DKIsles, "Isles Dirt Patch (Under Caves Lobby)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.Isles, -1, 0x2A2)]),  # Caves Slope
     Locations.RainbowCoin_Location05: Location(Levels.DKIsles, "Isles Dirt Patch (Aztec Roof)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.Isles, -1, 0x2A3)]),  # Aztec Roof
     Locations.RainbowCoin_Location06: Location(Levels.AngryAztec, "Aztec Dirt Patch (Oasis)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.AngryAztec, -1, 0x2A4)]),  # Oasis
     Locations.RainbowCoin_Location07: Location(Levels.FungiForest, "Forest Dirt Patch (Grass)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.FungiForest, -1, 0x2A5)]),  # Isotarge Coin

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -810,6 +810,18 @@ class LogicVarHolder:
                 # Require both hunky chunky and twirl (or hard bosses) before Helm to prevent boss fill failures
                 if order_of_level > 7 and not self.hunkyChunky or (not self.twirl and not self.settings.hard_bosses):
                     return False
+            # Make sure we have access to all prior required keys before entering the next level - this prevents keys from being placed in levels beyond what they unlock
+            if order_of_level > 1 and not self.JapesKey:
+                return False
+            elif order_of_level > 2 and not self.AztecKey:
+                return False
+            elif order_of_level > 4 and (not self.FactoryKey or not self.GalleonKey):
+                return False
+            elif order_of_level > 5 and not self.ForestKey:
+                return False
+            elif order_of_level > 7 and (not self.CavesKey or not self.CastleKey):
+                return False
+
         # If we have the moves, ensure we have enough kongs as well
         return self.HasEnoughKongs(level, forPreviousLevel=True)
 

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -178,6 +178,7 @@ LogicRegions = {
 
     Regions.KremIsle: Region("Krem Isle Base", "Krem Isle", Levels.DKIsles, False, None, [], [], [
         TransitionFront(Regions.IslesMain, lambda l: True),
+        TransitionFront(Regions.GloomyGalleonLobbyEntrance, lambda l: (l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events or l.CanPhaseswim()) and (l.swim or l.assumeLevel4Entry), Transitions.IslesMainToGalleonLobby),
         TransitionFront(Regions.KremIsleBeyondLift, lambda l: l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events or l.CanMoonkick() or l.tbs),
         TransitionFront(Regions.KremIsleTopLevel, lambda l: l.monkeyport and l.istiny),
     ]),
@@ -188,7 +189,6 @@ LogicRegions = {
         Event(Events.IslesW4bTagged, lambda l: True),
     ], [
         TransitionFront(Regions.KremIsle, lambda l: True),
-        TransitionFront(Regions.GloomyGalleonLobbyEntrance, lambda l: (l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events or l.CanPhaseswim()) and (l.swim or l.assumeLevel4Entry), Transitions.IslesMainToGalleonLobby),
         TransitionFront(Regions.IslesSnideRoom, lambda l: True, Transitions.IslesMainToSnideRoom),
         TransitionFront(Regions.FranticFactoryLobby, lambda l: l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events or (l.CanSkew(True) and l.CanSTS()), Transitions.IslesMainToFactoryLobby),
     ]),

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -47,6 +47,7 @@ class Spoiler:
         self.woth = {}
         self.woth_locations = {}
         self.woth_paths = {}
+        self.krool_paths = {}
         self.shuffled_barrel_data = {}
         self.shuffled_exit_data = {}
         self.shuffled_exit_instructions = []
@@ -295,6 +296,23 @@ class Spoiler:
                 wothSlams += 1
                 extra = " " + str(wothSlams)
             humanspoiler["Paths"][destination_item.name + extra] = path_dict
+        # Paths for K. Rool phases - also do not show up on the site, just for debugging
+        for kong, path in self.krool_paths.items():
+            path_dict = {}
+            for path_loc_id in path:
+                path_location = LocationList[path_loc_id]
+                path_item = ItemList[path_location.item]
+                path_dict[path_location.name] = path_item.name
+            phase_name = "K. Rool Donkey Phase"
+            if kong == Kongs.diddy:
+                phase_name = "K. Rool Diddy Phase"
+            elif kong == Kongs.lanky:
+                phase_name = "K. Rool Lanky Phase"
+            elif kong == Kongs.tiny:
+                phase_name = "K. Rool Tiny Phase"
+            elif kong == Kongs.chunky:
+                phase_name = "K. Rool Chunky Phase"
+            humanspoiler["Paths"][phase_name] = path_dict
 
         self.pregiven_items = []
         for location_id, location in LocationList.items():

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -29,6 +29,7 @@ from randomizer.Enums.Settings import (
 # from randomizer.Enums.Items import Items
 import randomizer.Lists.Exceptions as Ex
 from randomizer.Fill import Generate_Spoiler
+from randomizer.SettingStrings import decrypt_settings_string_enum
 from randomizer.Settings import Settings
 from randomizer.Spoiler import Spoiler
 
@@ -214,10 +215,26 @@ def generate_settings():
     return data
 
 
-def test_forward_fill(generate_lo_rando_race_settings):
+def test_manual_settings_dict(generate_lo_rando_race_settings):
     """Asdf."""
     generate_lo_rando_race_settings["algorithm"] = FillAlgorithm.forward
     settings = Settings(generate_lo_rando_race_settings)
+    spoiler = Spoiler(settings)
+    Generate_Spoiler(spoiler)
+    print(spoiler)
+    print(spoiler.json)
+    asdf = 1 / 0
+    print(asdf)
+    raise Exception
+
+
+def test_with_settings_string():
+    """Confirm that settings strings decryption is working and generate a spoiler log with it."""
+    # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
+    settings_string = "baGFiRorPN5yunTChIoPw+qhoRDIhKlsa58CCI0ivUyYRCnrG2rBACoUht9QX8EsAycBkF1ls0FAXUAgwE7AIHA3cBhAI8AQJBXkChQM9AYLB3sDhgQow08fGQpnqShoKlsvbTcAM0NjlGuKFRFgMTEUDF+2R2OWvAX6RwPApkqkuxuiSaxBJBmBBHNCBgzm4yA4tloXFgsiwUlwNCgWisVGEmjEjkk5CQPACsAA"
+
+    settings_dict = decrypt_settings_string_enum(settings_string)
+    settings = Settings(settings_dict)
     spoiler = Spoiler(settings)
     Generate_Spoiler(spoiler)
     print(spoiler)


### PR DESCRIPTION
- Actually fixed the issue where keys would be placed beyond they were logically required for
- Added the appropriate phase to K. Rool hints. The hints are generated in an identical manner, just with a little extra info to help you determine what exactly you're looking for.
- Added ability to plug a settings string into the python tests to debug them SIGNIFICANTLY easier than before.
- Fixed a couple stray logic issues - a bad transition in Isles and bad logic for CBs in the Library