### PR TITLE
limit shared shops, stray fixes

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -141,6 +141,11 @@ hint_list = [
         base=True,
     ),
     Hint(hint="[[WOTB]]", important=False, base=True),
+    Hint(
+        hint="By using DK64Randomizer.com, users agree to release the developers from any claims, damages, bad seeds, or liabilities. Please exercise caution and randomizer responsibly.",
+        important=False,
+        base=True,
+    ),
 ]
 
 kong_list = ["\x04Donkey\x04", "\x05Diddy\x05", "\x06Lanky\x06", "\x07Tiny\x07", "\x08Chunky\x08", "\x04Any kong\x04"]
@@ -353,7 +358,9 @@ def compileHints(spoiler: Spoiler):
             if key_id == Items.HideoutHelmKey and spoiler.settings.key_8_helm:
                 # Your training in Gorilla Gone, Monkeyport, and Vines are always pointless hints if Key 8 is in Helm, so let's not
                 useless_locations[Items.HideoutHelmKey] = [
-                    loc for loc in spoiler.woth_paths[key_location_ids[key_id]] if loc in TrainingBarrelLocations and LocationList[loc].item in [Items.GorillaGone, Items.Monkeyport, Items.Vines]
+                    loc
+                    for loc in spoiler.woth_paths[key_location_ids[key_id]]
+                    if (loc in TrainingBarrelLocations or loc in PreGivenLocations) and LocationList[loc].item in [Items.GorillaGone, Items.Monkeyport, Items.Vines]
                 ]
                 path_length -= len(useless_locations[Items.HideoutHelmKey])
             key_difficulty_score[key_id] = path_length  # The length of the path serves as a "score" for how much this key needs hints
@@ -379,16 +386,22 @@ def compileHints(spoiler: Spoiler):
         # Determine which K. Rool path locations are useless
         # First calculate all of them correctly
         if Kongs.diddy in spoiler.settings.krool_order:
-            useless_locations[Kongs.diddy] = [loc for loc in spoiler.krool_paths[Kongs.diddy] if loc in TrainingBarrelLocations and LocationList[loc].item in [Items.Peanut, Items.RocketbarrelBoost]]
+            useless_locations[Kongs.diddy] = [
+                loc for loc in spoiler.krool_paths[Kongs.diddy] if (loc in TrainingBarrelLocations or loc in PreGivenLocations) and LocationList[loc].item in [Items.Peanut, Items.RocketbarrelBoost]
+            ]
         if Kongs.lanky in spoiler.settings.krool_order:
-            useless_locations[Kongs.lanky] = [loc for loc in spoiler.krool_paths[Kongs.lanky] if loc in TrainingBarrelLocations and LocationList[loc].item in [Items.Barrels, Items.Trombone]]
+            useless_locations[Kongs.lanky] = [
+                loc for loc in spoiler.krool_paths[Kongs.lanky] if (loc in TrainingBarrelLocations or loc in PreGivenLocations) and LocationList[loc].item in [Items.Barrels, Items.Trombone]
+            ]
         if Kongs.tiny in spoiler.settings.krool_order:
-            useless_locations[Kongs.tiny] = [loc for loc in spoiler.krool_paths[Kongs.tiny] if loc in TrainingBarrelLocations and LocationList[loc].item in [Items.Feather, Items.MiniMonkey]]
+            useless_locations[Kongs.tiny] = [
+                loc for loc in spoiler.krool_paths[Kongs.tiny] if (loc in TrainingBarrelLocations or loc in PreGivenLocations) and LocationList[loc].item in [Items.Feather, Items.MiniMonkey]
+            ]
         if Kongs.chunky in spoiler.settings.krool_order:
             useless_locations[Kongs.chunky] = [
                 loc
                 for loc in spoiler.krool_paths[Kongs.chunky]
-                if loc in TrainingBarrelLocations and LocationList[loc].item in [Items.ProgressiveSlam, Items.PrimatePunch, Items.HunkyChunky, Items.GorillaGone]
+                if (loc in TrainingBarrelLocations or loc in PreGivenLocations) and LocationList[loc].item in [Items.ProgressiveSlam, Items.PrimatePunch, Items.HunkyChunky, Items.GorillaGone]
             ]
     # Otherwise we dynamically generate the hint distribution
     else:
