### PR TITLE
fixes to clear logic ahead of fills, training hint improvements, stray fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ static/py_libraries/dk64rando*.whl
 test.bps
 rom_tester.html
 tools/dumps
+test-result-*.json

--- a/randomizer/Enums/Locations.py
+++ b/randomizer/Enums/Locations.py
@@ -6,13 +6,13 @@ class Locations(IntEnum):
     """Location enum."""
 
     # Training Barrel locations
-    IslesVinesTrainingBarrel = auto()
+    IslesVinesTrainingBarrel = auto()  # ID: 1
     IslesSwimTrainingBarrel = auto()
     IslesOrangesTrainingBarrel = auto()
     IslesBarrelsTrainingBarrel = auto()
 
     # Pre-given move locations (36 locations) - the integer value of these matter for starting move count
-    PreGiven_Location00 = auto()
+    PreGiven_Location00 = auto()  # ID: 5
     PreGiven_Location01 = auto()
     PreGiven_Location02 = auto()
     PreGiven_Location03 = auto()
@@ -50,7 +50,7 @@ class Locations(IntEnum):
     PreGiven_Location35 = auto()
 
     # DK Isles locations
-    IslesDonkeyJapesRock = auto()
+    IslesDonkeyJapesRock = auto()  # ID: 41
     IslesTinyCagedBanana = auto()
     IslesTinyInstrumentPad = auto()
     IslesLankyCagedBanana = auto()
@@ -84,7 +84,7 @@ class Locations(IntEnum):
     BananaHoard = auto()
 
     # Jungle Japes location
-    JapesDonkeyMedal = auto()
+    JapesDonkeyMedal = auto()  # ID: 73
     JapesDiddyMedal = auto()
     JapesLankyMedal = auto()
     JapesTinyMedal = auto()
@@ -120,7 +120,7 @@ class Locations(IntEnum):
     JapesKey = auto()
 
     # Angry Aztec
-    AztecDonkeyMedal = auto()
+    AztecDonkeyMedal = auto()  # ID: 107
     AztecDiddyMedal = auto()
     AztecLankyMedal = auto()
     AztecTinyMedal = auto()
@@ -157,7 +157,7 @@ class Locations(IntEnum):
     AztecKey = auto()
 
     # Frantic Factory locations
-    FactoryDonkeyMedal = auto()
+    FactoryDonkeyMedal = auto()  # 142
     FactoryDiddyMedal = auto()
     FactoryLankyMedal = auto()
     FactoryTinyMedal = auto()
@@ -194,7 +194,7 @@ class Locations(IntEnum):
     FactoryKey = auto()
 
     # Gloomy Galleon locations
-    GalleonDonkeyMedal = auto()
+    GalleonDonkeyMedal = auto()  # ID: 177
     GalleonDiddyMedal = auto()
     GalleonLankyMedal = auto()
     GalleonTinyMedal = auto()
@@ -234,7 +234,7 @@ class Locations(IntEnum):
     GalleonKey = auto()
 
     # Fungi Forest locations
-    ForestDonkeyMedal = auto()
+    ForestDonkeyMedal = auto()  # ID: 215
     ForestDiddyMedal = auto()
     ForestLankyMedal = auto()
     ForestTinyMedal = auto()
@@ -270,7 +270,7 @@ class Locations(IntEnum):
     ForestKey = auto()
 
     # Crystal Caves locations
-    CavesDonkeyMedal = auto()
+    CavesDonkeyMedal = auto()  # ID: 249
     CavesDiddyMedal = auto()
     CavesLankyMedal = auto()
     CavesTinyMedal = auto()
@@ -305,7 +305,7 @@ class Locations(IntEnum):
     CavesKey = auto()
 
     # Creepy Castle locations
-    CastleDonkeyMedal = auto()
+    CastleDonkeyMedal = auto()  # ID: 282
     CastleDiddyMedal = auto()
     CastleLankyMedal = auto()
     CastleTinyMedal = auto()
@@ -340,7 +340,7 @@ class Locations(IntEnum):
     CastleKey = auto()
 
     # Hideout Helm locations
