### PR TITLE
Key 9 doesn't exist, it can't hurt you

### DIFF
--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -810,10 +810,11 @@ class Settings:
         else:
             required_key_count = self.krool_key_count
         if self.krool_access or self.win_condition == WinCondition.get_key8:
-            # If helm is guaranteed or the win condition, make sure it's added and included in the key count
-            self.krool_keys_required.append(Events.HelmKeyTurnedIn)
+            # If key 8 is guaranteed to be needed, make sure it's added and included in the key count
+            if Events.HelmKeyTurnedIn not in self.krool_keys_required:
+                self.krool_keys_required.append(Events.HelmKeyTurnedIn)
+                required_key_count -= 1
             key_list.remove(Events.HelmKeyTurnedIn)
-            required_key_count -= 1
         if not self.select_keys:
             random.shuffle(key_list)
             for x in range(required_key_count):


### PR DESCRIPTION
Fixed a bug where Key 8 is placed twice when selecting starting keys, not selecting key 8 as a starting key, and putting key 8 in helm. (A logical choice of settings, just the code being derpy. We still love the code)