### PR TITLE
better local resets, random starting location fixes

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1275,12 +1275,14 @@ def FillKongsAndMovesGeneric(spoiler):
             retries += 1
             if retries % 5 == 0:
                 js.postMessage("Retrying fill really hard. Tries: " + str(retries))
-                # Handle Loading Zones - does not work right now but is something I want here eventually
+                # TODO: Handle Loading Zones - does not work right now but is something I want here eventually
                 # if spoiler.settings.shuffle_loading_zones != ShuffleLoadingZones.none:
                 #     ShuffleExits.Reset()
                 #     ShuffleExits.ExitShuffle(spoiler.settings)
                 #     spoiler.UpdateExits()
                 spoiler.settings.shuffle_prices()
+                if spoiler.settings.random_starting_region:
+                    spoiler.settings.RandomizeStartingLocation()
             else:
                 js.postMessage("Retrying fill. Tries: " + str(retries))
             Reset()
@@ -1709,10 +1711,12 @@ def FillKongsAndMovesForLevelOrder(spoiler):
             if retries == 20:
                 js.postMessage("Fill failed, out of retries.")
                 raise ex
-            # Every 5th fill, retry more aggressively by reshuffling level order and move prices
+            # Every 5th fill, retry more aggressively by reshuffling level order, move prices, and starting location as applicable
             if retries % 5 == 0:
                 js.postMessage("Retrying fill really hard. Tries: " + str(retries))
                 spoiler.settings.shuffle_prices()
+                if spoiler.settings.random_starting_region:
+                    spoiler.settings.RandomizeStartingLocation()
                 if spoiler.settings.shuffle_loading_zones == ShuffleLoadingZones.levels:
                     ShuffleExits.ShuffleExits(spoiler.settings)
                     spoiler.UpdateExits()

--- a/randomizer/LogicClasses.py
+++ b/randomizer/LogicClasses.py
@@ -176,13 +176,15 @@ class TransitionBack:
 class TransitionFront:
     """The entered side of a transition between regions."""
 
-    def __init__(self, dest, logic, exitShuffleId=None, assumed=False, time=Time.Both):
+    def __init__(self, dest, logic, exitShuffleId=None, assumed=False, time=Time.Both, isGlitchTransition=False, isBananaportTransition=False):
         """Initialize with given parameters."""
         self.dest = dest  # Planning to remove this
         self.logic = logic  # Lambda function for accessibility
         self.exitShuffleId = exitShuffleId  # Planning to remove this
         self.time = time
         self.assumed = assumed  # Indicates this is an assumed exit attached to the root
+        self.isGlitchTransition = isGlitchTransition  # Indicates if this is a glitch-logic transition for this entrance
+        self.isBananaportTransition = isBananaportTransition  # Indicates if this transition is due to a Bananaport
 
 
 class Sphere:

--- a/randomizer/LogicFiles/FranticFactory.py
+++ b/randomizer/LogicFiles/FranticFactory.py
@@ -70,7 +70,7 @@ LogicRegions = {
         TransitionFront(Regions.FranticFactoryMedals, lambda l: True),
         TransitionFront(Regions.Testing, lambda l: True),
         TransitionFront(Regions.FactoryTinyRaceLobby, lambda l: (l.mini and l.istiny) or l.phasewalk or l.CanOStandTBSNoclip()),
-        TransitionFront(Regions.FactoryTinyRace, lambda l: l.phasewalk or l.CanOStandTBSNoclip(), Transitions.FactoryRandDToRace),
+        TransitionFront(Regions.FactoryTinyRace, lambda l: l.phasewalk or l.CanOStandTBSNoclip(), Transitions.FactoryRandDToRace, isGlitchTransition=True),
         TransitionFront(Regions.ChunkyRoomPlatform, lambda l: True),
         TransitionFront(Regions.FactoryBossLobby, lambda l: not l.settings.tns_location_rando),
     ]),