-    HelmDonkey1 = auto()
+    HelmDonkey1 = auto()  # ID: 315
     HelmDonkey2 = auto()
     HelmDiddy1 = auto()
     HelmDiddy2 = auto()
@@ -360,7 +360,7 @@ class Locations(IntEnum):
     HelmKey = auto()
 
     # Shop locations
-    CoconutGun = auto()
+    CoconutGun = auto()  # ID: 333
     PeanutGun = auto()
     GrapeGun = auto()
     FeatherGun = auto()
@@ -397,7 +397,7 @@ class Locations(IntEnum):
     GorillaGone = auto()
     RarewareCoin = auto()
     # These act as placeholders for shuffled move locations. In Vanilla game there is no move here
-    DonkeyGalleonPotion = auto()
+    DonkeyGalleonPotion = auto()  # ID: 369
     DonkeyForestPotion = auto()
     DonkeyCavesPotion = auto()
     DonkeyCastlePotion = auto()
@@ -460,7 +460,7 @@ class Locations(IntEnum):
     SharedJapesGun = auto()
     SharedAztecGun = auto()
     SharedGalleonGun = auto()
-    DonkeyFactoryInstrument = auto()
+    DonkeyFactoryInstrument = auto()  # ID: 432
     DonkeyGalleonInstrument = auto()
     DonkeyCavesInstrument = auto()
     DonkeyCastleInstrument = auto()
@@ -483,7 +483,7 @@ class Locations(IntEnum):
     SharedAztecInstrument = auto()
     SharedFactoryInstrument = auto()
 
-    TurnInDKIslesDonkeyBlueprint = auto()
+    TurnInDKIslesDonkeyBlueprint = auto()  # ID: 454
     TurnInDKIslesDiddyBlueprint = auto()
     TurnInDKIslesLankyBlueprint = auto()
     TurnInDKIslesTinyBlueprint = auto()
@@ -522,10 +522,10 @@ class Locations(IntEnum):
     TurnInCreepyCastleDiddyBlueprint = auto()
     TurnInCreepyCastleLankyBlueprint = auto()
     TurnInCreepyCastleTinyBlueprint = auto()
-    TurnInCreepyCastleChunkyBlueprint = auto()
+    TurnInCreepyCastleChunkyBlueprint = auto()  # ID: 493
 
     # Door locations must remain grouped together in this specific order for hint door location logic
-    JapesDonkeyDoor = auto()
+    JapesDonkeyDoor = auto()  # ID: 494
     JapesDiddyDoor = auto()
     JapesLankyDoor = auto()
     JapesTinyDoor = auto()
@@ -559,10 +559,10 @@ class Locations(IntEnum):
     CastleDiddyDoor = auto()
     CastleLankyDoor = auto()
     CastleTinyDoor = auto()
-    CastleChunkyDoor = auto()
+    CastleChunkyDoor = auto()  # ID: 528
 
     # Crown locations must stay grouped in this order
-    JapesBattleArena = auto()
+    JapesBattleArena = auto()  # ID: 529
     AztecBattleArena = auto()
     FactoryBattleArena = auto()
     GalleonBattleArena = auto()
@@ -571,10 +571,10 @@ class Locations(IntEnum):
     CastleBattleArena = auto()
     IslesBattleArena1 = auto()
     IslesBattleArena2 = auto()
-    HelmBattleArena = auto()
+    HelmBattleArena = auto()  # ID: 538
 
     # These locations are only utilized in kasplat rando and must stay grouped in this order
-    JapesDonkeyKasplatRando = auto()
+    JapesDonkeyKasplatRando = auto()  # ID: 539
     JapesDiddyKasplatRando = auto()
     JapesLankyKasplatRando = auto()
     JapesTinyKasplatRando = auto()
@@ -613,10 +613,10 @@ class Locations(IntEnum):
     IslesDiddyKasplatRando = auto()
     IslesLankyKasplatRando = auto()
     IslesTinyKasplatRando = auto()