@@ -430,24 +443,31 @@ def compileHints(spoiler: Spoiler):
                     if Kongs.diddy in spoiler.settings.krool_order:
                         hint_distribution[HintType.RequiredWinConditionHint] += 1
                         useless_locations[Kongs.diddy] = [
-                            loc for loc in spoiler.krool_paths[Kongs.diddy] if loc in TrainingBarrelLocations and LocationList[loc].item in [Items.Peanut, Items.RocketbarrelBoost]
+                            loc
+                            for loc in spoiler.krool_paths[Kongs.diddy]
+                            if (loc in TrainingBarrelLocations or loc in PreGivenLocations) and LocationList[loc].item in [Items.Peanut, Items.RocketbarrelBoost]
                         ]
                     if Kongs.lanky in spoiler.settings.krool_order:
                         hint_distribution[HintType.RequiredWinConditionHint] += 1
                         useless_locations[Kongs.lanky] = [
-                            loc for loc in spoiler.krool_paths[Kongs.lanky] if loc in TrainingBarrelLocations and LocationList[loc].item in [Items.Barrels, Items.Trombone]
+                            loc
+                            for loc in spoiler.krool_paths[Kongs.lanky]
+                            if (loc in TrainingBarrelLocations or loc in PreGivenLocations) and LocationList[loc].item in [Items.Barrels, Items.Trombone]
                         ]
                     if Kongs.tiny in spoiler.settings.krool_order:
                         hint_distribution[HintType.RequiredWinConditionHint] += 1
                         useless_locations[Kongs.tiny] = [
-                            loc for loc in spoiler.krool_paths[Kongs.tiny] if loc in TrainingBarrelLocations and LocationList[loc].item in [Items.Feather, Items.MiniMonkey]
+                            loc
+                            for loc in spoiler.krool_paths[Kongs.tiny]
+                            if (loc in TrainingBarrelLocations or loc in PreGivenLocations) and LocationList[loc].item in [Items.Feather, Items.MiniMonkey]
                         ]
                     if Kongs.chunky in spoiler.settings.krool_order:
                         hint_distribution[HintType.RequiredWinConditionHint] += 2
                         useless_locations[Kongs.chunky] = [
                             loc
                             for loc in spoiler.krool_paths[Kongs.chunky]
-                            if loc in TrainingBarrelLocations and LocationList[loc].item in [Items.ProgressiveSlam, Items.PrimatePunch, Items.HunkyChunky, Items.GorillaGone]
+                            if (loc in TrainingBarrelLocations or loc in PreGivenLocations)
+                            and LocationList[loc].item in [Items.ProgressiveSlam, Items.PrimatePunch, Items.HunkyChunky, Items.GorillaGone]
                         ]
                     path_length -= len(useless_locations[Kongs.diddy]) + len(useless_locations[Kongs.lanky]) + len(useless_locations[Kongs.tiny]) + len(useless_locations[Kongs.chunky])
                     if hint_distribution[HintType.RequiredWinConditionHint] != 0:
@@ -536,7 +556,7 @@ def compileHints(spoiler: Spoiler):
                         useless_locations[Items.HideoutHelmKey] = [
                             loc
                             for loc in spoiler.woth_paths[key_location_ids[key_id]]
-                            if loc in TrainingBarrelLocations and LocationList[loc].item in [Items.GorillaGone, Items.Monkeyport, Items.Vines]
+                            if (loc in TrainingBarrelLocations or loc in PreGivenLocations) and LocationList[loc].item in [Items.GorillaGone, Items.Monkeyport, Items.Vines]
                         ]
                         path_length -= len(useless_locations[Items.HideoutHelmKey])
                     if path_length <= 1:  # 1-2

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -40,6 +40,9 @@ def PlaceConstants(settings):
         else:
             LocationList[location].constant = False
             LocationList[location].item = None
+        # While we're looping here, also reset shops that became inaccessible due to fill lockouts
+        if LocationList[location].type == Types.Shop:
+            LocationList[location].inaccessible = LocationList[location].smallerShopsInaccessible
     # Make extra sure the Helm Key is right
     if settings.key_8_helm:
         LocationList[Locations.HelmKey].PlaceItem(Items.HideoutHelmKey)

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -42,6 +42,7 @@ class Location:
         self.logically_relevant = logically_relevant  # This is True if this location is needed to derive the logic for another location
         self.placement_index = None
         self.inaccessible = False
+        self.smallerShopsInaccessible = False
         if self.type == Types.Shop:
             self.movetype = data[0]
             self.index = data[1]
