### PR TITLE
minor fill tweaks

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -275,7 +275,7 @@ hint_distribution_default = {
     HintType.TroffNScoff: 0,
     HintType.KongLocation: 1,  # must be placed before you find them and placed in a door of a free kong
     # HintType.MedalsRequired: 1,
-    HintType.Entrance: 8,
+    HintType.Entrance: 6,
     HintType.RequiredKongHint: -1,  # Fixed number based on the number of locked kongs
     HintType.RequiredKeyHint: -1,  # Fixed number based on the number of keys to be obtained over the seed
     HintType.RequiredWinConditionHint: 0,  # Fixed number based on what K. Rool phases you must defeat

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1682,8 +1682,14 @@ def FillKongsAndMoves(spoiler, placedTypes):
     if any(locationsNeedingMoves):
         newlyPlacedItems = []
         toBeUnplaced = []
-        possibleStartingMoves = ItemPool.AllKongMoves()
-        possibleStartingMoves.extend(ItemPool.JunkSharedMoves)
+        possibleStartingMoves = ItemPool.AllKongMoves().copy()
+        if len(locationsNeedingMoves) < 10:
+            # Generally only include one copy of the useless progressive moves to bias against picking them when you only have a few starting moves
+            possibleStartingMoves.append(Items.ProgressiveAmmoBelt)
+            possibleStartingMoves.append(Items.ProgressiveInstrumentUpgrade)
+        else:
+            # If we have lots of starting moves, we'll need to include all copies so we have enough stuff to fill all locations
+            possibleStartingMoves.extend(ItemPool.JunkSharedMoves)
         if spoiler.settings.training_barrels == TrainingBarrels.shuffled:
             possibleStartingMoves.extend(ItemPool.TrainingBarrelAbilities())
         if spoiler.settings.shockwave_status in (ShockwaveStatus.shuffled, ShockwaveStatus.shuffled_decoupled):

--- a/randomizer/LogicFiles/JungleJapes.py
+++ b/randomizer/LogicFiles/JungleJapes.py
@@ -40,7 +40,7 @@ LogicRegions = {
         TransitionFront(Regions.JapesBaboonBlast, lambda l: (l.vines or l.CanMoonkick()) and l.blast and l.isdonkey),  # , Transitions.JapesMainToBBlast)
     ]),
 
