### PR TITLE
Improve foolish hints, Training logic alignment

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -1078,6 +1078,24 @@ def compileHints(spoiler: Spoiler):
     # Foolish Region hints state that a hint region is foolish. Useful in item rando.
     # Foolish regions contain no major items that would block any amount of progression, even non-required progression
     if hint_distribution[HintType.FoolishRegion] > 0:
+        # Determine how many locations are contained in the foolish regions
+        total_foolish_location_score = 0
+        foolish_region_location_score = {}
+        for foolish_name in spoiler.foolish_region_names:
+            foolish_location_score = 0
+            shops_in_region = 0
+            regions_in_region = [region for region in RegionList.values() if region.hint_name == foolish_name]
+            for region in regions_in_region:
+                foolish_location_score += len([loc for loc in region.locations if not LocationList[loc.id].inaccessible and LocationList[loc.id].type in spoiler.settings.shuffled_location_types])
+                if region.level == Levels.Shops:
+                    shops_in_region += 1
+            if "Medal Rewards" in foolish_name:  # "Medal Rewards" regions are cb foolish hints, which are just generally more valuable to hint foolish
+                foolish_location_score += 3
+            elif shops_in_region > 0:  # Shops are generally overvalued (4/6 locations per shop) with this method due to having mutually exclusive locations
+                foolish_location_score -= 1 * shops_in_region  # With smaller shops, this reduces the location count to 3 locations per shop
+            foolish_location_score = foolish_location_score**1.25  # Exponentiation of this score puts additional emphasis (but not too much) on larger regions
+            total_foolish_location_score += foolish_location_score
+            foolish_region_location_score[foolish_name] = foolish_location_score
         random.shuffle(spoiler.foolish_region_names)
         for i in range(hint_distribution[HintType.FoolishRegion]):
             # If you run out of foolish regions (maybe in an all medals run?) - this *should* be covered by the distribution earlier but this is a good failsafe
@@ -1086,7 +1104,9 @@ def compileHints(spoiler: Spoiler):
                 hint_distribution[HintType.FoolishRegion] -= 1
                 hint_distribution[HintType.WothLocation] += 1
                 continue
-            hinted_region_name = spoiler.foolish_region_names.pop()
+            hinted_region_name = random.choices(list(foolish_region_location_score.keys()), foolish_region_location_score.values())[0]  # Weighted random choice from list of foolish region names
+            spoiler.foolish_region_names.remove(hinted_region_name)
+            del foolish_region_location_score[hinted_region_name]
             hint_location = getRandomHintLocation()
             level_color = "\x05"
             for region_id in Regions:

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -769,13 +769,25 @@ class LogicVarHolder:
         """Return true if the boss for a given level is beatable according to boss location rando and boss kong rando."""
         requiredKong = self.settings.boss_kongs[level]
         bossFight = self.settings.boss_maps[level]
+        # Ensure we have the required moves for the boss fight itself
         hasRequiredMoves = True
-        if bossFight == Maps.FactoryBoss and requiredKong == Kongs.tiny:
+        if bossFight == Maps.FactoryBoss and requiredKong == Kongs.tiny and not self.settings.hard_bosses:
             hasRequiredMoves = self.twirl
         elif bossFight == Maps.FungiBoss:
             hasRequiredMoves = self.hunkyChunky and self.barrels
         elif bossFight == Maps.JapesBoss or bossFight == Maps.AztecBoss or bossFight == Maps.CavesBoss:
             hasRequiredMoves = self.barrels
+        # In simple level order, there are a couple very specific cases we have to account for in order to prevent boss fill failures
+        level_order_matters = not self.settings.hard_level_progression and self.settings.shuffle_loading_zones in (ShuffleLoadingZones.none, ShuffleLoadingZones.levels)
+        if level_order_matters:
+            order_of_level = 7  # Guaranteed to be 1-7 here
+            for level_order in self.settings.level_order:
+                if self.settings.level_order[level_order] == level:
+                    order_of_level = level_order
+            if order_of_level == 4 and not self.barrels:  # Prevent Barrels on boss 3
+                return False
+            if order_of_level == 7 and not self.hunkyChunky or (not self.twirl and not self.settings.hard_bosses):  # Prevent Hunky on boss 7, and also Twirl on non-hard bosses
+                return False
         return self.IsKong(requiredKong) and hasRequiredMoves
 
     def HasFillRequirementsForLevel(self, level):
@@ -797,12 +809,12 @@ class LogicVarHolder:
             # You need to have vines or twirl before you can enter Aztec or any level beyond it
             if order_of_level >= order_of_aztec and not (self.vines or (self.istiny and self.twirl)):
                 return False
-            if order_of_level >= 3:
-                # Require barrels by level 3 to prevent boss barrel fill failures
-                if not self.barrels:
-                    return False
-                # Require swim by level 4 to prevent T&S being zero'd out
-                if order_of_level >= 4 and not self.swim:  # and not "the ability to dive without dive" whenever we get that squared away
+            if order_of_level >= 4:
+                # Require the following moves by level 4:
+                # - Swim so you can get into Lobby 4. This prevents logic from skipping this level for T&S requirements, preventing 0'd T&S.
+                # - Barrels so there will always be an eligible boss fill given the available moves at any level.
+                # - Vines for gameplay reasons. Needing vines for Helm is a frequent bottleneck and this eases the hunt for it.
+                if not self.swim or not self.barrels or not self.vines:
                     return False
                 # Require one of twirl or hunky chunky by level 7 to prevent non-hard-boss fill failures
                 if not self.settings.hard_bosses and order_of_level >= 7 and not (self.twirl or self.hunkyChunky):