@@ -85,7 +86,7 @@ class Location:
         # If we're placing a real move here, lock out mutually exclusive shop locations
         if item != Items.NoItem and self.type == Types.Shop:
             for location in ShopLocationReference[self.level][self.vendor]:
-                if location in RemovedShopLocations:
+                if LocationList[location].smallerShopsInaccessible:
                     continue
                 # If this is a shared spot, lock out kong-specific locations in this shop
                 if self.kong == Kongs.any and LocationList[location].kong != Kongs.any:
@@ -121,11 +122,11 @@ class Location:
         if self.type == Types.Shop:
             # Check other locations in this shop
             for location_id in ShopLocationReference[self.level][self.vendor]:
-                if location_id in RemovedShopLocations:
+                if LocationList[location_id].smallerShopsInaccessible:
                     continue
                 if LocationList[location_id].kong == Kongs.any and LocationList[location_id].inaccessible:
                     # If there are no other items remaining in this shop, then we can unlock the shared location
-                    itemsInThisShop = len([location for location in ShopLocationReference[self.level][self.vendor] if location not in RemovedShopLocations and LocationList[location].item not in (None, Items.NoItem)])
+                    itemsInThisShop = len([location for location in ShopLocationReference[self.level][self.vendor] if LocationList[location].item not in (None, Items.NoItem)])
                     if itemsInThisShop == 0:
                         LocationList[location_id].inaccessible = False
                 # Locations are only inaccessible due to lockouts. If any exist, they're because this location caused them to be locked out.
@@ -1086,8 +1087,6 @@ ShopLocationReference[Levels.CreepyCastle][VendorType.Funky] = [
 ]
 ShopLocationReference[Levels.DKIsles] = {}
 ShopLocationReference[Levels.DKIsles][VendorType.Cranky] = [Locations.DonkeyIslesPotion, Locations.DiddyIslesPotion, Locations.LankyIslesPotion, Locations.TinyIslesPotion, Locations.ChunkyIslesPotion, Locations.SimianSlam]
-
-RemovedShopLocations = []
 
 
 def ResetLocationList():

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -84,7 +84,7 @@ LogicRegions = {
         TransitionFront(Regions.CrankyIsles, lambda l: True),
     ]),
 