-    IslesChunkyKasplatRando = auto()
+    IslesChunkyKasplatRando = auto()  # ID: 578
 
     # Rainbow Coin Locations used for dirt patch rando and item rando. Must remain in this order
-    RainbowCoin_Location00 = auto()
+    RainbowCoin_Location00 = auto()  # ID: 579
     RainbowCoin_Location01 = auto()
     RainbowCoin_Location02 = auto()
     RainbowCoin_Location03 = auto()
@@ -631,4 +631,4 @@ class Locations(IntEnum):
     RainbowCoin_Location12 = auto()
     RainbowCoin_Location13 = auto()
     RainbowCoin_Location14 = auto()
-    RainbowCoin_Location15 = auto()
+    RainbowCoin_Location15 = auto()  # ID: 594

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -17,23 +17,6 @@ from randomizer.Lists.ShufflableExit import ShufflableExits
 
 def PlaceConstants(settings):
     """Place items which are to be put in a hard-coded location."""
-    # Handle key placements
-    if settings.key_8_helm:
-        LocationList[Locations.HelmKey].PlaceItem(Items.HideoutHelmKey)
-    if settings.shuffle_loading_zones == ShuffleLoadingZones.levels and Types.Key not in settings.shuffled_location_types:
-        # Place keys in the lobbies they normally belong in
-        # Ex. Whatever level is in the Japes lobby entrance will always have the Japes key
-        for level in LevelInfoList.values():
-            # If level exit isn't shuffled, use vanilla key
-            if not ShufflableExits[level.TransitionTo].shuffled:
-                LocationList[level.KeyLocation].PlaceConstantItem(level.KeyItem)
-            else:
-                # Find the transition this exit is attached to, and use that to get the proper location to place this key
-                dest = ShufflableExits[level.TransitionTo].shuffledId
-                shuffledTo = [x for x in LevelInfoList.values() if x.TransitionTo == dest][0]
-                LocationList[shuffledTo.KeyLocation].PlaceConstantItem(level.KeyItem)
-        # The key in Helm is always Key 8 in these settings
-        LocationList[Locations.HelmKey].PlaceConstantItem(Items.HideoutHelmKey)
     # Settings-dependent locations
     # Determine what types of locations are being shuffled
     typesOfItemsShuffled = []
@@ -54,6 +37,27 @@ def PlaceConstants(settings):
     for location in LocationList:
         if LocationList[location].type in typesOfItemsNotShuffled:
             LocationList[location].PlaceDefaultItem()
+        else:
+            LocationList[location].constant = False
+            LocationList[location].item = None
+    # Make extra sure the Helm Key is right
+    if settings.key_8_helm:
+        LocationList[Locations.HelmKey].PlaceItem(Items.HideoutHelmKey)
+    # Handle key placements
+    if settings.shuffle_loading_zones == ShuffleLoadingZones.levels and Types.Key not in settings.shuffled_location_types:
+        # Place keys in the lobbies they normally belong in
+        # Ex. Whatever level is in the Japes lobby entrance will always have the Japes key
+        for level in LevelInfoList.values():
+            # If level exit isn't shuffled, use vanilla key
+            if not ShufflableExits[level.TransitionTo].shuffled:
+                LocationList[level.KeyLocation].PlaceConstantItem(level.KeyItem)
+            else:
+                # Find the transition this exit is attached to, and use that to get the proper location to place this key
+                dest = ShufflableExits[level.TransitionTo].shuffledId
+                shuffledTo = [x for x in LevelInfoList.values() if x.TransitionTo == dest][0]
+                LocationList[shuffledTo.KeyLocation].PlaceConstantItem(level.KeyItem)
+        # The key in Helm is always Key 8 in these settings
+        LocationList[Locations.HelmKey].PlaceConstantItem(Items.HideoutHelmKey)
 
     # Empty out some locations based on the settings
     if settings.starting_kongs_count == 5:

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -1088,3 +1088,10 @@ ShopLocationReference[Levels.DKIsles] = {}
 ShopLocationReference[Levels.DKIsles][VendorType.Cranky] = [Locations.DonkeyIslesPotion, Locations.DiddyIslesPotion, Locations.LankyIslesPotion, Locations.TinyIslesPotion, Locations.ChunkyIslesPotion, Locations.SimianSlam]
 
 RemovedShopLocations = []
