### PR TITLE
Coin Logic Improvements

### DIFF
--- a/randomizer/Enums/SearchMode.py
+++ b/randomizer/Enums/SearchMode.py
@@ -6,6 +6,7 @@ class SearchMode(IntEnum):
     """Search mode enum."""
 
     GetReachable = auto()
+    GetReachableForFilling = auto()
     GeneratePlaythrough = auto()
     CheckBeatable = auto()
     CheckAllReachable = auto()

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -455,22 +455,22 @@ def VerifyWorldWithWorstCoinUsage(settings):
         mostExpensivePearl = None
         pearlShops = [location for location in newReachableShops if LocationList[location].item == Items.Pearl]
         for shop in pearlShops:
-            if mostExpensivePearl == None or settings.prices[shop] > settings.prices[mostExpensivePearl]:
+            if mostExpensivePearl is None or settings.prices[shop] > settings.prices[mostExpensivePearl]:
                 mostExpensivePearl = shop
         mostExpensiveMedal = None
         medalShops = [location for location in newReachableShops if LocationList[location].item == Items.BananaMedal]
         for shop in medalShops:
-            if mostExpensiveMedal == None or settings.prices[shop] > settings.prices[mostExpensiveMedal]:
+            if mostExpensiveMedal is None or settings.prices[shop] > settings.prices[mostExpensiveMedal]:
                 mostExpensiveMedal = shop
         mostExpensiveFairy = None
         fairyShops = [location for location in newReachableShops if LocationList[location].item == Items.BananaFairy]
         for shop in fairyShops:
-            if mostExpensiveFairy == None or settings.prices[shop] > settings.prices[mostExpensiveFairy]:
+            if mostExpensiveFairy is None or settings.prices[shop] > settings.prices[mostExpensiveFairy]:
                 mostExpensiveFairy = shop
         mostExpensiveGB = None
         gbShops = [location for location in newReachableShops if (LocationList[location].item == Items.GoldenBanana or LocationList[location].item in ItemPool.Blueprints())]
         for shop in gbShops:
-            if mostExpensiveGB == None or settings.prices[shop] > settings.prices[mostExpensiveGB]:
+            if mostExpensiveGB is None or settings.prices[shop] > settings.prices[mostExpensiveGB]:
                 mostExpensiveGB = shop
         # Prepare the candidates for "worst location" - exclude any of the threshold items that we know the worst of
         thresholdItems = ItemPool.Blueprints().copy()

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -89,10 +89,10 @@ class Location:
                     continue
                 # If this is a shared spot, lock out kong-specific locations in this shop
                 if self.kong == Kongs.any and LocationList[location].kong != Kongs.any:
-                    LocationList[location].PlaceItem(Items.NoItem)
+                    LocationList[location].inaccessible = True
                 # If this is a kong-specific spot, lock out the shared location in this shop
                 if self.kong != Kongs.any and LocationList[location].kong == Kongs.any:
-                    LocationList[location].PlaceItem(Items.NoItem)
+                    LocationList[location].inaccessible = True
                     break  # There's only one shared spot to block
 
     def PlaceConstantItem(self, item):
@@ -123,13 +123,14 @@ class Location:
             for location_id in ShopLocationReference[self.level][self.vendor]:
                 if location_id in RemovedShopLocations:
                     continue
-                if LocationList[location_id].kong == Kongs.any and LocationList[location_id].item == Items.NoItem:
+                if LocationList[location_id].kong == Kongs.any and LocationList[location_id].inaccessible:
+                    # If there are no other items remaining in this shop, then we can unlock the shared location
                     itemsInThisShop = len([location for location in ShopLocationReference[self.level][self.vendor] if location not in RemovedShopLocations and LocationList[location].item not in (None, Items.NoItem)])
                     if itemsInThisShop == 0:
-                        location_id.item = None
-                # Items.NoItem are only placed when locking out locations. If any exist, they're because this location caused them to be placed here
-                elif LocationList[location_id].item == Items.NoItem:
-                    LocationList[location_id].item = None
+                        LocationList[location_id].inaccessible = False
+                # Locations are only inaccessible due to lockouts. If any exist, they're because this location caused them to be locked out.
+                elif LocationList[location_id].inaccessible:
+                    LocationList[location_id].inaccessible = False
 
 
 LocationList = {

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -682,23 +682,22 @@ class LogicVarHolder:
                 collectible.added = True
 
     def PurchaseShopItem(self, location_id):
-        """Purchase items from shops and subtract price from logical coin counts."""
+        """Purchase from this location and subtract price from logical coin counts."""
         location = LocationList[location_id]
-        if location.item is not None and location.item is not Items.NoItem:
-            price = GetPriceAtLocation(self.settings, location_id, location, self.Slam, self.AmmoBelts, self.InstUpgrades)
-            if price is None:  # This probably shouldn't happen but I think it's harmless
-                return  # TODO: solve this
-            # print("BuyShopItem for location: " + location.name)
-            # print("Item: " + ItemList[location.item].name + " has Price: " + str(price))
-            # If shared move, take the price from all kongs EVEN IF THEY AREN'T FREED YET
-            if location.kong == Kongs.any:
-                for kong in range(0, 5):
-                    self.Coins[kong] -= price
-                    self.SpentCoins[kong] += price
-            # If kong specific move, just that kong paid for it
-            else:
-                self.Coins[location.kong] -= price
-                self.SpentCoins[location.kong] += price
+        price = GetPriceAtLocation(self.settings, location_id, location, self.Slam, self.AmmoBelts, self.InstUpgrades)
+        if price is None:  # This shouldn't happen but it's probably harmless
+            return  # TODO: solve this
+        # If shared move, take the price from all kongs EVEN IF THEY AREN'T FREED YET
+        if location.kong == Kongs.any:
+            for kong in range(0, 5):
+                self.Coins[kong] -= price
+                self.SpentCoins[kong] += price
+            return
+        # If kong specific move, just that kong paid for it
+        else:
+            self.Coins[location.kong] -= price
+            self.SpentCoins[location.kong] += price
+            return
 
     @staticmethod
     def HasAccess(region, kong):

--- a/randomizer/LogicFiles/GloomyGalleon.py
+++ b/randomizer/LogicFiles/GloomyGalleon.py
@@ -64,7 +64,7 @@ LogicRegions = {
         TransitionFront(Regions.Shipyard, lambda l: l.CanPhaseswim() or (l.phasewalk and l.CanGetOnCannonGamePlatform())),
     ]),
 