--- a/randomizer/ShuffleKasplats.py
+++ b/randomizer/ShuffleKasplats.py
@@ -101,9 +101,9 @@ def ShuffleKasplatsAndLocations(spoiler, LogicVariables):
     spoiler.shuffled_kasplat_map = {}
     LogicVariables.kasplat_map = {}
     for location in shufflable:
-        Logic.LocationList.pop(location, None)
+        Logic.LocationList[location].inaccessible = True
     for location in constants:
-        Logic.LocationList.pop(location, None)
+        Logic.LocationList[location].inaccessible = True
     # Fill kasplats level by level
     for level in KasplatLocationList:
         kasplats = KasplatLocationList[level]
@@ -141,9 +141,9 @@ def ShuffleKasplatsInVanillaLocations(spoiler, LogicVariables):
     spoiler.shuffled_kasplat_map = {}
     LogicVariables.kasplat_map = {}
     for location in shufflable:
-        Logic.LocationList.pop(location, None)
+        Logic.LocationList[location].inaccessible = True
     for location in constants:
-        Logic.LocationList.pop(location, None)
+        Logic.LocationList[location].inaccessible = True
     # Place by level
     for level in KasplatLocationList:
         availableKongs = GetKongs().copy()
@@ -221,6 +221,11 @@ def ShuffleKasplats(LogicVariables):
 
 def KasplatShuffle(spoiler, LogicVariables):
     """Facilitate the shuffling of kasplat types."""
+    # If these were ever set at any prior point (likely only relevant running locally) then reset them - the upcoming methods will handle this TODO: maybe do this on other shufflers
+    for location in shufflable:
+        Logic.LocationList[location].inaccessible = False
+    for location in constants:
+        Logic.LocationList[location].inaccessible = False
     if spoiler.settings.kasplat_rando:
         retries = 0
         while True:

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -241,7 +241,7 @@ class Spoiler:
             humanspoiler["End Game"]["Coin Door Item"] = self.settings.coin_door_item.name
             humanspoiler["End Game"]["Coin Door Item Amount"] = self.settings.coin_door_item_count
         if self.settings.shuffle_items:
-            humanspoiler["Item Pool"] = [enum.name for enum in self.settings.shuffled_location_types]
+            humanspoiler["Item Pool"] = list(set([enum.name for enum in self.settings.shuffled_location_types]))
         humanspoiler["Items"] = {
             "Kongs": {},
             "Shops": {},

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -229,10 +229,10 @@ def test_manual_settings_dict(generate_lo_rando_race_settings):
 def test_with_settings_string():
     """Confirm that settings strings decryption is working and generate a spoiler log with it."""
     # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
-    # This top one is always the S2 Preset (probably up to date)
-    settings_string = "baGFiRorPN5yunTChooPw+qhoRDIhKlsa58CCI0ivUyYRCnrG2rBACoUhqC/glgGTgMgustmgoC6gEGAnYBA4G7gMIBHgCBIK8gUKBnoDBYO9gcMCFGGnj4yFM9SUNBUtl7abgBmhsco1xQqIsBiYigYv2yOxy14C/SOB4HMlUl2N0STWIJIMwII5oQMGc3GQHFstC43lgsiwUlwNCgWisVGEmjEjkk5CQPACsAA"
+    # This top one is always the S2 Preset (probably up to date, if it isn't go steal it from the season2.json)
+    settings_string = "baGFiRorPN5yunTChooPw+qhoRDIhKlsa58CCI0ivUyYRCnrG2rBACoUht9QX8EsAycBkF1ls0FAXUAgwE7AIHA3cBhAI8AQJBXkChQM9AYLB3sDhgQow08fGQpnqShoKlsvbTcAM0NjlGuKFRFgMTEUDF+2R2OWvAX6RwPA5kqkuxuiSaxBJBmBBHNCBgzm4yA4tloXFgsiwUlwNCgWisVGEmjEjkk5CQPACsAA"
     # This one is for ease of testing, go wild with it
-    # settings_string = "baGGiRorxNXm8rp0woolg7Bc4xRYfh8giNIr1MmEQs9uslPWOtWCAFQpDb6hE4CL/iWAROBZKY1K5VGQXmWzQUBdQCDATsAgcDdwGEAjwBAkFeQKFAz0BgsHewOGBCjDTx8V7DUz1I80KTaXTGX1GpNKZxQqQsBCZCgCv2yOxy14C/SOB4FMlUiSuxuiSaxIJCA4tloXFgslwUC0jmk5B4AVQBWAA"
+    # settings_string = "baGGCRorPE1eK6dMKQxRLB2DBXOMUWH4fVRAIhkKY6EqWxrnwEaRXqZMIhZ7dZKesbaoEAKhSG31Bf8SwCJ2KZXGQXmWzQUBdQCDATsAgcDdwGEAjwBAkFeQKFAz0BgsHewOGBAajPjhYamepKGhCbS6Yy+o1KhyuNFSFgQTIUAl+rCQRDIUx0JUtjXPhGbZHbXgL9I4HgUyVSXY3RJNhBADi2WhcWCyLC4GhQLRUUSOaSSHBIHgA"
 
     settings_dict = decrypt_settings_string_enum(settings_string)
     settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly


### PR DESCRIPTION
Improved foolish hints:
The regions hinted by foolish hints are now weighted by the size of the region. Eligible regions with more relevant checks are more likely to be hinted foolish.

Training move logic change:
You are now able to find vines, swim, and barrels BEFORE level 4. As before, you are able to find Tiny+Twirl OR vines before Aztec. These are now the only two fill rules for training moves.

In other fixes:
- Fixed an outrageously rare fill that could cause failures in boss fills
- Removed duplicate names from the item pool in the spoiler log. There can be only one Bean.