+
+
+def ResetLocationList():
+    """Reset the LocationList to values conducive to a new fill."""
+    for location in LocationList.values():
+        location.PlaceDefaultItem()
+    # Known to be incomplete - it should also confirm the correct locations of Fairies, Dirt, and Crowns

--- a/randomizer/LogicFiles/GloomyGalleon.py
+++ b/randomizer/LogicFiles/GloomyGalleon.py
@@ -235,7 +235,7 @@ LogicRegions = {
     ]),
 
     Regions.LankyShip: Region("Lanky Ship", "Shipyard Outskirts", Levels.GloomyGalleon, False, None, [
-        LocationLogic(Locations.GalleonLanky2DoorShip, lambda l: l.islanky or l.settings.free_trade_items),
+        LocationLogic(Locations.GalleonLanky2DoorShip, lambda l: l.islanky),
     ], [], [
         TransitionFront(Regions.GloomyGalleonMedals, lambda l: True),
         TransitionFront(Regions.ShipyardUnderwater, lambda l: True, Transitions.GalleonLankyToShipyard),

--- a/randomizer/Prices.py
+++ b/randomizer/Prices.py
@@ -240,7 +240,7 @@ def GetPriceAtLocation(settings, location_id, location, slamLevel, ammoBelts, in
         if slamLevel in [1, 2]:
             return settings.prices[item][slamLevel - 1]
         else:
-            # If already have max slam, there's no move to buy (this shouldn't happen?)
+            # If already have max slam, there's no move to buy (this is fine only if it's in VerifyWorld)
             return 0
     elif item == Items.ProgressiveAmmoBelt:
         if ammoBelts in [0, 1]:

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -605,7 +605,16 @@ class Settings:
                 self.shuffled_location_types.append(Types.PreGivenMove)
         self.shuffle_prices()
 
-        # Starting Move Locations
+        # Starting Move Location handling
+        # Undo any damage that might leak between seeds
+        LocationList[Locations.IslesVinesTrainingBarrel].default = Items.Vines
+        LocationList[Locations.IslesVinesTrainingBarrel].type = Types.TrainingBarrel
+        LocationList[Locations.IslesSwimTrainingBarrel].default = Items.Swim
+        LocationList[Locations.IslesSwimTrainingBarrel].type = Types.TrainingBarrel
+        LocationList[Locations.IslesBarrelsTrainingBarrel].default = Items.Barrels
+        LocationList[Locations.IslesBarrelsTrainingBarrel].type = Types.TrainingBarrel
+        LocationList[Locations.IslesOrangesTrainingBarrel].default = Items.Oranges
+        LocationList[Locations.IslesOrangesTrainingBarrel].type = Types.TrainingBarrel
         location_cap = 36
         if self.shockwave_status in (ShockwaveStatus.vanilla, ShockwaveStatus.start_with):
             location_cap -= 2

--- a/randomizer/ShuffleBosses.py
+++ b/randomizer/ShuffleBosses.py
@@ -203,7 +203,7 @@ def ShuffleBossesBasedOnOwnedItems(settings, ownedKongs: dict, ownedMoves: dict)
         if isinstance(ex.args[0], str) and "pop from empty list" in ex.args[0]:
             print("Barrels bad.")
             raise BossOutOfLocationsException("No valid locations to place " + bossTryingToBePlaced)
-        raise ex
+        raise FillException("Something went wrong while assigning bosses.")
 
     # Only apply this shuffle if the settings permit it
     # If kongs are random we have to shuffle bosses and locations or else we might break logic

--- a/randomizer/ShuffleDoors.py
+++ b/randomizer/ShuffleDoors.py
@@ -61,6 +61,9 @@ def ShuffleDoors(spoiler):
             if spoiler.settings.tns_location_rando:
                 if door.placed == "tns":
                     door.placed = "none"
+    # Hint doors have Locations tied to them. If we're about to add new ones, then we must remove the old ones.
+    if spoiler.settings.wrinkly_location_rando:
+        ClearHintDoorLogic()
     # Assign Wrinkly Doors & T&S Portals
     for level in door_locations:
         # Get all door locations that can be given a door
@@ -139,6 +142,7 @@ def ShuffleDoors(spoiler):
 
 def ShuffleVanillaDoors(spoiler):
     """Shuffle T&S and Wrinkly doors amongst the vanilla locations."""
+    ClearHintDoorLogic()
     for level in door_locations:
         # Reset the data structures for door shuffling information sharing
         shuffled_door_data[level] = []
@@ -190,3 +194,9 @@ def ShuffleVanillaDoors(spoiler):
         spoiler.human_hint_doors = human_hint_doors
     if spoiler.settings.tns_location_rando:
         spoiler.human_portal_doors = human_portal_doors
+
+
+def ClearHintDoorLogic():
+    """Remove existing hint door locations from the logic in preparation for custom door locations to be added."""
+    for id, region in Logic.Regions.items():
+        region.locations = [loclogic for loclogic in region.locations if loclogic.id < Locations.JapesDonkeyDoor or loclogic.id > Locations.CastleChunkyDoor]

--- a/randomizer/ShuffleFairies.py
+++ b/randomizer/ShuffleFairies.py
@@ -16,6 +16,7 @@ from randomizer.Enums.Locations import Locations
 from randomizer.Lists.FairyLocations import fairy_locations
 from randomizer.Lists.Location import LocationList
 from randomizer.LogicClasses import LocationLogic
+from randomizer.Logic import Regions as RegionList
 from randomizer.Spoiler import Spoiler
 
 
@@ -29,6 +30,30 @@ class FairyPlacementInfo:
         self.internal_level_index = internal_level_index
         self.id = id
         self.shift = shift
+
+
+all_fairy_locations = [
+    Locations.JapesBananaFairyRambiCave,
+    Locations.JapesBananaFairyLankyCave,
+    Locations.AztecBananaFairyLlamaTemple,
+    Locations.AztecBananaFairyTinyTemple,
+    Locations.FactoryBananaFairybyFunky,
+    Locations.FactoryBananaFairybyCounting,
+    Locations.GalleonBananaFairybyCranky,
+    Locations.GalleonBananaFairy5DoorShip,
+    Locations.CavesBananaFairyIgloo,
+    Locations.CavesBananaFairyCabin,
+    Locations.ForestBananaFairyRafters,
+    Locations.ForestBananaFairyThornvines,
+    Locations.CastleBananaFairyBallroom,
+    Locations.CastleBananaFairyTree,
+    Locations.IslesBananaFairyFactoryLobby,
+    Locations.IslesBananaFairyForestLobby,
+    Locations.IslesBananaFairyIsland,
+    Locations.IslesBananaFairyCrocodisleIsle,
+    Locations.HelmBananaFairy1,
+    Locations.HelmBananaFairy2,
+]
 
 
 def ShuffleFairyLocations(spoiler: Spoiler):
@@ -59,6 +84,7 @@ def ShuffleFairyLocations(spoiler: Spoiler):
         Levels.HideoutHelm: "Helm",
     }
     if spoiler.settings.random_fairies:
+        ClearFairyLogic()
         fairy_data_table = [
             # HAS to remain in this order. DO NOT REORDER
             FairyPlacementInfo(Locations.JapesBananaFairyRambiCave, Levels.JungleJapes, 0, 51),
@@ -120,3 +146,9 @@ def ShuffleFairyLocations(spoiler: Spoiler):
                         new_region = fairy_locations[level][x].region
                         level_to_enum[level][new_region].locations.append(LocationLogic(data.location, fairy_locations[level][x].logic))
                         LocationList[data.location].name = f"{level_to_name[level]} Fairy ({fairy_locations[level][x].name})"
+
+
+def ClearFairyLogic():
+    """Clear out any fairy locations in preparation for filling custom ones."""
+    for id, region in RegionList.items():
+        RegionList[region].locations = [loc for loc in RegionList[region].locations if loc.id not in all_fairy_locations]

--- a/randomizer/ShuffleKasplats.py
+++ b/randomizer/ShuffleKasplats.py
@@ -230,6 +230,8 @@ def KasplatShuffle(spoiler, LogicVariables):
         retries = 0
         while True:
             try:
+                # Clear any existing logic
+                ResetShuffledKasplatLocations()
                 # Shuffle kasplats
                 if spoiler.settings.kasplat_location_rando:
                     ShuffleKasplatsAndLocations(spoiler, LogicVariables)
@@ -244,14 +246,12 @@ def KasplatShuffle(spoiler, LogicVariables):
                         # This is the first VerifyWorld check, and serves as the canary in the coal mine
                         # If we get to this point in the code, the world itself is likely unstable from some combination of settings or bugs
                         js.postMessage("Settings combination is likely unstable.")
+                        ResetShuffledKasplatLocations()
                         raise Ex.SettingsIncompatibleException
                 return
             except Ex.KasplatPlacementException:
                 retries += 1
                 js.postMessage("Kasplat placement failed. Retrying. Tries: " + str(retries))
-                # We've added logic in kasplat location rando, now we need to remove it
-                if spoiler.settings.kasplat_location_rando:
-                    ResetShuffledKasplatLocations()
 
 
 def InitKasplatMap(LogicVariables):

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -202,18 +202,18 @@ def generate_settings():
     return data
 
 
-def test_manual_settings_dict(generate_lo_rando_race_settings):
-    """Asdf."""
-    generate_lo_rando_race_settings["algorithm"] = FillAlgorithm.forward
-    settings = Settings(generate_lo_rando_race_settings)
-    spoiler = Spoiler(settings)
-    Generate_Spoiler(spoiler)
-    print(spoiler)
-    print(spoiler.json)
-    print("all done")
+# def test_manual_settings_dict(generate_lo_rando_race_settings):
+#     """Asdf."""
+#     generate_lo_rando_race_settings["algorithm"] = FillAlgorithm.forward
+#     settings = Settings(generate_lo_rando_race_settings)
+#     spoiler = Spoiler(settings)
+#     Generate_Spoiler(spoiler)
+#     print(spoiler)
+#     print(spoiler.json)
+#     print("all done")
 
 
-def test_with_settings_string():
+def test_with_settings_string_1():
     """Confirm that settings strings decryption is working and generate a spoiler log with it."""
     # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
     # This top one is always the S2 Preset (probably up to date, if it isn't go steal it from the season2.json)
@@ -229,7 +229,143 @@ def test_with_settings_string():
     print(spoiler)
     print(spoiler.json)
     # printHintDistribution(spoiler)
-    print("all done")
+    with open("test-result-1.json", "w") as outfile:
+        outfile.write(spoiler.json)
+    print("test 1 done")
+
+
+def test_with_settings_string_2():
+    """Confirm that settings strings decryption is working and generate a spoiler log with it."""
+    # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
+    # non-item rando seed
+    settings_string = "Vi5oQVEE4Yi0gIJ+/AkAETQMguAoC6DwGBXU8A4e7MgIHnd9BJk8SwKQXmvBag9ZAMZFCGnj2yFI9Rls9Eql1SKSjgRUBYEEwFAJejlqvsigeADEUxcktsMISQRfQJyQYYDwPD4RI5dJYvCBmNpjBxaLICIIgFpuK5YFYoLYaE4sFQpMhlMBMGBGNBFOJrDZ/EZDKoA"
+
+    settings_dict = decrypt_settings_string_enum(settings_string)
+    settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
+    settings = Settings(settings_dict)
+    spoiler = Spoiler(settings)
+    Generate_Spoiler(spoiler)
+    # print(spoiler)
+    # print(spoiler.json)
+    # printHintDistribution(spoiler)
+    with open("test-result-2.json", "w") as outfile:
+        outfile.write(spoiler.json)
+    print("test 2 done")
+
+
+def test_with_settings_string_3():
+    """Confirm that settings strings decryption is working and generate a spoiler log with it."""
+    # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
+    # S2
+    settings_string = "bKEFiRorPN5ysnPCBogPQ+qBoRDIhKlsa58B+I0eu0uXxCnLE2nBACoMgt1PX4EkAyaBkF1kssFAXQAgwE6gIHA3YBhAI7gQJBXgChQM8gYLB3oDhgQoQ08e2QpHqKhnKlMubRbwM0NjlFuCFRFgMTEUDF61xyN2q/32RQPAZiqcuUOS2EJIIvoE5IMMGY2mMHFosi0rlgVigthoTiwVCkwEwYEYkHERh0AVQA"
+
+    settings_dict = decrypt_settings_string_enum(settings_string)
+    settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
+    settings = Settings(settings_dict)
+    spoiler = Spoiler(settings)
+    Generate_Spoiler(spoiler)
+    # print(spoiler)
+    # print(spoiler.json)
+    # printHintDistribution(spoiler)
+    with open("test-result-3.json", "w") as outfile:
+        outfile.write(spoiler.json)
+    print("test 3 done")
+
+
+def test_with_settings_string_4():
+    """Confirm that settings strings decryption is working and generate a spoiler log with it."""
+    # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
+    # all location rando
+    for i in range(1, 11):
+        settings_string = "bKsnPCAMMSwVfwNyjFEh6H1QQCIZCmOhKlsa58B+I0eu0uXxCzW2x05Yi0wIB1arMCoMgp8TAIv2JIBk3FcolUZBeZLLBQF0AIMBOoCBwN2AYQCO4ECQV4AoUDPIGCwd6A4YEBqM9uFgqR6ioZ0JlKpc2i3gRqbotxuFFSFgQTIUAl6qigRDIUx0JUtjXPhGdbNccjdqv99kUDwCYqnLlDkuDFpuK5YLYaE4sFJQGBGJAjIQAOgA"
+
+        settings_dict = decrypt_settings_string_enum(settings_string)
+        settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
+        settings = Settings(settings_dict)
+        spoiler = Spoiler(settings)
+        Generate_Spoiler(spoiler)
+        # print(spoiler)
+        # print(spoiler.json)
+        # printHintDistribution(spoiler)
+        with open("test-result-4." + str(i) + ".json", "w") as outfile:
+            outfile.write(spoiler.json)
+        print("test 4." + str(i) + " done")
+
+
+def test_with_settings_string_5():
+    """Confirm that settings strings decryption is working and generate a spoiler log with it."""
+    # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
+    # no location rando
+    settings_string = "bKsnPCBoiPQ+qCARDIUx0JUtjXPgPxGj12ly+IWa205Yi0wIB1arMCoMgp6/YkgGTcVyiVRkF5kssFAXQAgwE6gIHA3YBhAI7gQJBXgChQM8gYLB3oDhgQGoz24WCpHqKhnQlIubRbwI1N0W43CipCwIJkKAS9VRQIhkKY6EqWxrnwjOtmuORu1X++yKB4BMVTlyhyWwhJBF9AnJBhgxi03FcsFsNCcWCkoEwYEYkCMhAA6AA"
+
+    settings_dict = decrypt_settings_string_enum(settings_string)
+    settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
+    settings = Settings(settings_dict)
+    spoiler = Spoiler(settings)
+    Generate_Spoiler(spoiler)
+    # print(spoiler)
+    # print(spoiler.json)
+    # printHintDistribution(spoiler)
+    with open("test-result-5.json", "w") as outfile:
+        outfile.write(spoiler.json)
+    print("test 5 done")
+
+
+def test_with_settings_string_6():
+    """Confirm that settings strings decryption is working and generate a spoiler log with it."""
+    # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
+    # Ice's settings
+    settings_string = "bKEGCRorPE1eKyc8IQwxLBV+5RiiQ9D6oIBEMhTHQlS2Nc+AjR67S5fELNbbHTlijTAgHQKgyC3U+JgEX7EkAybiuUSqMgvMllgoC6AEGAnUBA4G7AMIBHcCBIK8AUKBnkDBYO9AcMCA1Ge3CwVI9RUM6EylUubRbwI1N0W43CipCwIJkKAS9VRQIhkKY6EqWxrnwjOtmuOWq/32RQPAJiqcuUOS4FBh8tFkWlcsFsNCcWCkoDAjEgNiMOgA"
+
+    settings_dict = decrypt_settings_string_enum(settings_string)
+    settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
+    settings = Settings(settings_dict)
+    spoiler = Spoiler(settings)
+    Generate_Spoiler(spoiler)
+    # print(spoiler)
+    # print(spoiler.json)
+    # printHintDistribution(spoiler)
+    with open("test-result-6.json", "w") as outfile:
+        outfile.write(spoiler.json)
+    print("test 6 done")
+
+
+def test_with_settings_string_7():
+    """Confirm that settings strings decryption is working and generate a spoiler log with it."""
+    # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
+    # VBB
+    settings_string = "Vg5oShEE4Yg0gIJ+/AkAETQMguAoC6DwGBXU8A4e7MgIHnd9BJk8SwKQXmvBag9ZAMZFCGnj2yFI9Rls9Eql1SKTDgRUBYEEwFAJejlqvsigeADEUxcktsMISQRfQJyQYYDwPD4RI5dJYvCBmNpjBxaLICIIgFpuK5YFYoLYaE4sFQpMhlMBMGBGNBFOJrDZ/EZDKoA"
+
+    settings_dict = decrypt_settings_string_enum(settings_string)
+    settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
+    settings = Settings(settings_dict)
+    spoiler = Spoiler(settings)
+    Generate_Spoiler(spoiler)
+    # print(spoiler)
+    # print(spoiler.json)
+    # printHintDistribution(spoiler)
+    with open("test-result-7.json", "w") as outfile:
+        outfile.write(spoiler.json)
+    print("test 7 done")
+
+
+def test_with_settings_string_8():
+    """Confirm that settings strings decryption is working and generate a spoiler log with it."""
+    # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
+    # S2
+    settings_string = "bKEFiRorPN5ysnPCBogPQ+qBoRDIhKlsa58B+I0eu0uXxCnLE2nBACoMgt1PX4EkAyaBkF1kssFAXQAgwE6gIHA3YBhAI7gQJBXgChQM8gYLB3oDhgQoQ08e2QpHqKhnKlMubRbwM0NjlFuCFRFgMTEUDF61xyN2q/32RQPAZiqcuUOS2EJIIvoE5IMMGY2mMHFosi0rlgVigthoTiwVCkwEwYEYkHERh0AVQA"
+
+    settings_dict = decrypt_settings_string_enum(settings_string)
+    settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
+    settings = Settings(settings_dict)
+    spoiler = Spoiler(settings)
+    Generate_Spoiler(spoiler)
+    # print(spoiler)
+    # print(spoiler.json)
+    # printHintDistribution(spoiler)
+    with open("test-result-8.json", "w") as outfile:
+        outfile.write(spoiler.json)
+    print("test 8 done")
 
 
 def printHintDistribution(spoiler: Spoiler):


### PR DESCRIPTION
- Added some logic to clear custom logic ahead of custom locations. This was intended to make sequential seed generations to be independent and it works... if the settings are identical. More to be done on this front but these changes don't really hurt any and are a good failsafe. The hint door shuffle change in particular definitely needed to happen.
- Improved Training move hints - you can no longer be hinted very obvious training moves on paths (e.g. Your training in Rocketbarrel is on the path to Diddy K. Rool or Your training in Vines is on the path to Key 8 (in helm).)
- Fixed an issue that would prevent certain random starting locations from generating because they couldn't logically pause exit.
- Fixed a potential LZR issue with FTA in Lanky's 2-door ship.
- Big update to the tests that outputs the spoiler log to a file instead of dumping it to the console (though you can do that if desired).