-    Regions.JungleJapesMain: Region("Jungle Japes Main", "Japes Highlands", Levels.JungleJapes, True, None, [
+    Regions.JungleJapesMain: Region("Jungle Japes Main", "Japes Hillside", Levels.JungleJapes, True, None, [
         LocationLogic(Locations.DiddyKong, lambda l: l.CanFreeDiddy()),
         LocationLogic(Locations.JapesDonkeyFrontofCage, lambda l: l.HasKong(l.settings.diddy_freeing_kong) or l.settings.free_trade_items),
         LocationLogic(Locations.JapesDonkeyFreeDiddy, lambda l: Events.JapesFreeKongOpenGates in l.Events),
@@ -67,7 +67,7 @@ LogicRegions = {
         TransitionFront(Regions.BeyondRambiGate, lambda l: l.CanPhaseswim() or l.CanSkew(False) or l.phasewalk or l.generalclips),
     ]),
 
-    Regions.JapesTopOfMountain: Region("Japes Top of Mountain", "Japes Highlands", Levels.JungleJapes, False, None, [
+    Regions.JapesTopOfMountain: Region("Japes Top of Mountain", "Japes Hillside", Levels.JungleJapes, False, None, [
         LocationLogic(Locations.JapesDiddyMountain, lambda l: Events.JapesDiddySwitch2 in l.Events and (l.isdiddy or l.settings.free_trade_items)),
     ], [
         Event(Events.JapesW5bTagged, lambda l: Locations.JapesDiddyMountain in l.SpecialLocationsReached),

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -25,7 +25,7 @@
                             class="form-select"
                             aria-label="Randomization type"
                             data-toggle="tooltip"
-                            title="Determines if and how moves are randomized.&#10;-Vanilla: Moves are in their vanilla locations and can only be bought by their normal kongs.&#10;-Shuffle: Moves can be randomized to different shops, but must still be bought by their normal kong. Shared moves can be bought by any kong.&#10;-Cross Kong Purchases: Kongs can now purchase another kongs moves. Shop Indicator will still show which kong buys the move.&#10;-Unlock All Moves: This option will make all moves available from the start without purchasing them.">
+                            title="Determines if and how moves are randomized.&#10;-Vanilla: Moves are in their vanilla locations and can only be bought by their normal kongs.&#10;-Shuffle: Moves can be randomized to different shops, but must still be bought by their normal kong. Shared moves can be bought by any kong.&#10;-Cross Kong Purchases: Kongs can now purchase another kongs moves. Shop Indicator will still show which kong buys the move.">
                         <option id="move_off"
                                 selected
                                 value="off"

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -229,9 +229,9 @@ def test_with_settings_string():
     """Confirm that settings strings decryption is working and generate a spoiler log with it."""
     # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
     # This top one is always the S2 Preset (probably up to date, if it isn't go steal it from the season2.json)
-    settings_string = "baGFiRorPN5yunTChooPw+qhoRDIhKlsa58CCI0ivUyYRCnrG2rBACoUht9QX8EsAycBkF1ls0FAXUAgwE7AIHA3cBhAI8AQJBXkChQM9AYLB3sDhgQow08fGQpnqShoKlsvbTcAM0NjlGuKFRFgMTEUDF+2R2OWvAX6RwPA5kqkuxuiSaxBJBmBBHNCBgzm4yA4tloXFgsiwUlwNCgWisVGEmjEjkk5CQPACsAA"
+    settings_string = "bKEFiRorPN5ysnPCBogPQ+qBoRDIhKlsa58B+I0eu0uXxCnLE2nBACoMgt1PX4EkAyaBkF1kssFAXQAgwE6gIHA3YBhAI7gQJBXgChQM8gYLB3oDhgQoQ08e2QpHqKhnKlMubRbwM0NjlFuCFRFgMTEUDF61xyN2q/32RQPAZiqcuUOS2EJIIvoE5IMMGY2mMHFosi0rlgVigthoTiwVCkwEwYEYkHERh0AVQA"
     # This one is for ease of testing, go wild with it
-    # settings_string = "baunTCgMUSwcYoqPx4Wx3EGWsQgvXz+AePhhNHPmcUwpwPqoMIZTISQRGkV6mRC3U/Y21YIAVvqC/glAETqsSiWxlFxls0FAXUAgwE7AIHA3cBhAI8AQJBXkChQM9AYLB3sDhgQow2WfMgpnqUtool0vqTSocSKkLAYmQoFL8dtd+wKZCpLsbk1gQRzQgwM5kBxbLRCEIuLIsFJcDQrFRhJoxI5pIxyNgcQAjAYkIhDAFYA"
+    # settings_string = "baGFiRorPN5yunTChooPw+qhoRDIhKlsa58CCI0ivUyYRCnrGGrBACoUht9QX8EsAycBkF1ls0FAXUAgwE7AIHA3cBhAI8AQJBXkChQM9AYLB3sDhgQow08fGQpnqShoKlsvbTcAM0NjlGuKFRFgMTEUDF+2R2OWvAX6RwPA5kqkuxuiSaxBJBmBBHNCBgzm4yA4tloXFgsiwUlwNCgWisVGEmjEjkk5CQPACsAA"
 
     settings_dict = decrypt_settings_string_enum(settings_string)
     settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly


### PR DESCRIPTION
- Removed duplicate progressive moves when selecting starting moves if you start with a low number of moves. This should generally reduce the number of times you load up on instrument upgrades or ammo belts as starting moves. You can still get them, they're just less likely
- Reduced the number of entrance hints in the default distribution
- Renamed Japes Highlands to Japes Hillside
- Fixed a bad UI tooltip