-    Regions.IslesMain: Region("Isles Main", "DK Isle", Levels.DKIsles, True, None, [
+    Regions.IslesMain: Region("Isles Main", "Outside DK Isle", Levels.DKIsles, True, None, [
         # Don't check for donkey for rock- If lobbies are closed and first B.Locker is not 0, this banana must be grabbable by
         # the starting kong, so for logic we assume any kong can grab it since that's practically true.
         LocationLogic(Locations.IslesDonkeyJapesRock, lambda l: (l.settings.open_lobbies or Events.KLumsyTalkedTo in l.Events)),
@@ -116,7 +116,7 @@ LogicRegions = {
         TransitionFront(Regions.KRool, lambda l: l.CanAccessKRool() or l.assumeKRoolAccess),
     ]),
 
-    Regions.IslesMainUpper: Region("Isles Main Upper", "DK Isle", Levels.DKIsles, False, None, [
+    Regions.IslesMainUpper: Region("Isles Main Upper", "Outside DK Isle", Levels.DKIsles, False, None, [
         LocationLogic(Locations.IslesChunkyInstrumentPad, lambda l: l.triangle and l.chunky and l.barrels),
     ], [
         Event(Events.IslesDiddyBarrelSpawn, lambda l: l.chunky and l.trombone and l.lanky and l.barrels),
@@ -244,13 +244,14 @@ LogicRegions = {
         TransitionFront(Regions.GloomyGalleonStart, lambda l: l.IsLevelEnterable(Levels.GloomyGalleon), Transitions.IslesToGalleon),
     ]),
 
-    Regions.CabinIsle: Region("Cabin Isle", "DK Isle", Levels.DKIsles, False, None, [
+    Regions.CabinIsle: Region("Cabin Isle", "Outside DK Isle", Levels.DKIsles, False, None, [
         LocationLogic(Locations.IslesDiddyCagedBanana, lambda l: ((Events.IslesDiddyBarrelSpawn in l.Events and l.jetpack) or (l.advanced_platforming and (l.isdiddy or (l.isdonkey and l.settings.krusha_kong != Kongs.donkey) or (l.istiny and l.twirl) or l.ischunky))) and ((l.peanut and l.isdiddy) or l.phasewalk and l.settings.free_trade_items)),
         LocationLogic(Locations.IslesDiddySummit, lambda l: Events.IslesDiddyBarrelSpawn in l.Events and l.jetpack and l.isdiddy, MinigameType.BonusBarrel),
         LocationLogic(Locations.RainbowCoin_Location03, lambda l: l.shockwave),
         LocationLogic(Locations.RainbowCoin_Location05, lambda l: ((Events.IslesDiddyBarrelSpawn in l.Events and l.jetpack and l.isdiddy) or (l.twirl and l.istiny and l.advanced_platforming)) and l.shockwave),
     ], [], [
         TransitionFront(Regions.IslesMain, lambda l: True),
+        TransitionFront(Regions.IslesMainUpper, lambda l: l.twirl and l.istiny and l.advanced_platforming),
         TransitionFront(Regions.FungiForestLobby, lambda l: True, Transitions.IslesMainToForestLobby),
     ]),
 

--- a/randomizer/Prices.py
+++ b/randomizer/Prices.py
@@ -16,7 +16,6 @@ from randomizer.Lists.Location import (
     DonkeyMoveLocations,
     LankyMoveLocations,
     LocationList,
-    RemovedShopLocations,
     SharedMoveLocations,
     SharedShopLocations,
     TinyMoveLocations,
@@ -169,7 +168,7 @@ def GetMaxForKong(settings, kong):
         kongMoveLocations = ChunkyMoveLocations.copy()
 
     for location in kongMoveLocations:
-        if location in RemovedShopLocations:  # Ignore any shop locations that don't even exist anymore
+        if LocationList[location].inaccessible:  # Ignore any shop locations that don't even exist anymore
             continue
         item_id = LocationList[location].item
         if item_id is not None and item_id != Items.NoItem:

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -219,7 +219,7 @@ def test_with_settings_string_1():
     # This top one is always the S2 Preset (probably up to date, if it isn't go steal it from the season2.json)
     settings_string = "bKEFiRorPN5ysnPCBogPQ+qBoRDIhKlsa58B+I0eu0uXxCnLE2nBACoMgt1PX4EkAyaBkF1kssFAXQAgwE6gIHA3YBhAI7gQJBXgChQM8gYLB3oDhgQoQ08e2QpHqKhnKlMubRbwM0NjlFuCFRFgMTEUDF61xyN2q/32RQPAZiqcuUOS2EJIIvoE5IMMGY2mMHFosi0rlgVigthoTiwVCkwEwYEYkHERh0AVQA"
     # This one is for ease of testing, go wild with it
-    # settings_string = "baGFiRorPN5yunTChooPw+qhoRDIhKlsa58CCI0ivUyYRCnrGGrBACoUht9QX8EsAycBkF1ls0FAXUAgwE7AIHA3cBhAI8AQJBXkChQM9AYLB3sDhgQow08fGQpnqShoKlsvbTcAM0NjlGuKFRFgMTEUDF+2R2OWvAX6RwPA5kqkuxuiSaxBJBmBBHNCBgzm4yA4tloXFgsiwUlwNCgWisVGEmjEjkk5CQPACsAA"
+    # settings_string = "bKEGiRorPE1ecrJzwgDDEsFX7lGKJD0Pj8Ro9dpcviFmpyxRpgRArdT4mBxJFZ7fgSICJoV5XKJPLJVKYyi+yWWCgLoAQYCdQEDgbsAwgEdwIEgrwBQoGeQMFg70BwwIUIbkPf0UqFHIz0SqXVFpMOBFQFgoTAUAl6qgxTxnWzVgExFMXKHJcCgzaYwcWiyQRALSwWw0YCYMCMaCQcTWHA2fz6IgGIw6AKgA+AA"
 
     settings_dict = decrypt_settings_string_enum(settings_string)
     settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly


### PR DESCRIPTION
- Added a limit to the number of shared shops that can be filled in a seed. The limit is lowered slightly in an attempt to get around Helm problems that I plan on addressing later. The S2 limit is 11 (I don't think anyone has gotten close ever). Kamerson's settings that inspired all this is 7. This number takes into account smaller shops. When the Helm problems are addressed, these numbers may go up by 1, TBD.
- Renamed the "DK Isle" hint region to "Outside DK Isle" to distinguish it from the level "DK Isles"
- Fixed an issue where moves beyond 4 were ineligible for the un-hinting of training moves in my last update
- Added advanced logic transition from Cabin Isle to Upper Isles w/ twirl