@@ -169,7 +169,7 @@ LogicRegions = {
         TransitionFront(Regions.FranticFactoryMedals, lambda l: True),
         TransitionFront(Regions.LowerCore, lambda l: True),
         TransitionFront(Regions.UpperCore, lambda l: Events.MainCoreActivated in l.Events),
-        TransitionFront(Regions.InsideCore, lambda l: l.ledgeclip, Transitions.FactoryBeyondHatchToInsideCore),
+        TransitionFront(Regions.InsideCore, lambda l: l.ledgeclip, Transitions.FactoryBeyondHatchToInsideCore, isGlitchTransition=True),
     ]),
 
     Regions.UpperCore: Region("Upper Core", "Production Room", Levels.FranticFactory, False, -1, [

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -194,7 +194,7 @@ LogicRegions = {
         TransitionFront(Regions.ThornvineArea, lambda l: True, time=Time.Night),
         TransitionFront(Regions.Snide, lambda l: True, time=Time.Day),
         TransitionFront(Regions.ForestBossLobby, lambda l: not l.settings.tns_location_rando, time=Time.Day),
-        TransitionFront(Regions.ThornvineBarn, lambda l: l.CanPhaseswim(), Transitions.ForestMainToBarn),
+        TransitionFront(Regions.ThornvineBarn, lambda l: l.CanPhaseswim(), Transitions.ForestMainToBarn, isGlitchTransition=True),
     ]),
 
     Regions.MillChunkyTinyArea: Region("Mill Back Room", "Forest Mills", Levels.FungiForest, False, -1, [], [

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -739,35 +739,7 @@ class Settings:
 
         # Start Region
         if self.random_starting_region:
-            region_data = [
-                randomizer.LogicFiles.DKIsles.LogicRegions,
-                randomizer.LogicFiles.JungleJapes.LogicRegions,
-                randomizer.LogicFiles.AngryAztec.LogicRegions,
-                randomizer.LogicFiles.FranticFactory.LogicRegions,
-                randomizer.LogicFiles.GloomyGalleon.LogicRegions,
-                randomizer.LogicFiles.FungiForest.LogicRegions,
-                randomizer.LogicFiles.CrystalCaves.LogicRegions,
-                randomizer.LogicFiles.CreepyCastle.LogicRegions,
-            ]
-            selected_region_world = random.choice(region_data)
-            valid_starting_regions = []
-            for region in selected_region_world:
-                region_data = selected_region_world[region]
-                transitions = [
-                    x.exitShuffleId for x in region_data.exits if x.exitShuffleId is not None and x.exitShuffleId in ShufflableExits and ShufflableExits[x.exitShuffleId].back.reverse is not None
-                ]
-                if region in RegionMapList:
-                    # Has tied map
-                    tied_map = GetMapId(region)
-                    for transition in transitions:
-                        relevant_transition = ShufflableExits[transition].back.reverse
-                        tied_exit = GetExitId(ShufflableExits[relevant_transition].back)
-                        valid_starting_regions.append(
-                            {"region": region, "map": tied_map, "exit": tied_exit, "region_name": region_data.name, "exit_name": ShufflableExits[relevant_transition].back.name}
-                        )
-            self.starting_region = random.choice(valid_starting_regions)
-            for x in range(2):
-                randomizer.LogicFiles.DKIsles.LogicRegions[Regions.GameStart].exits[x + 1].dest = self.starting_region["region"]
+            self.RandomizeStartingLocation()
 
         # Initial Switch Level Placement - Will be corrected if level order rando is on during the fill process. Disable it for vanilla
         if self.level_randomization == LevelRandomization.vanilla:
@@ -941,9 +913,9 @@ class Settings:
             ItemList[Items.BananaMedal].playthrough = True
         if self.crown_door_item in (HelmDoorItem.vanilla, HelmDoorItem.req_crown) or self.coin_door_item == HelmDoorItem.req_crown:
             ItemList[Items.BattleCrown].playthrough = True
-        if self.crown_door_item == HelmDoorItem.req_bean or self.coin_door_item == HelmDoorItem.req_bean:
+        if self.crown_door_item == HelmDoorItem.req_bean or self.coin_door_item == HelmDoorItem.req_bean or Types.Bean in self.shuffled_location_types:
             ItemList[Items.Bean].playthrough = True
-        if self.crown_door_item == HelmDoorItem.req_pearl or self.coin_door_item == HelmDoorItem.req_pearl:
+        if self.crown_door_item == HelmDoorItem.req_pearl or self.coin_door_item == HelmDoorItem.req_pearl or Types.Pearl in self.shuffled_location_types:
             ItemList[Items.Pearl].playthrough = True
 
         self.free_trade_items = self.free_trade_setting != FreeTradeSetting.none
@@ -1168,6 +1140,38 @@ class Settings:
             kongCageLocations.remove(Locations.LankyKong)
             kongCageLocations.append(random.choice([Locations.DiddyKong, Locations.TinyKong, Locations.ChunkyKong]))
         return kongCageLocations
+
+    def RandomizeStartingLocation(self):
+        """Randomize the starting point of this seed."""
+        region_data = [
+            randomizer.LogicFiles.DKIsles.LogicRegions,
+            randomizer.LogicFiles.JungleJapes.LogicRegions,
+            randomizer.LogicFiles.AngryAztec.LogicRegions,
+            randomizer.LogicFiles.FranticFactory.LogicRegions,
+            randomizer.LogicFiles.GloomyGalleon.LogicRegions,
+            randomizer.LogicFiles.FungiForest.LogicRegions,
+            randomizer.LogicFiles.CrystalCaves.LogicRegions,
+            randomizer.LogicFiles.CreepyCastle.LogicRegions,
+        ]
+        selected_region_world = random.choice(region_data)
+        valid_starting_regions = []
+        for region in selected_region_world:
+            region_data = selected_region_world[region]
+            transitions = [
+                x.exitShuffleId
+                for x in region_data.exits
+                if x.exitShuffleId is not None and x.exitShuffleId in ShufflableExits and ShufflableExits[x.exitShuffleId].back.reverse is not None and not x.isGlitchTransition
+            ]
+            if region in RegionMapList:
+                # Has tied map
+                tied_map = GetMapId(region)
+                for transition in transitions:
+                    relevant_transition = ShufflableExits[transition].back.reverse
+                    tied_exit = GetExitId(ShufflableExits[relevant_transition].back)
+                    valid_starting_regions.append({"region": region, "map": tied_map, "exit": tied_exit, "region_name": region_data.name, "exit_name": ShufflableExits[relevant_transition].back.name})
+        self.starting_region = random.choice(valid_starting_regions)
+        for x in range(2):
+            randomizer.LogicFiles.DKIsles.LogicRegions[Regions.GameStart].exits[x + 1].dest = self.starting_region["region"]
 
     def __repr__(self):
         """Return printable version of the object as json.

--- a/randomizer/ShuffleDoors.py
+++ b/randomizer/ShuffleDoors.py
@@ -48,6 +48,10 @@ def ShuffleDoors(spoiler):
     """Shuffle Wrinkly and T&S Doors based on settings."""
     # Reset Doors
     for level in door_locations:
+        # Also reset the data structures that share info across processes
+        shuffled_door_data[level] = []
+        human_hint_doors[level_list[level]] = {}
+        human_portal_doors[level_list[level]] = {}
         for door in door_locations[level]:
             door.placed = door.default_placed
             if spoiler.settings.wrinkly_location_rando:
@@ -135,6 +139,10 @@ def ShuffleDoors(spoiler):
 def ShuffleVanillaDoors(spoiler):
     """Shuffle T&S and Wrinkly doors amongst the vanilla locations."""
     for level in door_locations:
+        # Reset the data structures for door shuffling information sharing
+        shuffled_door_data[level] = []
+        human_hint_doors[level_list[level]] = {}
+        human_portal_doors[level_list[level]] = {}
         # Find the vanilla doors that are valid hint locations and clear their door
         vanilla_door_indexes = []
         for door_index, door in enumerate(door_locations[level]):

--- a/randomizer/ShuffleShopLocations.py
+++ b/randomizer/ShuffleShopLocations.py
@@ -95,9 +95,11 @@ def ShuffleShopLocations(spoiler: Spoiler):
         shops_in_levels = []
         for shop in shop_array:
             if not shop.locked:
-                # This is a valid shop to shuffle, so we need to remove the preexisting logical access
-                old_region = Logic.Regions[shop.containing_region]
-                old_region.exits = [exit for exit in old_region.exits if exit.dest != shop.shop_exit]
+                # This is a valid shop to shuffle, so we need to remove all preexisting logical access, wherever it is
+                possible_containing_region_ids = [shop_location.containing_region for shop_location in shop_array]
+                for region_id in possible_containing_region_ids:
+                    old_region = Logic.Regions[region_id]
+                    old_region.exits = [exit for exit in old_region.exits if exit.dest != shop.shop_exit]
                 shops_in_levels.append(shop)
         random.shuffle(shops_in_levels)
         # Assign shuffle to data

--- a/randomizer/ShuffleWarps.py
+++ b/randomizer/ShuffleWarps.py
@@ -144,9 +144,13 @@ def ShuffleWarpsCrossMap(bananaport_replacements, human_ports, is_coupled, selec
 
 def LinkWarps():
     """Given the current state of warps, create the transitions between them."""
+    # Remove all existing transitions that are warp transitions - this prevents warp logic from bleeding between seed gens
+    for region in Logic.Regions.values():
+        region.exits = [exit for exit in region.exits if not exit.isBananaportTransition]
+    # For each warp, identify the source and destination regions
     for warp_data in BananaportVanilla.values():
         destination_warp_data = getWarpFromSwapIndex(warp_data.tied_index)
         if warp_data.region_id != destination_warp_data.region_id:
             source_region = Logic.Regions[warp_data.region_id]
             # The source region gets a transition to the destination region conditionally based on the destination warp being tagged
-            source_region.exits.append(TransitionFront(destination_warp_data.region_id, destination_warp_data.event_logic))
+            source_region.exits.append(TransitionFront(destination_warp_data.region_id, destination_warp_data.event_logic, isBananaportTransition=True))

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -546,7 +546,7 @@ class Spoiler:
         if self.settings.tns_location_rando:
             humanspoiler["T&S Portal Locations"] = self.human_portal_doors
         if self.settings.crown_placement_rando:
-            humanspoiler["Shuffled Crowns"] = self.human_crowns
+            humanspoiler["Battle Arena Locations"] = self.human_crowns
         level_dict = {
             Levels.DKIsles: "DK Isles",
             Levels.JungleJapes: "Jungle Japes",

--- a/static/presets/qol_only.json
+++ b/static/presets/qol_only.json
@@ -18,7 +18,7 @@
     "random_patches":false,
     "shuffle_shops":false,
     "move_rando":"off",
-    "random_prices":"low",
+    "random_prices":"vanilla",
     "randomize_blocker_required_amounts":false,
     "randomize_cb_required_amounts":false,
     "blocker_0":1,

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -223,22 +223,34 @@ def test_manual_settings_dict(generate_lo_rando_race_settings):
     Generate_Spoiler(spoiler)
     print(spoiler)
     print(spoiler.json)
-    asdf = 1 / 0
-    print(asdf)
-    raise Exception
+    print("all done")
 
 
 def test_with_settings_string():
     """Confirm that settings strings decryption is working and generate a spoiler log with it."""
     # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
+    # This top one is always the S2 Preset (probably up to date)
     settings_string = "baGFiRorPN5yunTChIoPw+qhoRDIhKlsa58CCI0ivUyYRCnrG2rBACoUht9QX8EsAycBkF1ls0FAXUAgwE7AIHA3cBhAI8AQJBXkChQM9AYLB3sDhgQow08fGQpnqShoKlsvbTcAM0NjlGuKFRFgMTEUDF+2R2OWvAX6RwPApkqkuxuiSaxBJBmBBHNCBgzm4yA4tloXFgsiwUlwNCgWisVGEmjEjkk5CQPACsAA"
+    # This one is for ease of testing, go wild with it
+    # settings_string = "baGFiRorPN5yunTChQVzwlFB+H1UNCIZEJUtjXPgQRGkV6mTCIW6yU9Y21YIgVCkNvqC/glgGTgMgustmgoC6gEGAnYBA4G7gMIBHgCBIK8gUKBnoDBYO9gcMCFGGnj4yFM9SUNBUtl7abgBmhsco1xQqIsBiYigYv2yOxy14C/SOB4FMlUl2N0STWIJIMwBgzg4tloXFgsiwUlwNCgWisVGEmjEjkk5CQPAD6AKwA"
 
     settings_dict = decrypt_settings_string_enum(settings_string)
+    settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
     settings = Settings(settings_dict)
     spoiler = Spoiler(settings)
     Generate_Spoiler(spoiler)
     print(spoiler)
     print(spoiler.json)
-    asdf = 1 / 0
-    print(asdf)
-    raise Exception
+    # printHintDistribution(spoiler)
+    print("all done")
+
+
+def printHintDistribution(spoiler: Spoiler):
+    """Print the hint distribution for the given spoiler log."""
+    types = ""
+    values = ""
+    for key, value in spoiler.hint_distribution.items():
+        types += (key.name + ", ")
+        values += (str(value) + ", ")
+    print(types)
+    print(values)


### PR DESCRIPTION
This PR attempts to solve some issues with local generation. It should be able to generate locally multiple times in a row now with some more settings on. Maybe this is the end of it? I dunno but it's better.

Other fixes:
- Fixed some starting locations starting you in the wrong region
- Improve the tests further by putting in the S2 preset and make it easier to work with. Also they pass now.
- Every 5th fail the fill will choose a new random starting location in case we found a bad one