-    Regions.LighthouseSurface: Region("Lighthouse Surface", "Lighthouse Area", Levels.GloomyGalleon, False, -1, [
+    Regions.LighthouseSurface: Region("Lighthouse Surface", "Lighthouse Area", Levels.GloomyGalleon, False, None, [
         LocationLogic(Locations.GalleonKasplatLighthouseArea, lambda l: not l.settings.kasplat_rando),
     ], [
         Event(Events.GalleonChunkyPad, lambda l: (l.triangle and l.chunky) and (l.swim or l.settings.high_req)),

--- a/randomizer/Prices.py
+++ b/randomizer/Prices.py
@@ -235,31 +235,33 @@ meaning we just must consider the maximum price for every location.
 def GetPriceAtLocation(settings, location_id, location, slamLevel, ammoBelts, instUpgrades):
     """Get the price at this location."""
     item = location.item
-    if item is None or item == Items.NoItem:
-        return 0
-    elif item == Items.ProgressiveSlam:
+    # Progressive items have their prices managed separately
+    if item == Items.ProgressiveSlam:
         if slamLevel in [1, 2]:
             return settings.prices[item][slamLevel - 1]
         else:
-            # If already have max slam, there's move to buy
+            # If already have max slam, there's no move to buy (this shouldn't happen?)
             return 0
     elif item == Items.ProgressiveAmmoBelt:
         if ammoBelts in [0, 1]:
             return settings.prices[item][ammoBelts]
         else:
-            # If already have max ammo belt, there's move to buy
+            # If already have max ammo belt, there's no move to buy (this shouldn't happen?)
             return 0
     elif item == Items.ProgressiveInstrumentUpgrade:
         if instUpgrades in [0, 1, 2]:
             return settings.prices[item][instUpgrades]
         else:
-            # If already have max instrument upgrade, there's move to buy
+            # If already have max instrument upgrade, there's no move to buy (this shouldn't happen?)
             return 0
     # Vanilla prices are by item, not by location
     elif settings.random_prices == RandomPrices.vanilla:
+        # Treat the location as free if it's empty
+        if item is None or item == Items.NoItem:
+            return 0
         return settings.prices[item]
-    else:
-        return settings.prices[location_id]
+    # In all other cases, the price is determined solely by the location
+    return settings.prices[location_id]
 
 
 def KongCanBuy(location_id, logic, kong):

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -625,6 +625,7 @@ class Settings:
 
         # Smaller shop setting blocks 2 Kong-specific locations from each shop randomly but is only valid if item rando is on and includes shops
         if self.smaller_shops and self.shuffle_items and Types.Shop in self.shuffled_location_types:
+            RemovedShopLocations = []
             # To evenly distribute the locations blocked, we can use the fact there are 20 shops to our advantage
             # These evenly distributed pairs will represent "locations to block" for each shop
             kongPairs = [
@@ -661,6 +662,7 @@ class Settings:
                     accessible_shops = [location_id for location_id in ShopLocationReference[level][vendor] if location_id not in inaccessible_shops]
                     for location_id in inaccessible_shops:
                         LocationList[location_id].inaccessible = True
+                        RemovedShopLocations.append(location_id)
                     for location_id in accessible_shops:
                         LocationList[location_id].inaccessible = False
 


### PR DESCRIPTION
Two major improvements to coin logic:
- When in the process of filling items, GetAccessibleLocations will now purchase empty locations. This should cut down on coin logic failures during fills, as a more accurate number of shop locations accessible will be returned.
- VerifyWorldWithWorstCoinUsage performance is GREATLY improved with some corner-cutting and optimization. I estimate this method is multiple times faster than it was before by significantly reducing the number of GetAccessibleLocations calls.

I estimate this PR is of higher risk than the average in less measurable metrics. My testing found you ran into almost zero coin locks on medium prices and a few coin locks on high prices. The big problem is that the odds of coin locks vary wildly by settings so I can't really guarantee all settings will like these changes. On paper the fill changes should be an improvement everywhere, but I can't be certain due to the immense complexity. That said the performance upgrade should be always an improvement all the time so I put that in a separate commit intentionally.

In other fixes:
- Prevent deathwarping out of the lighthouse surface. You can't guarantee the kasplat will be there which is extremely annoying. I hate random starting locations.