### PR TITLE
Shorten Kasplat Names, better fill

### DIFF
--- a/randomizer/Lists/KasplatLocations.py
+++ b/randomizer/Lists/KasplatLocations.py
@@ -44,7 +44,7 @@ KasplatLocationList = {
             region=Regions.BeyondRambiGate,
         ),
         KasplatLocation(
-            name="Japes Kasplat: On top of mountain",
+            name="Japes Kasplat: Top of mountain",
             map_id=Maps.JungleJapes,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1592, 989, 2443],
@@ -66,7 +66,7 @@ KasplatLocationList = {
             region=Regions.JapesBeyondFeatherGate,
         ),
         KasplatLocation(
-            name="Japes Kasplat: Lower area of Tunnel to Beehive",
+            name="Japes Kasplat: Hive Tunnel Lower",
             map_id=Maps.JungleJapes,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2769, 335, 2071],
@@ -74,7 +74,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Japes Kasplat: Upper area of Tunnel to Beehive",
+            name="Japes Kasplat: Hive Tunnel Upper",
             map_id=Maps.JungleJapes,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[3180, 437, 2379],
@@ -91,7 +91,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Japes Kasplat: Near Speedy Swing Sortie Bonus",
+            name="Japes Kasplat: Near Lanky Bonus",
             map_id=Maps.JungleJapes,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2014, 251, 2767],
@@ -154,7 +154,7 @@ KasplatLocationList = {
             additional_logic=lambda l: l.swim and (l.oranges or l.HasGun(Kongs.any) or l.HasInstrument(Kongs.any)),
         ),
         KasplatLocation(
-            name="Japes Kasplat: In the water near Rambi Wall",
+            name="Japes Kasplat: Rambi Water Pool",
             map_id=Maps.JungleJapes,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[382, 140, 2818],
@@ -177,7 +177,7 @@ KasplatLocationList = {
             region=Regions.JapesBeyondCoconutGate2,
         ),
         KasplatLocation(
-            name="Japes Kasplat: In the Troff 'n' Scoff Alcove",
+            name="Japes Kasplat: Hillside Alcove",
             map_id=Maps.JungleJapes,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[773, 538, 2320],
@@ -194,7 +194,7 @@ KasplatLocationList = {
             name="Japes Kasplat: Inside the Shell", map_id=Maps.JapesTinyHive, kong_lst=[Kongs.tiny], coords=[1371, 213, 1400], xmin=1217, xmax=1468, zmin=1288, zmax=1482, region=Regions.TinyHive
         ),
         KasplatLocation(
-            name="Japes Kasplat: Up the Hill to the Painting Room",
+            name="Japes Kasplat: Painting Room Hill",
             map_id=Maps.JungleJapes,
             kong_lst=[Kongs.lanky, Kongs.tiny],
             coords=[544, 370, 1815],
@@ -206,7 +206,7 @@ KasplatLocationList = {
             additional_logic=lambda l: (l.lanky and l.handstand) or (l.tiny and l.twirl) or l.CanMoonkick() or ((l.phasewalk or l.generalclips) and (l.istiny or l.isdiddy)),
         ),
         KasplatLocation(
-            name="Japes Kasplat: In the Minecart Exit",
+            name="Japes Kasplat: Minecart Exit",
             map_id=Maps.JungleJapes,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1105, 290, 1965],
@@ -219,7 +219,7 @@ KasplatLocationList = {
     ],
     Levels.AngryAztec: [
         KasplatLocation(
-            name="Aztec Kasplat: In the Sealed Quicksand Tunnel",
+            name="Aztec Kasplat: DK Quicksand Tunnel",
             map_id=Maps.AngryAztec,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2738, 120, 4763],
@@ -241,7 +241,7 @@ KasplatLocationList = {
             region=Regions.AngryAztecOasis,
         ),
         KasplatLocation(
-            name="Aztec Kasplat: On the Llama's Cage",
+            name="Aztec Kasplat: On Llama Cage",
             map_id=Maps.AngryAztec,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2130, 310, 1588],
@@ -253,7 +253,7 @@ KasplatLocationList = {
             additional_logic=lambda l: l.vines or (l.jetpack and l.isdiddy) or (l.advanced_platforming and (l.istiny or l.isdiddy)) or l.CanMoonkick(),
         ),
         KasplatLocation(
-            name="Aztec Kasplat: Near the giant boulder",
+            name="Aztec Kasplat: Near giant boulder",
             map_id=Maps.AngryAztec,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[3782, 120, 2391],
@@ -264,7 +264,7 @@ KasplatLocationList = {
             region=Regions.AngryAztecConnectorTunnel,
         ),
         KasplatLocation(
-            name="Aztec Kasplat: Behind the DK Stone Door",
+            name="Aztec Kasplat: Behind DK Stone Door",
             map_id=Maps.AngryAztec,
             kong_lst=[Kongs.donkey, Kongs.tiny],
             coords=[1363, 162, 738],
@@ -273,7 +273,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Aztec Kasplat: In the lava room in Llama Temple",
+            name="Aztec Kasplat: Llama Temple Lava",
             map_id=Maps.AztecLlamaTemple,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1378, 420, 3632],
@@ -281,7 +281,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Aztec Kasplat: Near the Hunky Chunky Barrel",
+            name="Aztec Kasplat: Hunky Chunky Barrel",
             map_id=Maps.AngryAztec,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[3162, 120, 1845],
@@ -310,7 +310,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Aztec Kasplat: In the Vase Room",
+            name="Aztec Kasplat: In Vase Room",
             map_id=Maps.AngryAztec,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[406, 138, 701],
@@ -322,7 +322,7 @@ KasplatLocationList = {
             additional_logic=lambda l: (l.chunky and l.pineapple) or l.phasewalk,
         ),
         KasplatLocation(
-            name="Aztec Kasplat: Behind the 5-Door Temple",
+            name="Aztec Kasplat: Behind 5-Door Temple",
             map_id=Maps.AngryAztec,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1997, 280, 3500],
@@ -344,7 +344,7 @@ KasplatLocationList = {
             region=Regions.AngryAztecMain,
         ),
         KasplatLocation(
-            name="Aztec Kasplat: Below the Llama in Llama Temple",
+            name="Aztec Kasplat: By the Llama in his Temple",
             map_id=Maps.AztecLlamaTemple,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1964, 472, 2408],
@@ -355,7 +355,7 @@ KasplatLocationList = {
             region=Regions.LlamaTemple,
         ),
         KasplatLocation(
-            name="Aztec Kasplat: In the Free Tiny Room",
+            name="Aztec Kasplat: Free Tiny Room",
             map_id=Maps.AztecTinyTemple,
             kong_lst=[Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[453, 345, 1465],
@@ -366,7 +366,7 @@ KasplatLocationList = {
             region=Regions.TempleUnderwater,
         ),
         KasplatLocation(
-            name="Aztec Kasplat: In Chunky 5-Door Temple",
+            name="Aztec Kasplat: Chunky 5-Door Temple",
             map_id=Maps.AztecChunky5DTemple,
             kong_lst=[Kongs.chunky],
             coords=[936, 122, 2027],
@@ -386,7 +386,7 @@ KasplatLocationList = {
             region=Regions.AngryAztecMain,
         ),
         KasplatLocation(
-            name="Aztec Kasplat: Inside the Llama Temple Matching Game",
+            name="Aztec Kasplat: Lanky Matching Game",
             map_id=Maps.AztecLlamaTemple,
             kong_lst=[Kongs.lanky],
             coords=[1080, 642, 2240],
@@ -411,7 +411,7 @@ KasplatLocationList = {
         #     additional_logic=lambda l: l.HasInstrument(l.settings.lanky_freeing_kong),
         # ),
         KasplatLocation(
-            name="Aztec Kasplat: Inside Tiny Temple by Mini Monkey Barrel",
+            name="Aztec Kasplat: Tiny Temple Mini Monkey",
             map_id=Maps.AztecTinyTemple,
             kong_lst=[Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1767, 330, 1093],
@@ -422,7 +422,7 @@ KasplatLocationList = {
             region=Regions.TempleStart,
         ),
         KasplatLocation(
-            name="Aztec Kasplat: In Donkey 5-Door Temple",
+            name="Aztec Kasplat: Donkey 5-Door Temple",
             map_id=Maps.AztecDonkey5DTemple,
             kong_lst=[Kongs.donkey],
             coords=[726, 58, 677],
@@ -447,7 +447,7 @@ KasplatLocationList = {
             region=Regions.FranticFactoryStart,
         ),
         KasplatLocation(
-            name="Factory Kasplat: Near the Power Hut",
+            name="Factory Kasplat: Near Power Hut",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1464, 127, 865],
@@ -458,7 +458,7 @@ KasplatLocationList = {
             region=Regions.ChunkyRoomPlatform,
         ),
         KasplatLocation(
-            name="Factory Kasplat: Down the pole covered by a Hatch",
+            name="Factory Kasplat: Down the Hatch Pole",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[646, 460, 1792],
@@ -469,7 +469,7 @@ KasplatLocationList = {
             region=Regions.LowerCore,  # This guy is weird - no good logic region to put him in besides Production Room
         ),
         KasplatLocation(
-            name="Factory Kasplat: In the Dark Room",
+            name="Factory Kasplat: Dark Room",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2053, 7, 573],
@@ -481,7 +481,7 @@ KasplatLocationList = {
             additional_logic=lambda l: (l.punch and l.chunky) or l.phasewalk,
         ),
         KasplatLocation(
-            name="Factory Kasplat: On the lowest platform in Production Room",
+            name="Factory Kasplat: Lowest Production Platform",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[633, 157, 1672],
@@ -492,7 +492,7 @@ KasplatLocationList = {
             region=Regions.MiddleCore,
         ),
         KasplatLocation(
-            name="Factory Kasplat: Near the slippery pipe in Production Room",
+            name="Factory Kasplat: Upper Production Pipe",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[782, 557, 1686],
@@ -500,7 +500,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Factory Kasplat: At the base of Production Room",
+            name="Factory Kasplat: Base of Production",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[509, 0, 1591],
@@ -508,7 +508,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Factory Kasplat: In Research and Development",
+            name="Factory Kasplat: Research and Development",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[4148, 1336, 1016],
@@ -516,7 +516,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Factory Kasplat: Below the pole to the DK Arcade Machine",
+            name="Factory Kasplat: Pole to Arcade",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1296, 6, 240],
@@ -524,7 +524,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Factory Kasplat: In Block Tower Room",
+            name="Factory Kasplat: Block Tower",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2234, 1026, 1372],
@@ -555,11 +555,9 @@ KasplatLocationList = {
             zmax=2240,
             region=Regions.Testing,
         ),
+        KasplatLocation(name="Factory Kasplat: Power Hut", map_id=Maps.FactoryPowerHut, kong_lst=[Kongs.donkey], coords=[116, 2, 121], xmin=68, xmax=151, zmin=66, zmax=154, region=Regions.PowerHut),
         KasplatLocation(
-            name="Factory Kasplat: In the Power Shed", map_id=Maps.FactoryPowerHut, kong_lst=[Kongs.donkey], coords=[116, 2, 121], xmin=68, xmax=151, zmin=66, zmax=154, region=Regions.PowerHut
-        ),
-        KasplatLocation(
-            name="Factory Kasplat: In Research and Development by the Slot Car Race",
+            name="Factory Kasplat: By Car Race",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[3701, 1264, 1405],
@@ -570,7 +568,7 @@ KasplatLocationList = {
             region=Regions.RandD,
         ),
         KasplatLocation(
-            name="Factory Kasplat: Inside Tiny's Shooting Game",
+            name="Factory Kasplat: Tiny Shooting Game",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.tiny],
             coords=[2504, 1107, 938],
@@ -582,7 +580,7 @@ KasplatLocationList = {
             additional_logic=lambda l: l.mini or l.phasewalk,
         ),
         KasplatLocation(
-            name="Factory Kasplat: Inside the Crusher Room",
+            name="Factory Kasplat: Crusher Room",
             map_id=Maps.FactoryCrusher,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[484, 1, 491],
@@ -593,7 +591,7 @@ KasplatLocationList = {
             region=Regions.InsideCore,
         ),
         KasplatLocation(
-            name="Factory Kasplat: Past the Tiny Bonus Barrel in Upper Production",
+            name="Factory Kasplat: Upper Production Twirl",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.tiny],
             coords=[380, 859, 1600],
@@ -605,7 +603,7 @@ KasplatLocationList = {
             additional_logic=lambda l: l.twirl,
         ),
         KasplatLocation(
-            name="Factory Kasplat: In Lanky's Piano Game",
+            name="Factory Kasplat: Lanky Piano Game",
             map_id=Maps.FranticFactory,
             kong_lst=[Kongs.lanky],
             coords=[3504, 1265, 550],
@@ -619,7 +617,7 @@ KasplatLocationList = {
     ],
     Levels.GloomyGalleon: [
         KasplatLocation(
-            name="Galleon Kasplat: On the Lighthouse island",
+            name="Galleon Kasplat: Lighthouse Platform",
             map_id=Maps.GloomyGalleon,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1631, 1611, 4162],
@@ -642,7 +640,7 @@ KasplatLocationList = {
         #     region=Regions.Shipyard,
         # ),
         KasplatLocation(
-            name="Galleon Kasplat: On Diddy's Gold Tower",
+            name="Galleon Kasplat: Diddy Gold Tower",
             map_id=Maps.GloomyGalleon,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2037, 1750, 769],
@@ -650,7 +648,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Galleon Kasplat: In the Alcove near the Lighthouse",
+            name="Galleon Kasplat: Lighthouse Alcove",
             map_id=Maps.GloomyGalleon,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[699, 1564, 4093],
@@ -658,7 +656,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Galleon Kasplat: On the platforms in Cannon Game Room",
+            name="Galleon Kasplat: Cannon Game Room",
             map_id=Maps.GloomyGalleon,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1308, 1610, 2794],
@@ -667,7 +665,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Galleon Kasplat: Near the Troff 'n' Scoff near Cranky's",
+            name="Galleon Kasplat: Past Vines",
             map_id=Maps.GloomyGalleon,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2806, 1890, 2969],
@@ -675,7 +673,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Galleon Kasplat: On the Cactus near the sunken submarine",
+            name="Galleon Kasplat: Musical Cactus",
             map_id=Maps.GloomyGalleon,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[4372, 1650, 1031],
@@ -718,7 +716,7 @@ KasplatLocationList = {
             region=Regions.GloomyGalleonStart,
         ),
         KasplatLocation(
-            name="Galleon Kasplat: Inside the Lighthouse at the Top",
+            name="Galleon Kasplat: Atop Whomp's Lighthouse",
             map_id=Maps.GalleonLighthouse,
             kong_lst=[Kongs.donkey],
             coords=[448, 721, 514],
@@ -729,10 +727,10 @@ KasplatLocationList = {
             region=Regions.Lighthouse,
         ),
         KasplatLocation(
-            name="Galleon Kasplat: Inside the Mechfish", map_id=Maps.GalleonMechafish, kong_lst=[Kongs.diddy], coords=[314, 25, 528], xmin=303, xmax=322, zmin=497, zmax=537, region=Regions.Mechafish
+            name="Galleon Kasplat: In the Mechfish", map_id=Maps.GalleonMechafish, kong_lst=[Kongs.diddy], coords=[314, 25, 528], xmin=303, xmax=322, zmin=497, zmax=537, region=Regions.Mechafish
         ),
         KasplatLocation(
-            name="Galleon Kasplat: On Lanky's Gold Tower",
+            name="Galleon Kasplat: Lanky Gold Tower",
             map_id=Maps.GloomyGalleon,
             kong_lst=[Kongs.lanky],
             coords=[1658, 2042, 490],
@@ -744,11 +742,9 @@ KasplatLocationList = {
             additional_logic=lambda l: (Events.WaterSwitch in l.Events or (Events.ShipyardEnguarde in l.Events and Events.ShipyardTreasureRoomOpened in l.Events and l.advanced_platforming))
             and l.balloon,
         ),
+        KasplatLocation(name="Galleon Kasplat: Sickbay", map_id=Maps.GalleonSickBay, kong_lst=[Kongs.chunky], coords=[571, 21, 922], xmin=522, xmax=637, zmin=852, zmax=944, region=Regions.SickBay),
         KasplatLocation(
-            name="Galleon Kasplat: In Chunky's Drunk Ship", map_id=Maps.GalleonSickBay, kong_lst=[Kongs.chunky], coords=[571, 21, 922], xmin=522, xmax=637, zmin=852, zmax=944, region=Regions.SickBay
-        ),
-        KasplatLocation(
-            name="Galleon Kasplat: On the Middle Deck of the Shipwreck",
+            name="Galleon Kasplat: Middle Deck of Shipwreck",
             map_id=Maps.GloomyGalleon,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[3076, 1791, 3377],
@@ -770,7 +766,7 @@ KasplatLocationList = {
             region=Regions.GloomyGalleonStart,
         ),
         KasplatLocation(
-            name="Galleon Kasplat: Inside a Punchable Chest",
+            name="Galleon Kasplat: Inside Punchable Chest",
             map_id=Maps.GloomyGalleon,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[3537, 1671, 3905],
@@ -782,7 +778,7 @@ KasplatLocationList = {
             additional_logic=lambda l: l.punch and l.chunky,
         ),
         KasplatLocation(
-            name="Galleon Kasplat: Also on the Cactus near the sunken submarine",
+            name="Galleon Kasplat: Also Musical Cactus",
             map_id=Maps.GloomyGalleon,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[4398, 1651, 1007],
@@ -795,7 +791,7 @@ KasplatLocationList = {
     ],
     Levels.FungiForest: [
         KasplatLocation(
-            name="Forest Kasplat: Behind the Diddy Dark Barn",
+            name="Forest Kasplat: Behind Diddy Barn",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[3150, 273, 4332],
@@ -806,7 +802,7 @@ KasplatLocationList = {
             region=Regions.MillArea,
         ),
         KasplatLocation(
-            name="Forest Kasplat: Behind the beanstalk",
+            name="Forest Kasplat: Behind beanstalk",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1853, 230, 473],
@@ -817,7 +813,7 @@ KasplatLocationList = {
             region=Regions.WormArea,
         ),
         KasplatLocation(
-            name="Forest Kasplat: Near the rocketbarrel near the Giant Mushroom",
+            name="Forest Kasplat: By Giant Mushroom Rocketbarrel",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[183, 241, 756],
@@ -828,7 +824,7 @@ KasplatLocationList = {
             region=Regions.GiantMushroomArea,
         ),
         KasplatLocation(
-            name="Forest Kasplat: On the top floor of the Giant Mushroom",
+            name="Forest Kasplat: Giant Mushroom Top Floor",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[850, 1250, 550],
@@ -851,7 +847,7 @@ KasplatLocationList = {
         #     region=Regions.HollowTreeArea,
         # ),
         KasplatLocation(
-            name="Forest Kasplat: Near the sleeping Rabbit",
+            name="Forest Kasplat: Near the Rabbit",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2335, 143, 3639],
@@ -862,7 +858,7 @@ KasplatLocationList = {
             region=Regions.HollowTreeArea,
         ),
         KasplatLocation(
-            name="Forest Kasplat: Near the Troff 'n' Scoff near the Owl's Tree",
+            name="Forest Kasplat: Owl Tree Troff",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[543, 194, 3748],
@@ -881,7 +877,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Forest Kasplat: Inside the Giant Mushroom",
+            name="Forest Kasplat: Inside Giant Mushroom",
             map_id=Maps.ForestGiantMushroom,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[329, 534, 402],
@@ -889,7 +885,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Forest Kasplat: Under the Owl's Tree",
+            name="Forest Kasplat: Under Owl Tree",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1270, 249, 3927],
@@ -897,7 +893,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Forest Kasplat: On a low platform on the exterior of Giant Mushroom",
+            name="Forest Kasplat: Low Mushroom Exterior",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1209, 389, 678],
@@ -905,7 +901,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Forest Kasplat: On a high platform on the exterior of Giant Mushroom",
+            name="Forest Kasplat: Mushroom Night Door",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[732, 979, 597],
@@ -913,7 +909,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Forest Kasplat: Behind the Cuckoo Clock",
+            name="Forest Kasplat: Behind Cuckoo Clock",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2297, 604, 2318],
@@ -924,7 +920,7 @@ KasplatLocationList = {
             region=Regions.FungiForestStart,
         ),
         KasplatLocation(
-            name="Forest Kasplat: Inside the mill",
+            name="Forest Kasplat: Grinder Room",
             map_id=Maps.ForestMillFront,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[360, 0, 450],
@@ -935,7 +931,7 @@ KasplatLocationList = {
             region=Regions.GrinderRoom,
         ),
         KasplatLocation(
-            name="Forest Kasplat: In the moat around the Giant Mushroom",
+            name="Forest Kasplat: Giant Mushroom Moat",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1009, 100, 576],
@@ -947,7 +943,7 @@ KasplatLocationList = {
             additional_logic=lambda l: l.swim and (l.oranges or l.HasGun(Kongs.any) or l.HasInstrument(Kongs.any)),
         ),
         KasplatLocation(
-            name="Forest Kasplat: At the very top of the Giant Mushroom",
+            name="Forest Kasplat: Giant Mushroom Peak",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.diddy, Kongs.lanky],
             coords=[949, 1501, 1010],
@@ -959,7 +955,7 @@ KasplatLocationList = {
             additional_logic=lambda l: l.jetpack or l.handstand,
         ),
         KasplatLocation(
-            name="Forest Kasplat: On the Mill Roof",
+            name="Forest Kasplat: On Mill Roof",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[4275, 377, 3639],
@@ -970,7 +966,7 @@ KasplatLocationList = {
             region=Regions.MillArea,
         ),
         KasplatLocation(
-            name="Forest Kasplat: In the Minecart Exit Well",
+            name="Forest Kasplat: Minecart Exit Well",
             map_id=Maps.FungiForest,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[5352, 240, 3677],
@@ -981,7 +977,7 @@ KasplatLocationList = {
             region=Regions.MillArea,
         ),
         KasplatLocation(
-            name="Forest Kasplat: In the Lanky Mushroom Slam Room",
+            name="Forest Kasplat: Lanky Mushroom Slam Room",
             map_id=Maps.ForestLankyMushroomsRoom,
             kong_lst=[Kongs.lanky],
             coords=[289, 2, 308],
@@ -991,14 +987,10 @@ KasplatLocationList = {
             zmax=344,
             region=Regions.MushroomLankyMushroomsRoom,
         ),
+        KasplatLocation(name="Forest Kasplat: Spider Boss", map_id=Maps.ForestSpider, kong_lst=[Kongs.tiny], coords=[275, 173, 722], xmin=208, xmax=358, zmin=653, zmax=780, region=Regions.SpiderRoom),
+        KasplatLocation(name="Forest Kasplat: Winch Room", map_id=Maps.ForestWinchRoom, kong_lst=[Kongs.diddy], coords=[300, 1, 280], xmin=267, xmax=336, zmin=227, zmax=335, region=Regions.WinchRoom),
         KasplatLocation(
-            name="Forest Kasplat: In the Spider Boss", map_id=Maps.ForestSpider, kong_lst=[Kongs.tiny], coords=[275, 173, 722], xmin=208, xmax=358, zmin=653, zmax=780, region=Regions.SpiderRoom
-        ),
-        KasplatLocation(
-            name="Forest Kasplat: In the Winch Room", map_id=Maps.ForestWinchRoom, kong_lst=[Kongs.diddy], coords=[300, 1, 280], xmin=267, xmax=336, zmin=227, zmax=335, region=Regions.WinchRoom
-        ),
-        KasplatLocation(
-            name="Forest Kasplat: In Chunky's Face Shooting Room",
+            name="Forest Kasplat: Face Shooting Room",
             map_id=Maps.ForestChunkyFaceRoom,
             kong_lst=[Kongs.chunky],
             coords=[248, 1, 294],
@@ -1022,7 +1014,7 @@ KasplatLocationList = {
             region=Regions.CavesSnideArea,
         ),
         KasplatLocation(
-            name="Caves Kasplat: In the room with Tiny's Bonus Barrel",
+            name="Caves Kasplat: Bonus Barrel Cave",
             map_id=Maps.CrystalCaves,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[485, 181, 2495],
@@ -1033,7 +1025,7 @@ KasplatLocationList = {
             region=Regions.CavesBonusCave,
         ),
         KasplatLocation(
-            name="Caves Kasplat: Inside an Ice Shield",
+            name="Caves Kasplat: Inside Ice Shield",
             map_id=Maps.CrystalCaves,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[768, 50, 801],
@@ -1045,7 +1037,7 @@ KasplatLocationList = {
             additional_logic=lambda l: Events.CavesLargeBoulderButton in l.Events or (l.generalclips and l.ischunky),
         ),
         KasplatLocation(
-            name="Caves Kasplat: On the Cabin with 5 Doors",
+            name="Caves Kasplat: On 5-Door Cabin",
             map_id=Maps.CrystalCaves,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[3645, 343, 1865],
@@ -1056,7 +1048,7 @@ KasplatLocationList = {
             region=Regions.CabinArea,
         ),
         KasplatLocation(
-            name="Caves Kasplat: Across the river from Candy's",
+            name="Caves Kasplat: Across river from Candy",
             map_id=Maps.CrystalCaves,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[3003, 123, 1569],
@@ -1067,7 +1059,7 @@ KasplatLocationList = {
             region=Regions.CabinArea,
         ),
         KasplatLocation(
-            name="Caves Kasplat: In the room with the Giant Boulder",
+            name="Caves Kasplat: Giant Boulder Room",
             map_id=Maps.CrystalCaves,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1915, 280, 2676],
@@ -1078,7 +1070,7 @@ KasplatLocationList = {
             region=Regions.BoulderCave,
         ),
         KasplatLocation(
-            name="Caves Kasplat: Near the Ice Castle",
+            name="Caves Kasplat: Near Ice Castle",
             map_id=Maps.CrystalCaves,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1705, 285, 745],
@@ -1086,10 +1078,10 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Caves Kasplat: In the Hidden Room by Funky's", map_id=Maps.CrystalCaves, kong_lst=[Kongs.diddy, Kongs.tiny], coords=[3517, 286, 767], region=Regions.CavesBlueprintCave, vanilla=True
+            name="Caves Kasplat: Mini Room by Funky", map_id=Maps.CrystalCaves, kong_lst=[Kongs.diddy, Kongs.tiny], coords=[3517, 286, 767], region=Regions.CavesBlueprintCave, vanilla=True
         ),
         KasplatLocation(
-            name="Caves Kasplat: On the platform near Funky's",
+            name="Caves Kasplat: On the Pillar",
             map_id=Maps.CrystalCaves,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2783, 366, 927],
@@ -1105,7 +1097,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Caves Kasplat: On the 5-Door Igloo",
+            name="Caves Kasplat: On 5-Door Igloo",
             map_id=Maps.CrystalCaves,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[577, 142, 1285],
@@ -1113,7 +1105,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Caves Kasplat: In the water by the Baboon Blast Pad",
+            name="Caves Kasplat: Water by Blast Pad",
             map_id=Maps.CrystalCaves,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1340, 14, 2047],
@@ -1124,7 +1116,7 @@ KasplatLocationList = {
             region=Regions.CrystalCavesMain,
         ),
         KasplatLocation(
-            name="Caves Kasplat: Inbetween Funky's and the Ice Castle",
+            name="Caves Kasplat: Between Funky and Castle",
             map_id=Maps.CrystalCaves,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2659, 140, 1158],
@@ -1135,7 +1127,7 @@ KasplatLocationList = {
             region=Regions.CrystalCavesMain,
         ),
         KasplatLocation(
-            name="Caves Kasplat: At the Start of the Beetle Race",
+            name="Caves Kasplat: In the Beetle Race",
             map_id=Maps.CavesLankyRace,
             kong_lst=[Kongs.lanky],
             coords=[1367, 5111, 647],
@@ -1149,10 +1141,10 @@ KasplatLocationList = {
             name="Caves Kasplat: With the Giant Kosha", map_id=Maps.CrystalCaves, kong_lst=[Kongs.tiny], coords=[1768, 232, 3645], xmin=1753, xmax=1892, zmin=3543, zmax=3675, region=Regions.GiantKosha
         ),
         KasplatLocation(
-            name="Caves Kasplat: In Diddy's Igloo", map_id=Maps.CavesDiddyIgloo, kong_lst=[Kongs.diddy], coords=[265, 1, 290], xmin=192, xmax=333, zmin=201, zmax=391, region=Regions.DiddyIgloo
+            name="Caves Kasplat: In Diddy Igloo", map_id=Maps.CavesDiddyIgloo, kong_lst=[Kongs.diddy], coords=[265, 1, 290], xmin=192, xmax=333, zmin=201, zmax=391, region=Regions.DiddyIgloo
         ),
         KasplatLocation(
-            name="Caves Kasplat: In Donkey's Shooting Cabin",
+            name="Caves Kasplat: DK Shooting Cabin",
             map_id=Maps.CavesDonkeyCabin,
             kong_lst=[Kongs.donkey],
             coords=[377, 1, 429],
@@ -1163,7 +1155,7 @@ KasplatLocationList = {
             region=Regions.DonkeyCabin,
         ),
         KasplatLocation(
-            name="Caves Kasplat: In the Gorilla Gone Cave",
+            name="Caves Kasplat: Gorilla Gone Cave",
             map_id=Maps.CrystalCaves,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2578, 14, 426],
@@ -1199,7 +1191,7 @@ KasplatLocationList = {
             region=Regions.LowerCave,
         ),
         KasplatLocation(
-            name="Castle Kasplat: Inside the Dungeon",
+            name="Castle Kasplat: Dungeon Center",
             map_id=Maps.CastleDungeon,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[526, 195, 2013],
@@ -1210,7 +1202,7 @@ KasplatLocationList = {
             region=Regions.Dungeon,
         ),
         KasplatLocation(
-            name="Castle Kasplat: Near the Troff 'n' Scoff at the back of Castle",
+            name="Castle Kasplat: Back of Castle Troff",
             map_id=Maps.CreepyCastle,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1655, 371, 2048],
@@ -1221,7 +1213,7 @@ KasplatLocationList = {
             region=Regions.CreepyCastleMain,
         ),
         KasplatLocation(
-            name="Castle Kasplat: Inside the Ballroom",
+            name="Castle Kasplat: Ballroom",
             map_id=Maps.CastleBallroom,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[547, 45, 613],
@@ -1232,7 +1224,7 @@ KasplatLocationList = {
             region=Regions.Ballroom,
         ),
         KasplatLocation(
-            name="Castle Kasplat: At the top of the Castle",
+            name="Castle Kasplat: Castle Top Level",
             map_id=Maps.CreepyCastle,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1388, 1732, 1353],
@@ -1252,7 +1244,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Castle Kasplat: In the Lower Cave straight ahead",
+            name="Castle Kasplat: Lower Cave Center",
             map_id=Maps.CastleLowerCave,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1112, 200, 1242],
@@ -1260,7 +1252,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Castle Kasplat: Near the upper Warp 2",
+            name="Castle Kasplat: Near Upper Warp 2",
             map_id=Maps.CreepyCastle,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1892, 904, 1626],
@@ -1268,7 +1260,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Castle Kasplat: Near the Crypt Entrance on a lone platform",
+            name="Castle Kasplat: On a lone platform",
             map_id=Maps.CreepyCastle,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[66, 392, 911],
@@ -1284,7 +1276,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Castle Kasplat: In the water near the Tree",
+            name="Castle Kasplat: Tree Pond",
             map_id=Maps.CreepyCastle,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[845, 330, 235],
@@ -1307,7 +1299,7 @@ KasplatLocationList = {
             region=Regions.CreepyCastleMain,
         ),
         KasplatLocation(
-            name="Castle Kasplat: Near the Rocketbarrel by the drawbridge",
+            name="Castle Kasplat: Lower Rocketbarrel",
             map_id=Maps.CreepyCastle,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[195, 623, 542],
@@ -1318,7 +1310,7 @@ KasplatLocationList = {
             region=Regions.CreepyCastleMain,
         ),
         KasplatLocation(
-            name="Castle Kasplat: Inside the Greenhouse Maze",
+            name="Castle Kasplat: Greenhouse",
             map_id=Maps.CastleGreenhouse,
             kong_lst=[Kongs.lanky],
             coords=[347, 1, 596],
@@ -1329,7 +1321,7 @@ KasplatLocationList = {
             region=Regions.Greenhouse,
         ),
         KasplatLocation(
-            name="Castle Kasplat: By the Mysterious Pedestal in the Museum",
+            name="Castle Kasplat: Museum Mysterious Pedestal",
             map_id=Maps.CastleMuseum,
             kong_lst=[Kongs.tiny],
             coords=[1007, 201, 1509],
@@ -1341,7 +1333,7 @@ KasplatLocationList = {
             additional_logic=lambda l: l.monkeyport or l.phasewalk,
         ),
         KasplatLocation(
-            name="Castle Kasplat: In a Cage in the Dungeon",
+            name="Castle Kasplat: Caged in the Dungeon",
             map_id=Maps.CastleDungeon,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[800, 196, 2216],
@@ -1353,7 +1345,7 @@ KasplatLocationList = {
             additional_logic=lambda l: l.punch or l.phasewalk,
         ),
         KasplatLocation(
-            name="Castle Kasplat: By the Entrance to the Minecart",
+            name="Castle Kasplat: Entrance to Minecart",
             map_id=Maps.CastleCrypt,
             kong_lst=[Kongs.donkey],
             coords=[1517, 196, 2316],
@@ -1364,9 +1356,7 @@ KasplatLocationList = {
             region=Regions.Crypt,
             additional_logic=lambda l: l.coconut or l.phasewalk or l.generalclips,
         ),
-        KasplatLocation(
-            name="Castle Kasplat: In the Library", map_id=Maps.CastleLibrary, kong_lst=[Kongs.donkey], coords=[354, 191, 495], xmin=257, xmax=430, zmin=456, zmax=573, region=Regions.Library
-        ),
+        KasplatLocation(name="Castle Kasplat: Library", map_id=Maps.CastleLibrary, kong_lst=[Kongs.donkey], coords=[354, 191, 495], xmin=257, xmax=430, zmin=456, zmax=573, region=Regions.Library),
         KasplatLocation(
             name="Castle Kasplat: In the Clouds",
             map_id=Maps.CreepyCastle,
@@ -1382,7 +1372,7 @@ KasplatLocationList = {
     ],
     Levels.DKIsles: [
         KasplatLocation(
-            name="Isles Kasplat: On the Beaver Beach",
+            name="Isles Kasplat: Beaver Beach",
             map_id=Maps.Isles,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[3557, 497, 1555],
@@ -1393,7 +1383,7 @@ KasplatLocationList = {
             region=Regions.IslesMain,
         ),
         KasplatLocation(
-            name="Isles Kasplat: Inside Factory Lobby above the DK Portal",
+            name="Isles Kasplat: Factory Lobby above Portal",
             map_id=Maps.FranticFactoryLobby,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[676, 134, 372],
@@ -1405,7 +1395,7 @@ KasplatLocationList = {
             additional_logic=lambda l: (l.grab and l.donkey) or l.CanMoonkick() or (l.advanced_platforming and (l.istiny or l.isdiddy or l.ischunky)),
         ),
         KasplatLocation(
-            name="Isles Kasplat: Inside Hideout Helm Lobby",
+            name="Isles Kasplat: Helm Lobby",
             map_id=Maps.HideoutHelmLobby,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[335, 191, 637],
@@ -1414,7 +1404,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Isles Kasplat: Inside Creepy Castle Lobby",
+            name="Isles Kasplat: Castle Lobby",
             map_id=Maps.CreepyCastleLobby,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[577, 71, 766],
@@ -1423,7 +1413,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Isles Kasplat: Inside Crystal Caves Lobby",
+            name="Isles Kasplat: Caves Lobby Punch",
             map_id=Maps.CrystalCavesLobby,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1674, 13, 685],
@@ -1432,7 +1422,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Isles Kasplat: Inside Factory Lobby in the ? Box",
+            name="Isles Kasplat: Factory Lobby Box",
             map_id=Maps.FranticFactoryLobby,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[244, 20, 155],
@@ -1441,7 +1431,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Isles Kasplat: Inside Gloomy Galleon Lobby",
+            name="Isles Kasplat: Galleon Lobby",
             map_id=Maps.GloomyGalleonLobby,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[762, 119, 900],
@@ -1449,7 +1439,7 @@ KasplatLocationList = {
             vanilla=True,
         ),
         KasplatLocation(
-            name="Isles Kasplat: Inside the Rock which is blown up",
+            name="Isles Kasplat: Inside Big Rock",
             map_id=Maps.Isles,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[4449, 552, 1673],
@@ -1461,7 +1451,7 @@ KasplatLocationList = {
             additional_logic=lambda l: Events.IslesChunkyBarrelSpawn in l.Events and l.hunkyChunky and l.Slam and l.chunky,
         ),
         KasplatLocation(
-            name="Isles Kasplat: At the back of Kroc Isle halfway up",
+            name="Isles Kasplat: Back of Kroc Isle Middle",
             map_id=Maps.Isles,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2357, 1199, 3903],
@@ -1472,7 +1462,7 @@ KasplatLocationList = {
             region=Regions.KremIsleBeyondLift,
         ),
         KasplatLocation(
-            name="Isles Kasplat: On the Big X Platform",
+            name="Isles Kasplat: Big X Platform",
             map_id=Maps.Isles,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1578, 499, 457],
@@ -1483,7 +1473,7 @@ KasplatLocationList = {
             region=Regions.IslesMain,
         ),
         KasplatLocation(
-            name="Isles Kasplat: Behind the house to Fungi Lobby",
+            name="Isles Kasplat: Back of Cabin Isle",
             map_id=Maps.Isles,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2449, 1498, 785],
@@ -1494,7 +1484,7 @@ KasplatLocationList = {
             region=Regions.CabinIsle,
         ),
         KasplatLocation(
-            name="Isles Kasplat: On the upper platform in Caves Lobby",
+            name="Isles Kasplat: Caves Lobby Platform",
             map_id=Maps.CrystalCavesLobby,
             kong_lst=[Kongs.diddy],
             coords=[794, 281, 707],
@@ -1519,7 +1509,7 @@ KasplatLocationList = {
         #     additional_logic=lambda l: (l.settings.open_lobbies or Events.ForestKeyTurnedIn in l.Events) and (l.donkey or l.chunky or (l.tiny and l.twirl)),
         # ),
         KasplatLocation(
-            name="Isles Kasplat: Behind the Feather Gate in Aztec Lobby",
+            name="Isles Kasplat: Aztec Lobby Feather Gate",
             map_id=Maps.AngryAztecLobby,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1073, 1, 675],
@@ -1535,7 +1525,7 @@ KasplatLocationList = {
         #     name="Isles Kasplat: Inside Fairy Isle", map_id=Maps.BananaFairyRoom, kong_lst=[Kongs.tiny], coords=[493, 38, 334], xmin=471, xmax=553, zmin=277, zmax=374, region=Regions.BananaFairyRoom
         # ),
         KasplatLocation(
-            name="Isles Kasplat: Inside the Prison Sprint Cage",
+            name="Isles Kasplat: Prison Sprint Cage",
             map_id=Maps.KLumsy,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1328, 96, 373],
@@ -1547,7 +1537,7 @@ KasplatLocationList = {
             additional_logic=lambda l: (l.sprint and l.lanky) or l.phasewalk,
         ),
         KasplatLocation(
-            name="Isles Kasplat: Inside Jungle Japes Lobby",
+            name="Isles Kasplat: Japes Lobby",
             map_id=Maps.JungleJapesLobby,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[456, 5, 528],
@@ -1558,7 +1548,7 @@ KasplatLocationList = {
             region=Regions.JungleJapesLobby,
         ),
         KasplatLocation(
-            name="Isles Kasplat: By the Upper Monkeyport Pad",
+            name="Isles Kasplat: Upper Monkeyport",
             map_id=Maps.Isles,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2420, 1721, 3883],
@@ -1580,7 +1570,7 @@ KasplatLocationList = {
             region=Regions.IslesSnideRoom,
         ),
         KasplatLocation(
-            name="Isles Kasplat: On top of Angry Aztec Lobby",
+            name="Isles Kasplat: Aztec Lobby Roof",
             map_id=Maps.Isles,
             kong_lst=[Kongs.diddy],
             coords=[3510, 1175, 1739],
@@ -1591,7 +1581,7 @@ KasplatLocationList = {
             region=Regions.AztecLobbyRoof,
         ),
         KasplatLocation(
-            name="Isles Kasplat: Beneath the Waterfall",
+            name="Isles Kasplat: Waterfall Pool",
             map_id=Maps.Isles,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[2966, 410, 1108],

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -196,21 +196,21 @@ LocationList = {
     Locations.IslesDiddySnidesLobby: Location(Levels.DKIsles, "Isles Diddy Snides Spring Barrel", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(0, -1, 416, Kongs.diddy)]),
     Locations.IslesBattleArena1: Location(Levels.DKIsles, "Isles Battle Arena 1 (Snide's Room: Under Rock)", Items.BattleCrown, Types.Crown, Kongs.any, [MapIDCombo(Maps.SnidesCrown, -1, 615)]),
     Locations.IslesDonkeyInstrumentPad: Location(Levels.DKIsles, "Isles Donkey Bongos Pad", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(0, -1, 404, Kongs.donkey)]),
-    Locations.IslesKasplatFactoryLobby: Location(Levels.DKIsles, "Isles Kasplat: Inside Factory Lobby in the ? Box", Items.DKIslesTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.FranticFactoryLobby]),
+    Locations.IslesKasplatFactoryLobby: Location(Levels.DKIsles, "Isles Kasplat: Factory Lobby Box", Items.DKIslesTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.FranticFactoryLobby]),
     Locations.IslesBananaFairyFactoryLobby: Location(Levels.DKIsles, "Isles Banana Fairy Factory Lobby", Items.BananaFairy, Types.Fairy, Kongs.any, [MapIDCombo(Maps.FranticFactoryLobby, -1, 593)]),
     Locations.IslesTinyGalleonLobby: Location(Levels.DKIsles, "Isles Tiny Galleon Lobby Swim", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.GloomyGalleonLobby, 0x9, 403)]),
-    Locations.IslesKasplatGalleonLobby: Location(Levels.DKIsles, "Isles Kasplat: Inside Gloomy Galleon Lobby", Items.DKIslesChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.GloomyGalleonLobby]),
+    Locations.IslesKasplatGalleonLobby: Location(Levels.DKIsles, "Isles Kasplat: Galleon Lobby", Items.DKIslesChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.GloomyGalleonLobby]),
     Locations.IslesDiddyCagedBanana: Location(Levels.DKIsles, "Isles Diddy Peanut Cage", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(Maps.Isles, 0x2E, 423, Kongs.diddy)]),
     Locations.IslesDiddySummit: Location(Levels.DKIsles, "Isles Diddy Summit Barrel", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(0, -1, 428, Kongs.diddy)]),
     Locations.IslesBattleArena2: Location(Levels.DKIsles, "Isles Battle Arena 2 (Fungi Lobby: Gorilla Gone Box)", Items.BattleCrown, Types.Crown, Kongs.any, [MapIDCombo(Maps.LobbyCrown, -1, 614)]),
     Locations.IslesBananaFairyForestLobby: Location(Levels.DKIsles, "Isles Forest Lobby Banana Fairy", Items.BananaFairy, Types.Fairy, Kongs.any, [MapIDCombo(Maps.FungiForestLobby, -1, 594)]),
     Locations.IslesDonkeyLavaBanana: Location(Levels.DKIsles, "Isles Donkey Caves Lava", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.CrystalCavesLobby, 0x5, 411, Kongs.donkey)]),
     Locations.IslesDiddyInstrumentPad: Location(Levels.DKIsles, "Isles Diddy Guitar Pad", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(0, -1, 410, Kongs.diddy)]),
-    Locations.IslesKasplatCavesLobby: Location(Levels.DKIsles, "Isles Kasplat: Inside Crystal Caves Lobby", Items.DKIslesLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.CrystalCavesLobby]),
+    Locations.IslesKasplatCavesLobby: Location(Levels.DKIsles, "Isles Kasplat: Caves Lobby Punch", Items.DKIslesLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.CrystalCavesLobby]),
     Locations.IslesLankyCastleLobby: Location(Levels.DKIsles, "Isles Lanky Castle Lobby Barrel", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(0, -1, 415, Kongs.lanky)]),
-    Locations.IslesKasplatCastleLobby: Location(Levels.DKIsles, "Isles Kasplat: Inside Creepy Castle Lobby", Items.DKIslesDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.CreepyCastleLobby]),
+    Locations.IslesKasplatCastleLobby: Location(Levels.DKIsles, "Isles Kasplat: Castle Lobby", Items.DKIslesDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.CreepyCastleLobby]),
     Locations.IslesChunkyHelmLobby: Location(Levels.DKIsles, "Isles Chunky Helm Lobby Barrel", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(0, -1, 406, Kongs.chunky)]),
-    Locations.IslesKasplatHelmLobby: Location(Levels.DKIsles, "Isles Kasplat: Inside Hideout Helm Lobby", Items.DKIslesDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.HideoutHelmLobby]),
+    Locations.IslesKasplatHelmLobby: Location(Levels.DKIsles, "Isles Kasplat: Helm Lobby", Items.DKIslesDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.HideoutHelmLobby]),
     Locations.BananaHoard: Location(Levels.DKIsles, "Banana Hoard", Items.BananaHoard, Types.Constant),
     # Jungle Japes location
     Locations.JapesDonkeyMedal: Location(Levels.JungleJapes, "Japes Donkey Medal", Items.BananaMedal, Types.Medal, Kongs.donkey),
@@ -233,14 +233,14 @@ LocationList = {
     Locations.JapesDiddyTunnel: Location(Levels.JungleJapes, "Japes Diddy Peanut Tunnel", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(Maps.JungleJapes, 0x1E, 31, Kongs.diddy)]),
     Locations.JapesLankyGrapeGate: Location(Levels.JungleJapes, "Japes Lanky Grape Gate Barrel", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(0, -1, 1, Kongs.lanky)]),
     Locations.JapesTinyFeatherGateBarrel: Location(Levels.JungleJapes, "Japes Tiny Feather Gate Barrel", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(0, -1, 2, Kongs.tiny)]),
-    Locations.JapesKasplatLeftTunnelNear: Location(Levels.JungleJapes, "Japes Kasplat: Lower area of Tunnel to Beehive", Items.JungleJapesDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.JungleJapes]),
-    Locations.JapesKasplatLeftTunnelFar: Location(Levels.JungleJapes, "Japes Kasplat: Upper area of Tunnel to Beehive", Items.JungleJapesTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.JungleJapes]),
+    Locations.JapesKasplatLeftTunnelNear: Location(Levels.JungleJapes, "Japes Kasplat: Hive Tunnel Lower", Items.JungleJapesDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.JungleJapes]),
+    Locations.JapesKasplatLeftTunnelFar: Location(Levels.JungleJapes, "Japes Kasplat: Hive Tunnel Upper", Items.JungleJapesTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.JungleJapes]),
     Locations.JapesTinyStump: Location(Levels.JungleJapes, "Japes Tiny Stump", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.JungleJapes, 0x68, 8, Kongs.tiny)]),
     Locations.JapesChunkyGiantBonusBarrel: Location(Levels.JungleJapes, "Japes Chunky Giant Bonus Barrel", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(0, -1, 28, Kongs.chunky)]),
     Locations.JapesTinyBeehive: Location(Levels.JungleJapes, "Japes Tiny Beehive", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.JapesTinyHive, 0x3F, 9, Kongs.tiny)]),
     Locations.JapesLankySlope: Location(Levels.JungleJapes, "Japes Lanky Slope Barrel", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(0, -1, 11, Kongs.lanky)]),
     Locations.JapesKasplatNearPaintingRoom: Location(Levels.JungleJapes, "Japes Kasplat: Near Painting Room", Items.JungleJapesDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.JungleJapes]),
-    Locations.JapesKasplatNearLab: Location(Levels.JungleJapes, "Japes Kasplat: Near Speedy Swing Sortie Bonus", Items.JungleJapesLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.JungleJapes]),
+    Locations.JapesKasplatNearLab: Location(Levels.JungleJapes, "Japes Kasplat: Near Lanky Bonus", Items.JungleJapesLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.JungleJapes]),
     Locations.JapesBananaFairyRambiCave: Location(Levels.JungleJapes, "Japes Rambi Cave Banana Fairy", Items.BananaFairy, Types.Fairy, Kongs.any, [MapIDCombo(Maps.JungleJapes, -1, 589)]),
     Locations.JapesLankyFairyCave: Location(Levels.JungleJapes, "Japes Lanky Painting Room Zingers", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(Maps.JapesLankyCave, 0x4, 10, Kongs.lanky)]),
     Locations.JapesBananaFairyLankyCave: Location(Levels.JungleJapes, "Japes Painting Room Banana Fairy", Items.BananaFairy, Types.Fairy, Kongs.any, [MapIDCombo(Maps.JapesLankyCave, -1, 590)]),
@@ -256,7 +256,7 @@ LocationList = {
     Locations.AztecChunkyMedal: Location(Levels.AngryAztec, "Aztec Chunky Medal", Items.BananaMedal, Types.Medal, Kongs.chunky),
     Locations.AztecDonkeyFreeLlama: Location(Levels.AngryAztec, "Aztec Donkey Free Llama Blast", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.AngryAztec, 0x26, 51, Kongs.donkey)]),
     Locations.AztecChunkyVases: Location(Levels.AngryAztec, "Aztec Chunky Vases", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.AngryAztec, 0x23, 49, Kongs.chunky)]),
-    Locations.AztecKasplatSandyBridge: Location(Levels.AngryAztec, "Aztec Kasplat: Behind the DK Stone Door", Items.AngryAztecDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.AngryAztec]),
+    Locations.AztecKasplatSandyBridge: Location(Levels.AngryAztec, "Aztec Kasplat: Behind DK Stone Door", Items.AngryAztecDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.AngryAztec]),
     Locations.AztecKasplatOnTinyTemple: Location(Levels.AngryAztec, "Aztec Kasplat: On Tiny Temple", Items.AngryAztecDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.AngryAztec]),
     Locations.AztecTinyKlaptrapRoom: Location(Levels.AngryAztec, "Aztec Tiny Klaptrap Room", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.AztecTinyTemple, 0x7E, 65, Kongs.tiny)]),
     Locations.AztecChunkyKlaptrapRoom: Location(Levels.AngryAztec, "Aztec Chunky Klaptrap Room", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.AztecTinyTemple, 0x9, 64, Kongs.chunky)]),
@@ -268,14 +268,14 @@ LocationList = {
     Locations.AztecDiddyRamGongs: Location(Levels.AngryAztec, "Aztec Diddy Ram Gongs", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(Maps.AngryAztec, 0xA3, 54, Kongs.diddy)]),
     Locations.AztecDiddyVultureRace: Location(Levels.AngryAztec, "Aztec Diddy Vulture Race", Items.GoldenBanana, Types.ToughBanana, Kongs.diddy, [MapIDCombo(Maps.AngryAztec, 0xEB, 63, Kongs.diddy)]),
     Locations.AztecChunkyCagedBarrel: Location(Levels.AngryAztec, "Aztec Chunky Giant Caged Barrel", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(0, -1, 52, Kongs.chunky)]),
-    Locations.AztecKasplatNearLab: Location(Levels.AngryAztec, "Aztec Kasplat: Near the Hunky Chunky Barrel", Items.AngryAztecTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.AngryAztec]),
+    Locations.AztecKasplatNearLab: Location(Levels.AngryAztec, "Aztec Kasplat: Hunky Chunky Barrel", Items.AngryAztecTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.AngryAztec]),
     Locations.AztecDonkey5DoorTemple: Location(Levels.AngryAztec, "Aztec Donkey 5 Door Temple", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.AztecDonkey5DTemple, 0x6, 57, Kongs.donkey)]),
     Locations.AztecDiddy5DoorTemple: Location(Levels.AngryAztec, "Aztec Diddy 5 Door Temple", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(Maps.AztecDiddy5DTemple, 0x6, 56, Kongs.diddy)]),
     Locations.AztecLanky5DoorTemple: Location(Levels.AngryAztec, "Aztec Lanky 5 Door Temple", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(0, -1, 60, Kongs.lanky)]),
     Locations.AztecTiny5DoorTemple: Location(Levels.AngryAztec, "Aztec Tiny 5 Door Temple", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.AztecTiny5DTemple, 0x6, 58, Kongs.tiny)]),
     Locations.AztecBananaFairyTinyTemple: Location(Levels.AngryAztec, "Aztec Tiny 5 Door Temple Banana Fairy", Items.BananaFairy, Types.Fairy, Kongs.any, [MapIDCombo(Maps.AztecTiny5DTemple, -1, 601)]),
     Locations.AztecChunky5DoorTemple: Location(Levels.AngryAztec, "Aztec Chunky 5 Door Temple", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(0, -1, 59, Kongs.chunky)]),
-    Locations.AztecKasplatChunky5DT: Location(Levels.AngryAztec, "Aztec Kasplat: In Chunky 5-Door Temple", Items.AngryAztecChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.AztecChunky5DTemple]),
+    Locations.AztecKasplatChunky5DT: Location(Levels.AngryAztec, "Aztec Kasplat: Chunky 5-Door Temple", Items.AngryAztecChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.AztecChunky5DTemple]),
     Locations.AztecTinyBeetleRace: Location(Levels.AngryAztec, "Aztec Tiny Beetle Race", Items.GoldenBanana, Types.ToughBanana, Kongs.tiny, [MapIDCombo(Maps.AztecTinyRace, 0x48, 75, Kongs.tiny)]),
     Locations.LankyKong: Location(Levels.AngryAztec, "Lanky Kong's Cage", Items.Lanky, Types.Kong, Kongs.any, [MapIDCombo(0, -1, 70)], logically_relevant=True),
     Locations.AztecDonkeyFreeLanky: Location(Levels.AngryAztec, "Aztec Free Lanky Item", Items.GoldenBanana, Types.Banana, Kongs.any, [MapIDCombo(Maps.AztecLlamaTemple, 0x6C, 77, Kongs.donkey)]),  # Can be assigned to other kongs
@@ -283,7 +283,7 @@ LocationList = {
     Locations.AztecLankyMatchingGame: Location(Levels.AngryAztec, "Aztec Lanky Matching Game", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(Maps.AztecLlamaTemple, 0x2B, 72, Kongs.lanky)]),
     Locations.AztecBananaFairyLlamaTemple: Location(Levels.AngryAztec, "Aztec Llama Temple Banana Fairy", Items.BananaFairy, Types.Fairy, Kongs.any, [MapIDCombo(Maps.AztecLlamaTemple, -1, 600)]),
     Locations.AztecTinyLlamaTemple: Location(Levels.AngryAztec, "Aztec Tiny Llama Temple Lava Pedestals", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.AztecLlamaTemple, 0xAA, 71, Kongs.tiny)]),
-    Locations.AztecKasplatLlamaTemple: Location(Levels.AngryAztec, "Aztec Kasplat: In the lava room in Llama Temple", Items.AngryAztecLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.AztecLlamaTemple]),
+    Locations.AztecKasplatLlamaTemple: Location(Levels.AngryAztec, "Aztec Kasplat: Llama Temple Lava", Items.AngryAztecLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.AztecLlamaTemple]),
     Locations.AztecKey: Location(Levels.AngryAztec, "Aztec Boss Defeated", Items.AngryAztecKey, Types.Key, Kongs.any, [MapIDCombo(0, -1, 74)]),  # Can be assigned to any kong
     # Frantic Factory locations
     Locations.FactoryDonkeyMedal: Location(Levels.FranticFactory, "Factory Donkey Medal", Items.BananaMedal, Types.Medal, Kongs.donkey),
@@ -295,13 +295,13 @@ LocationList = {
     Locations.FactoryDiddyBlockTower: Location(Levels.FranticFactory, "Factory Diddy Block Tower", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(0, -1, 135, Kongs.diddy)]),
     Locations.FactoryLankyTestingRoomBarrel: Location(Levels.FranticFactory, "Factory Lanky Testing Room Barrel", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(0, -1, 137, Kongs.lanky)]),
     Locations.FactoryTinyDartboard: Location(Levels.FranticFactory, "Factory Tiny Dartboard", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.FranticFactory, 0x82, 124, Kongs.tiny)]),
-    Locations.FactoryKasplatBlocks: Location(Levels.FranticFactory, "Factory Kasplat: In Block Tower Room", Items.FranticFactoryChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.FranticFactory]),
+    Locations.FactoryKasplatBlocks: Location(Levels.FranticFactory, "Factory Kasplat: Block Tower", Items.FranticFactoryChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.FranticFactory]),
     Locations.FactoryBananaFairybyCounting: Location(Levels.FranticFactory, "Factory Banana Fairy by Counting", Items.BananaFairy, Types.Fairy, Kongs.any, [MapIDCombo(Maps.FranticFactory, -1, 602)]),
     Locations.FactoryBananaFairybyFunky: Location(Levels.FranticFactory, "Factory Banana Fairy by Funky", Items.BananaFairy, Types.Fairy, Kongs.any, [MapIDCombo(Maps.FranticFactory, -1, 591)]),
     Locations.FactoryDiddyRandD: Location(Levels.FranticFactory, "Factory Diddy Charge Enemies", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(Maps.FranticFactory, 0x60, 126, Kongs.diddy)]),
     Locations.FactoryLankyRandD: Location(Levels.FranticFactory, "Factory Lanky Piano Game", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(Maps.FranticFactory, 0x3E, 125, Kongs.lanky)]),
     Locations.FactoryChunkyRandD: Location(Levels.FranticFactory, "Factory Chunky Toy Monster", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.FranticFactory, 0x7C, 127, Kongs.chunky)]),
-    Locations.FactoryKasplatRandD: Location(Levels.FranticFactory, "Factory Kasplat: In Research and Development", Items.FranticFactoryLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.FranticFactory]),
+    Locations.FactoryKasplatRandD: Location(Levels.FranticFactory, "Factory Kasplat: Research and Development", Items.FranticFactoryLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.FranticFactory]),
     Locations.FactoryBattleArena: Location(Levels.FranticFactory, "Factory Battle Arena (Under R and D Grate)", Items.BattleCrown, Types.Crown, Kongs.any, [MapIDCombo(Maps.FactoryCrown, -1, 611)]),
     Locations.FactoryTinyCarRace: Location(Levels.FranticFactory, "Factory Tiny Car Race", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.FactoryTinyRace, 0x62, 139, Kongs.tiny)]),
     Locations.FactoryDiddyChunkyRoomBarrel: Location(Levels.FranticFactory, "Factory Diddy Storage Room Barrel", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(0, -1, 134, Kongs.diddy)]),
@@ -313,14 +313,14 @@ LocationList = {
     Locations.FactoryTinybyArcade: Location(Levels.FranticFactory, "Factory Tiny Mini by Arcade", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.FranticFactory, 0x23, 123, Kongs.tiny)]),
     Locations.FactoryChunkyDarkRoom: Location(Levels.FranticFactory, "Factory Chunky Dark Room", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.FranticFactory, 0x63, 121, Kongs.chunky)]),
     Locations.FactoryChunkybyArcade: Location(Levels.FranticFactory, "Factory Chunky Barrel by Arcade", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(0, -1, 136, Kongs.chunky)]),
-    Locations.FactoryKasplatProductionBottom: Location(Levels.FranticFactory, "Factory Kasplat: At the base of Production Room", Items.FranticFactoryDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.FranticFactory]),
-    Locations.FactoryKasplatStorage: Location(Levels.FranticFactory, "Factory Kasplat: Below the pole to the DK Arcade Machine", Items.FranticFactoryTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.FranticFactory, Kongs.tiny]),
+    Locations.FactoryKasplatProductionBottom: Location(Levels.FranticFactory, "Factory Kasplat: Base of Production", Items.FranticFactoryDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.FranticFactory]),
+    Locations.FactoryKasplatStorage: Location(Levels.FranticFactory, "Factory Kasplat: Pole to Arcade", Items.FranticFactoryTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.FranticFactory, Kongs.tiny]),
     Locations.FactoryDonkeyCrusherRoom: Location(Levels.FranticFactory, "Factory Donkey Crusher Room", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.FactoryCrusher, 0x7, 128, Kongs.donkey)]),
     Locations.FactoryDiddyProductionRoom: Location(Levels.FranticFactory, "Factory Diddy Production Spring", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(Maps.FranticFactory, 0x2C, 113, Kongs.diddy)]),
     Locations.FactoryLankyProductionRoom: Location(Levels.FranticFactory, "Factory Lanky Production Handstand", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(Maps.FranticFactory, 0x2A, 115, Kongs.lanky)]),
     Locations.FactoryTinyProductionRoom: Location(Levels.FranticFactory, "Factory Tiny Production Twirl", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(0, -1, 116, Kongs.tiny)]),
     Locations.FactoryChunkyProductionRoom: Location(Levels.FranticFactory, "Factory Chunky Production Timer", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.FranticFactory, 0x29, 114, Kongs.chunky)]),
-    Locations.FactoryKasplatProductionTop: Location(Levels.FranticFactory, "Factory Kasplat: Near the slippery pipe in Production Room", Items.FranticFactoryDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.FranticFactory]),
+    Locations.FactoryKasplatProductionTop: Location(Levels.FranticFactory, "Factory Kasplat: Upper Production Pipe", Items.FranticFactoryDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.FranticFactory]),
     Locations.FactoryKey: Location(Levels.FranticFactory, "Factory Boss Defeated", Items.FranticFactoryKey, Types.Key, Kongs.any, [MapIDCombo(0, -1, 138)]),  # Can be assigned to any kong
     # Gloomy Galleon locations
     Locations.GalleonDonkeyMedal: Location(Levels.GloomyGalleon, "Galleon Donkey Medal", Items.BananaMedal, Types.Medal, Kongs.donkey),
@@ -329,23 +329,23 @@ LocationList = {
     Locations.GalleonTinyMedal: Location(Levels.GloomyGalleon, "Galleon Tiny Medal", Items.BananaMedal, Types.Medal, Kongs.tiny),
     Locations.GalleonChunkyMedal: Location(Levels.GloomyGalleon, "Galleon Chunky Medal", Items.BananaMedal, Types.Medal, Kongs.chunky),
     Locations.GalleonChunkyChest: Location(Levels.GloomyGalleon, "Galleon Chunky Chest", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.GloomyGalleon, 0xE, 182, Kongs.chunky)]),
-    Locations.GalleonKasplatNearLab: Location(Levels.GloomyGalleon, "Galleon Kasplat: Near the Troff 'n' Scoff near Cranky's", Items.GloomyGalleonTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.GloomyGalleon]),
+    Locations.GalleonKasplatNearLab: Location(Levels.GloomyGalleon, "Galleon Kasplat: Past Vines", Items.GloomyGalleonTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.GloomyGalleon]),
     Locations.GalleonBattleArena: Location(Levels.GloomyGalleon, "Galleon Battle Arena (Under Cranky)", Items.BattleCrown, Types.Crown, Kongs.any, [MapIDCombo(Maps.GalleonCrown, -1, 612)]),
     Locations.GalleonBananaFairybyCranky: Location(Levels.GloomyGalleon, "Galleon Banana Fairy by Cranky", Items.BananaFairy, Types.Fairy, Kongs.any, [MapIDCombo(Maps.GloomyGalleon, -1, 592)]),
     Locations.GalleonChunkyCannonGame: Location(Levels.GloomyGalleon, "Galleon Chunky Cannon Game", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.GloomyGalleon, 0x32, 154, Kongs.chunky)]),
-    Locations.GalleonKasplatCannons: Location(Levels.GloomyGalleon, "Galleon Kasplat: On the platforms in Cannon Game Room", Items.GloomyGalleonLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.GloomyGalleon]),
+    Locations.GalleonKasplatCannons: Location(Levels.GloomyGalleon, "Galleon Kasplat: Cannon Game Room", Items.GloomyGalleonLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.GloomyGalleon]),
     Locations.GalleonDiddyShipSwitch: Location(Levels.GloomyGalleon, "Galleon Diddy Top of Lighthouse", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(Maps.GloomyGalleon, 0x2D, 204, Kongs.diddy)]),
     Locations.GalleonLankyEnguardeChest: Location(Levels.GloomyGalleon, "Galleon Lanky Enguarde Chest", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(Maps.GloomyGalleon, 0x6B, 192, Kongs.lanky)]),
-    Locations.GalleonKasplatLighthouseArea: Location(Levels.GloomyGalleon, "Galleon Kasplat: In the Alcove near the Lighthouse", Items.GloomyGalleonDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.GloomyGalleon]),
+    Locations.GalleonKasplatLighthouseArea: Location(Levels.GloomyGalleon, "Galleon Kasplat: Lighthouse Alcove", Items.GloomyGalleonDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.GloomyGalleon]),
     Locations.GalleonDonkeyLighthouse: Location(Levels.GloomyGalleon, "Galleon Donkey Lighthouse", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.GalleonLighthouse, 0x2F, 157, Kongs.donkey)]),
     Locations.GalleonTinyPearls: Location(Levels.GloomyGalleon, "Galleon Tiny Mermaid Reward", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.GalleonMermaidRoom, 0xE, 191, Kongs.tiny)]),
     Locations.GalleonChunkySeasick: Location(Levels.GloomyGalleon, "Galleon Chunky Seasick", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.GalleonSickBay, 0x6, 166, Kongs.chunky)]),
     Locations.GalleonDonkeyFreetheSeal: Location(Levels.GloomyGalleon, "Galleon Donkey Free the Seal", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.GloomyGalleon, 0x2E, 193, Kongs.donkey)]),
-    Locations.GalleonKasplatNearSub: Location(Levels.GloomyGalleon, "Galleon Kasplat: On the Cactus near the sunken submarine", Items.GloomyGalleonChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.GloomyGalleon]),
+    Locations.GalleonKasplatNearSub: Location(Levels.GloomyGalleon, "Galleon Kasplat: Musical Cactus", Items.GloomyGalleonChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.GloomyGalleon]),
     Locations.GalleonDonkeySealRace: Location(Levels.GloomyGalleon, "Galleon Donkey Seal Race", Items.GoldenBanana, Types.ToughBanana, Kongs.donkey, [MapIDCombo(Maps.GalleonSealRace, 0x3B, 165, Kongs.donkey)]),
     Locations.GalleonDiddyGoldTower: Location(Levels.GloomyGalleon, "Galleon Diddy Gold Tower Barrel", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(0, -1, 163, Kongs.diddy)], logically_relevant=True),
     Locations.GalleonLankyGoldTower: Location(Levels.GloomyGalleon, "Galleon Lanky Gold Tower Barrel", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(0, -1, 164, Kongs.lanky)]),
-    Locations.GalleonKasplatGoldTower: Location(Levels.GloomyGalleon, "Galleon Kasplat: On Diddy's Gold Tower", Items.GloomyGalleonDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.GloomyGalleon]),
+    Locations.GalleonKasplatGoldTower: Location(Levels.GloomyGalleon, "Galleon Kasplat: Diddy Gold Tower", Items.GloomyGalleonDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.GloomyGalleon]),
     Locations.GalleonTinySubmarine: Location(Levels.GloomyGalleon, "Galleon Tiny Submarine Barrel", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(0, -1, 202, Kongs.tiny)]),
     Locations.GalleonDiddyMechafish: Location(Levels.GloomyGalleon, "Galleon Diddy Mechfish", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(Maps.GalleonMechafish, 0xF, 167, Kongs.diddy)]),
     Locations.GalleonLanky2DoorShip: Location(Levels.GloomyGalleon, "Galleon Lanky 2 Door Ship", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(Maps.Galleon2DShip, 0x0, 183, Kongs.lanky)]),
@@ -372,17 +372,17 @@ LocationList = {
     Locations.ForestDiddyTopofMushroom: Location(Levels.FungiForest, "Forest Diddy Top of Mushroom Barrel", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(0, -1, 211, Kongs.diddy)]),
     Locations.ForestTinyMushroomBarrel: Location(Levels.FungiForest, "Forest Tiny Mushroom Barrel", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(0, -1, 227, Kongs.tiny)]),
     Locations.ForestDonkeyBaboonBlast: Location(Levels.FungiForest, "Forest Donkey Baboon Blast", Items.GoldenBanana, Types.ToughBanana, Kongs.donkey, [MapIDCombo(Maps.FungiForest, 0x39, 254, Kongs.donkey)]),
-    Locations.ForestKasplatLowerMushroomExterior: Location(Levels.FungiForest, "Forest Kasplat: On a low platform on the exterior of Giant Mushroom", Items.FungiForestTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.FungiForest]),
+    Locations.ForestKasplatLowerMushroomExterior: Location(Levels.FungiForest, "Forest Kasplat: Low Mushroom Exterior", Items.FungiForestTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.FungiForest]),
     Locations.ForestDonkeyMushroomCannons: Location(Levels.FungiForest, "Forest Donkey Mushroom Cannons", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.ForestGiantMushroom, 0x3, 228, Kongs.donkey)]),
-    Locations.ForestKasplatInsideMushroom: Location(Levels.FungiForest, "Forest Kasplat: Inside the Giant Mushroom", Items.FungiForestDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.ForestGiantMushroom]),
-    Locations.ForestKasplatUpperMushroomExterior: Location(Levels.FungiForest, "Forest Kasplat: On a high platform on the exterior of Giant Mushroom", Items.FungiForestChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.FungiForest]),
+    Locations.ForestKasplatInsideMushroom: Location(Levels.FungiForest, "Forest Kasplat: Inside Giant Mushroom", Items.FungiForestDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.ForestGiantMushroom]),
+    Locations.ForestKasplatUpperMushroomExterior: Location(Levels.FungiForest, "Forest Kasplat: Mushroom Night Door", Items.FungiForestChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.FungiForest]),
     Locations.ForestBattleArena: Location(Levels.FungiForest, "Forest Battle Arena (Giant Mushroom High Ladder Platform)", Items.BattleCrown, Types.Crown, Kongs.any, [MapIDCombo(Maps.ForestCrown, -1, 613)]),
     Locations.ForestChunkyFacePuzzle: Location(Levels.FungiForest, "Forest Chunky Face Puzzle", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.ForestChunkyFaceRoom, 0x2, 225, Kongs.chunky)]),
     Locations.ForestLankyZingers: Location(Levels.FungiForest, "Forest Lanky Zinger Bounce", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(Maps.ForestLankyZingersRoom, 0x0, 226, Kongs.lanky)]),
     Locations.ForestLankyColoredMushrooms: Location(Levels.FungiForest, "Forest Lanky Colored Mushroom Slam", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(0, -1, 224, Kongs.lanky)]),
     Locations.ForestDiddyOwlRace: Location(Levels.FungiForest, "Forest Diddy Owl Race", Items.GoldenBanana, Types.ToughBanana, Kongs.diddy, [MapIDCombo(0, -1, 250, Kongs.diddy)]),
     Locations.ForestLankyRabbitRace: Location(Levels.FungiForest, "Forest Lanky Rabbit Race", Items.GoldenBanana, Types.ToughBanana, Kongs.lanky, [MapIDCombo(Maps.FungiForest, 0x57, 249)]),
-    Locations.ForestKasplatOwlTree: Location(Levels.FungiForest, "Forest Kasplat: Under the Owl's Tree", Items.FungiForestLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.FungiForest]),
+    Locations.ForestKasplatOwlTree: Location(Levels.FungiForest, "Forest Kasplat: Under Owl Tree", Items.FungiForestLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.FungiForest]),
     Locations.ForestTinyAnthill: Location(Levels.FungiForest, "Forest Tiny Anthill Banana", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.ForestAnthill, 0x0, 205, Kongs.tiny)]),
     Locations.ForestDonkeyMill: Location(Levels.FungiForest, "Forest Donkey Mill Levers", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.FungiForest, 0x2B, 219, Kongs.donkey), MapIDCombo(Maps.ForestMillFront, 0xA, 219, Kongs.donkey)]),
     Locations.ForestDiddyCagedBanana: Location(Levels.FungiForest, "Forest Diddy Winch Cage", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(Maps.FungiForest, 0x28, 214, Kongs.diddy)]),
@@ -409,14 +409,14 @@ LocationList = {
     Locations.CavesTinyCaveBarrel: Location(Levels.CrystalCaves, "Caves Tiny Mini Cave Barrel", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(0, -1, 295, Kongs.tiny)], logically_relevant=True),
     Locations.CavesTinyMonkeyportIgloo: Location(Levels.CrystalCaves, "Caves Tiny Monkeyport Igloo", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.CrystalCaves, 0x29, 297, Kongs.tiny)]),
     Locations.CavesChunkyGorillaGone: Location(Levels.CrystalCaves, "Caves Chunky Gorilla Gone", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.CrystalCaves, 0x3E, 268, Kongs.chunky)]),
-    Locations.CavesKasplatNearLab: Location(Levels.CrystalCaves, "Caves Kasplat: Near the Ice Castle", Items.CrystalCavesDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.CrystalCaves]),
-    Locations.CavesKasplatNearFunky: Location(Levels.CrystalCaves, "Caves Kasplat: In the Hidden Room by Funky's", Items.CrystalCavesDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.CrystalCaves]),
-    Locations.CavesKasplatPillar: Location(Levels.CrystalCaves, "Caves Kasplat: On the platform near Funky's", Items.CrystalCavesLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.CrystalCaves]),
+    Locations.CavesKasplatNearLab: Location(Levels.CrystalCaves, "Caves Kasplat: Near Ice Castle", Items.CrystalCavesDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.CrystalCaves]),
+    Locations.CavesKasplatNearFunky: Location(Levels.CrystalCaves, "Caves Kasplat: Mini Room by Funky", Items.CrystalCavesDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.CrystalCaves]),
+    Locations.CavesKasplatPillar: Location(Levels.CrystalCaves, "Caves Kasplat: On the Pillar", Items.CrystalCavesLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.CrystalCaves]),
     Locations.CavesKasplatNearCandy: Location(Levels.CrystalCaves, "Caves Kasplat: By the Far Warp 2", Items.CrystalCavesTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.CrystalCaves]),
     Locations.CavesLankyBeetleRace: Location(Levels.CrystalCaves, "Caves Lanky Beetle Race", Items.GoldenBanana, Types.ToughBanana, Kongs.lanky, [MapIDCombo(Maps.CavesLankyRace, 0x1, 259, Kongs.lanky)]),
     Locations.CavesLankyCastle: Location(Levels.CrystalCaves, "Caves Lanky Ice Castle Slam Challenge", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(Maps.CavesFrozenCastle, 0x10, 271, Kongs.lanky)]),
     Locations.CavesChunkyTransparentIgloo: Location(Levels.CrystalCaves, "Caves Chunky Transparent Igloo", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.CrystalCaves, 0x28, 270, Kongs.chunky)]),
-    Locations.CavesKasplatOn5DI: Location(Levels.CrystalCaves, "Caves Kasplat: On the 5-Door Igloo", Items.CrystalCavesChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.CrystalCaves]),
+    Locations.CavesKasplatOn5DI: Location(Levels.CrystalCaves, "Caves Kasplat: On 5-Door Igloo", Items.CrystalCavesChunkyBlueprint, Types.Blueprint, Kongs.chunky, [Maps.CrystalCaves]),
     Locations.CavesDonkey5DoorIgloo: Location(Levels.CrystalCaves, "Caves Donkey 5 Door Igloo", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.CavesDonkeyIgloo, 0x1, 275, Kongs.donkey)]),
     Locations.CavesDiddy5DoorIgloo: Location(Levels.CrystalCaves, "Caves Diddy 5 Door Igloo", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(Maps.CavesDiddyIgloo, 0x1, 274, Kongs.diddy)]),
     Locations.CavesLanky5DoorIgloo: Location(Levels.CrystalCaves, "Caves Lanky 5 Door Igloo", Items.GoldenBanana, Types.Banana, Kongs.lanky, [MapIDCombo(Maps.CavesLankyIgloo, 0x3, 281, Kongs.lanky)]),
@@ -440,8 +440,8 @@ LocationList = {
     Locations.CastleTinyMedal: Location(Levels.CreepyCastle, "Castle Tiny Medal", Items.BananaMedal, Types.Medal, Kongs.tiny),
     Locations.CastleChunkyMedal: Location(Levels.CreepyCastle, "Castle Chunky Medal", Items.BananaMedal, Types.Medal, Kongs.chunky),
     Locations.CastleDiddyAboveCastle: Location(Levels.CreepyCastle, "Castle Diddy Above Castle", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(0, -1, 350, Kongs.diddy)]),
-    Locations.CastleKasplatHalfway: Location(Levels.CreepyCastle, "Castle Kasplat: Near the upper Warp 2", Items.CreepyCastleLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.CreepyCastle]),
-    Locations.CastleKasplatLowerLedge: Location(Levels.CreepyCastle, "Castle Kasplat: Near the Crypt Entrance on a lone platform", Items.CreepyCastleTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.CreepyCastle]),
+    Locations.CastleKasplatHalfway: Location(Levels.CreepyCastle, "Castle Kasplat: Near Upper Warp 2", Items.CreepyCastleLankyBlueprint, Types.Blueprint, Kongs.lanky, [Maps.CreepyCastle]),
+    Locations.CastleKasplatLowerLedge: Location(Levels.CreepyCastle, "Castle Kasplat: On a lone platform", Items.CreepyCastleTinyBlueprint, Types.Blueprint, Kongs.tiny, [Maps.CreepyCastle]),
     Locations.CastleDonkeyTree: Location(Levels.CreepyCastle, "Castle Donkey Tree Sniping", Items.GoldenBanana, Types.Banana, Kongs.donkey, [MapIDCombo(Maps.CastleTree, 0x8, 320, Kongs.donkey)]),
     Locations.CastleChunkyTree: Location(Levels.CreepyCastle, "Castle Chunky Tree Sniping Barrel", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(0, -1, 319, Kongs.chunky)]),
     Locations.CastleKasplatTree: Location(Levels.CreepyCastle, "Castle Kasplat: Inside the Tree", Items.CreepyCastleDonkeyBlueprint, Types.Blueprint, Kongs.donkey, [Maps.CastleTree]),
@@ -456,7 +456,7 @@ LocationList = {
     Locations.CastleTinyTrashCan: Location(Levels.CreepyCastle, "Castle Tiny Trash Can", Items.GoldenBanana, Types.Banana, Kongs.tiny, [MapIDCombo(Maps.CastleTrashCan, 0x4, 351, Kongs.tiny)]),
     Locations.CastleChunkyShed: Location(Levels.CreepyCastle, "Castle Chunky Shed", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.CastleShed, 0x6, 322, Kongs.chunky)]),
     Locations.CastleChunkyMuseum: Location(Levels.CreepyCastle, "Castle Chunky Museum", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(Maps.CastleMuseum, 0x7, 314, Kongs.chunky)]),
-    Locations.CastleKasplatCrypt: Location(Levels.CreepyCastle, "Castle Kasplat: In the Lower Cave straight ahead", Items.CreepyCastleDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.CastleLowerCave]),
+    Locations.CastleKasplatCrypt: Location(Levels.CreepyCastle, "Castle Kasplat: Lower Cave Center", Items.CreepyCastleDiddyBlueprint, Types.Blueprint, Kongs.diddy, [Maps.CastleLowerCave]),
     Locations.CastleDiddyCrypt: Location(Levels.CreepyCastle, "Castle Diddy Crypt", Items.GoldenBanana, Types.Banana, Kongs.diddy, [MapIDCombo(Maps.CastleCrypt, 0x8, 310, Kongs.diddy)]),
     Locations.CastleChunkyCrypt: Location(Levels.CreepyCastle, "Castle Chunky Crypt", Items.GoldenBanana, Types.Banana, Kongs.chunky, [MapIDCombo(0, -1, 311, Kongs.chunky)]),
     Locations.CastleDonkeyMinecarts: Location(Levels.CreepyCastle, "Castle Donkey Minecart", Items.GoldenBanana, Types.ToughBanana, Kongs.donkey, [MapIDCombo(0, -1, 318, Kongs.donkey)]),
@@ -701,22 +701,22 @@ LocationList = {
     Locations.CastleChunkyDoor: Location(Levels.CreepyCastle, "Castle Chunky Hint", Items.CastleChunkyHint, Types.Hint, Kongs.chunky),
 
     # Rainbow Coins - Has to be in order of map index
-    Locations.RainbowCoin_Location00: Location(Levels.JungleJapes, "Japes Dirt Patch (Painting Hill)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.JungleJapes, -1, 0x29E)]),  # Painting Hill
-    Locations.RainbowCoin_Location01: Location(Levels.AngryAztec, "Aztec Dirt Patch (Chunky Temple)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.AztecChunky5DTemple, -1, 0x29F)]),  # Chunky 5DT
-    Locations.RainbowCoin_Location02: Location(Levels.FranticFactory, "Factory Dirt Patch (Dark Room)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.FranticFactory, -1, 0x2A0)]),  # Dark Room
-    Locations.RainbowCoin_Location03: Location(Levels.DKIsles, "Isles Dirt Patch (Fungi Island)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.Isles, -1, 0x2A1)]),  # Fungi Entrance
-    Locations.RainbowCoin_Location04: Location(Levels.DKIsles, "Isles Dirt Patch (Under Caves Lobby)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.Isles, -1, 0x2A2)]),  # Caves Slope
-    Locations.RainbowCoin_Location05: Location(Levels.DKIsles, "Isles Dirt Patch (Aztec Roof)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.Isles, -1, 0x2A3)]),  # Aztec Roof
-    Locations.RainbowCoin_Location06: Location(Levels.AngryAztec, "Aztec Dirt Patch (Oasis)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.AngryAztec, -1, 0x2A4)]),  # Oasis
-    Locations.RainbowCoin_Location07: Location(Levels.FungiForest, "Forest Dirt Patch (Grass)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.FungiForest, -1, 0x2A5)]),  # Isotarge Coin
-    Locations.RainbowCoin_Location08: Location(Levels.FungiForest, "Forest Dirt Patch (Beanstalk)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.FungiForest, -1, 0x2A6)]),  # Beanstalk
-    Locations.RainbowCoin_Location09: Location(Levels.GloomyGalleon, "Galleon Dirt Patch (Lighthouse)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.GalleonLighthouse, -1, 0x2A7)]),  # Lighthouse
-    Locations.RainbowCoin_Location10: Location(Levels.CrystalCaves, "Caves Dirt Patch (Giant Kosha)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.CrystalCaves, -1, 0x2A8)]),  # Giant Kosha
-    Locations.RainbowCoin_Location11: Location(Levels.CreepyCastle, "Castle Dirt Patch (Top)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.CreepyCastle, -1, 0x2A9)]),  # Castle Top
-    Locations.RainbowCoin_Location12: Location(Levels.DKIsles, "Isles Dirt Patch (K. Lumsy)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.KLumsy, -1, 0x2AA)]),  # K. Lumsy
-    Locations.RainbowCoin_Location13: Location(Levels.DKIsles, "Isles Dirt Patch (Back of Training Grounds)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.TrainingGrounds, -1, 0x2AB)]),  # Back of TG
-    Locations.RainbowCoin_Location14: Location(Levels.DKIsles, "Isles Dirt Patch (Banana Hoard)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.TrainingGrounds, -1, 0x2AC)]),  # Banana Hoard
-    Locations.RainbowCoin_Location15: Location(Levels.DKIsles, "Isles Dirt Patch (Castle Lobby)", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.CreepyCastleLobby, -1, 0x2AD)]),  # Castle Lobby
+    Locations.RainbowCoin_Location00: Location(Levels.JungleJapes, "Japes Dirt: Painting Hill", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.JungleJapes, -1, 0x29E)]),  # Painting Hill
+    Locations.RainbowCoin_Location01: Location(Levels.AngryAztec, "Aztec Dirt: Chunky Temple", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.AztecChunky5DTemple, -1, 0x29F)]),  # Chunky 5DT
+    Locations.RainbowCoin_Location02: Location(Levels.FranticFactory, "Factory Dirt: Dark Room", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.FranticFactory, -1, 0x2A0)]),  # Dark Room
+    Locations.RainbowCoin_Location03: Location(Levels.DKIsles, "Isles Dirt: Cabin Isle", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.Isles, -1, 0x2A1)]),  # Fungi Entrance
+    Locations.RainbowCoin_Location04: Location(Levels.DKIsles, "Isles Dirt: Under Caves Lobby", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.Isles, -1, 0x2A2)]),  # Caves Slope
+    Locations.RainbowCoin_Location05: Location(Levels.DKIsles, "Isles Dirt: Aztec Roof", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.Isles, -1, 0x2A3)]),  # Aztec Roof
+    Locations.RainbowCoin_Location06: Location(Levels.AngryAztec, "Aztec Dirt: Oasis", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.AngryAztec, -1, 0x2A4)]),  # Oasis
+    Locations.RainbowCoin_Location07: Location(Levels.FungiForest, "Forest Dirt: Grass", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.FungiForest, -1, 0x2A5)]),  # Isotarge Coin
+    Locations.RainbowCoin_Location08: Location(Levels.FungiForest, "Forest Dirt: Beanstalk", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.FungiForest, -1, 0x2A6)]),  # Beanstalk
+    Locations.RainbowCoin_Location09: Location(Levels.GloomyGalleon, "Galleon Dirt: Lighthouse", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.GalleonLighthouse, -1, 0x2A7)]),  # Lighthouse
+    Locations.RainbowCoin_Location10: Location(Levels.CrystalCaves, "Caves Dirt: Giant Kosha", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.CrystalCaves, -1, 0x2A8)]),  # Giant Kosha
+    Locations.RainbowCoin_Location11: Location(Levels.CreepyCastle, "Castle Dirt: Top", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.CreepyCastle, -1, 0x2A9)]),  # Castle Top
+    Locations.RainbowCoin_Location12: Location(Levels.DKIsles, "Isles Dirt: Prison", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.KLumsy, -1, 0x2AA)]),  # K. Lumsy
+    Locations.RainbowCoin_Location13: Location(Levels.DKIsles, "Isles Dirt: Training Grounds Back", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.TrainingGrounds, -1, 0x2AB)]),  # Back of TG
+    Locations.RainbowCoin_Location14: Location(Levels.DKIsles, "Isles Dirt: Banana Hoard", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.TrainingGrounds, -1, 0x2AC)]),  # Banana Hoard
+    Locations.RainbowCoin_Location15: Location(Levels.DKIsles, "Isles Dirt: Castle Lobby", Items.RainbowCoin, Types.RainbowCoin, Kongs.any, [MapIDCombo(Maps.CreepyCastleLobby, -1, 0x2AD)]),  # Castle Lobby
 }
 
 TrainingBarrelLocations = {

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -850,6 +850,10 @@ class Settings:
         if self.random_medal_requirement:
             # Range roughly from 4 to 15, average around 10
             self.medal_requirement = round(random.normalvariate(10, 1.5))
+        self.original_medal_requirement = self.medal_requirement
+        self.logical_medal_requirement = min(math.floor(self.medal_requirement * 1.2), 40)
+        self.original_fairy_requirement = self.rareware_gb_fairies
+        self.logical_fairy_requirement = min(math.floor(self.rareware_gb_fairies * 1.2), 20)
 
         # Boss Rando
         self.boss_maps = ShuffleBosses(self.boss_location_rando)
@@ -940,6 +944,8 @@ class Settings:
         # Some settings (mostly win conditions) require modification of items in order to better generate the spoiler log
         if self.win_condition == WinCondition.all_fairies or self.crown_door_item == HelmDoorItem.req_fairy or self.coin_door_item == HelmDoorItem.req_fairy:
             ItemList[Items.BananaFairy].playthrough = True
+        if self.crown_door_item == HelmDoorItem.req_rainbowcoin or self.coin_door_item == HelmDoorItem.req_rainbowcoin:
+            ItemList[Items.RainbowCoin].playthrough = True
         if self.win_condition == WinCondition.all_blueprints or self.crown_door_item == HelmDoorItem.req_bp or self.coin_door_item == HelmDoorItem.req_bp:
             for item_index in ItemList:
                 if ItemList[item_index].type == Types.Blueprint:

--- a/randomizer/ShufflePatches.py
+++ b/randomizer/ShufflePatches.py
@@ -43,7 +43,7 @@ def addPatch(patch: DirtPatchData, enum_val: int, name: str):
     }
     level_data = level_to_enum[patch.level_name]
     level_data[patch.logicregion].locations.append(LocationLogic(enum_val, patch.logic))
-    LocationList[enum_val].name = f"{level_to_name[patch.level_name]} Dirt Patch ({name})"
+    LocationList[enum_val].name = f"{level_to_name[patch.level_name]} Dirt: {name}"
     LocationList[enum_val].default_mapid_data[0].map = patch.map_id
     LocationList[enum_val].level = patch.level_name
 

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -219,7 +219,7 @@ def test_with_settings_string_1():
     # This top one is always the S2 Preset (probably up to date, if it isn't go steal it from the season2.json)
     settings_string = "bKEFiRorPN5ysnPCBogPQ+qBoRDIhKlsa58B+I0eu0uXxCnLE2nBACoMgt1PX4EkAyaBkF1kssFAXQAgwE6gIHA3YBhAI7gQJBXgChQM8gYLB3oDhgQoQ08e2QpHqKhnKlMubRbwM0NjlFuCFRFgMTEUDF61xyN2q/32RQPAZiqcuUOS2EJIIvoE5IMMGY2mMHFosi0rlgVigthoTiwVCkwEwYEYkHERh0AVQA"
     # This one is for ease of testing, go wild with it
-    # settings_string = "bKEGiRorPE1ecrJzwgDDEsFX7lGKJD0Pj8Ro9dpcviFmpyxRpgRArdT4mBxJFZ7fgSICJoV5XKJPLJVKYyi+yWWCgLoAQYCdQEDgbsAwgEdwIEgrwBQoGeQMFg70BwwIUIbkPf0UqFHIz0SqXVFpMOBFQFgoTAUAl6qgxTxnWzVgExFMXKHJcCgzaYwcWiyQRALSwWw0YCYMCMaCQcTWHA2fz6IgGIw6AKgA+AA"
+    # settings_string = "bKEFiRorPN5ysnPCBogPQ+qBoRDIhKlsa58B+I0eu0uXxCnLE2nBACoMgt1PX4EkAyaBkF1kssFAXQAgwE6gIHA3YBhAI7gQJBXgChQM8gYLB3oDhgQoQ08e2QpHqKhnKlMubRbwM0NjlFuCFSFgMTIUDF61xyN2q/32RQPAZiqcuUOS2EJIIvoE5IMMGY2mMHFosi0rlgVigthoTiwVCkwEwYEYkHERh0AVQA"
 
     settings_dict = decrypt_settings_string_enum(settings_string)
     settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
@@ -314,8 +314,8 @@ def test_with_settings_string_5():
 def test_with_settings_string_6():
     """Confirm that settings strings decryption is working and generate a spoiler log with it."""
     # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
-    # Ice's settings
-    settings_string = "bKEGCRorPE1eKyc8IQwxLBV+5RiiQ9D6oIBEMhTHQlS2Nc+AjR67S5fELNbbHTlijTAgHQKgyC3U+JgEX7EkAybiuUSqMgvMllgoC6AEGAnUBA4G7AMIBHcCBIK8AUKBnkDBYO9AcMCA1Ge3CwVI9RUM6EylUubRbwI1N0W43CipCwIJkKAS9VRQIhkKY6EqWxrnwjOtmuOWq/32RQPAJiqcuUOS4FBh8tFkWlcsFsNCcWCkoDAjEgNiMOgA"
+    # Kamerson's settings
+    settings_string = "bKEGiRorPE1ecrJzwgDDEsFX7lGKJD0Pj8Ro9dpcviFmpyxRpgRArdT4mBxJFZ7fgSICJoV5XKJPLJVKYyi+yWWCgLoAQYCdQEDgbsAwgEdwIEgrwBQoGeQMFg70BwwIUIbkPf0UqFHIz0SqXVFpMOBFQFgoTAUAl6qgxTxnWzVgExFMXKHJcCgzaYwcWiyQRALSwWw0YCYMCMaCQcTWHA2fz6IgGIw6AKgA+AA"
 
     settings_dict = decrypt_settings_string_enum(settings_string)
     settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly

--- a/wiki-lists/KASPLATS.MD
+++ b/wiki-lists/KASPLATS.MD
@@ -7,24 +7,24 @@
 | Map | Name | Logic |
 | --- | ---- | ----- |
 | Jungle Japes | Japes Kasplat: Behind Rambi Wall |  | 
-| Jungle Japes | Japes Kasplat: On top of mountain |  | 
+| Jungle Japes | Japes Kasplat: Top of mountain |  | 
 | Jungle Japes | Japes Kasplat: Beehive Area |  | 
-| Jungle Japes | Japes Kasplat: Lower area of Tunnel to Beehive |  | 
-| Jungle Japes | Japes Kasplat: Upper area of Tunnel to Beehive |  | 
+| Jungle Japes | Japes Kasplat: Hive Tunnel Lower |  | 
+| Jungle Japes | Japes Kasplat: Hive Tunnel Upper |  | 
 | Japes Under Ground | Japes Kasplat: Underground | (l.vines and l.pineapple and l.ischunky) or (l.vines and (l.isdiddy or l.istiny) and l.advanced_platforming and l.settings.free_trade_items) or l.phasewalk | 
-| Jungle Japes | Japes Kasplat: Near Speedy Swing Sortie Bonus |  | 
+| Jungle Japes | Japes Kasplat: Near Lanky Bonus |  | 
 | Jungle Japes | Japes Kasplat: Near Painting Room |  | 
 | Jungle Japes | Japes Kasplat: Inside Tiny's Cage | ((Events.JapesTinySwitch in l.Events or l.phasewalk or l.CanPhaseswim() or l.CanSkew(False)) and l.tiny) | 
 | Jungle Japes | Japes Kasplat: Starting Area |  | 
 | Jungle Japes | Japes Kasplat: Diddy Cave |  | 
 | Jungle Japes | Japes Kasplat: In the river | l.swim and (l.oranges or l.HasGun(Kongs.any) or l.HasInstrument(Kongs.any)) | 
-| Jungle Japes | Japes Kasplat: In the water near Rambi Wall | l.swim and (l.oranges or l.HasGun(Kongs.any) or l.HasInstrument(Kongs.any)) | 
+| Jungle Japes | Japes Kasplat: Rambi Water Pool | l.swim and (l.oranges or l.HasGun(Kongs.any) or l.HasInstrument(Kongs.any)) | 
 | Jungle Japes | Japes Kasplat: Near Cranky's |  | 
-| Jungle Japes | Japes Kasplat: In the Troff 'n' Scoff Alcove |  | 
+| Jungle Japes | Japes Kasplat: Hillside Alcove |  | 
 | Japes Mountain | Japes Kasplat: Inside the Mountain |  | 
 | Japes Tiny Hive | Japes Kasplat: Inside the Shell |  | 
-| Jungle Japes | Japes Kasplat: Up the Hill to the Painting Room | (l.lanky and l.handstand) or (l.tiny and l.twirl) or l.CanMoonkick() or ((l.phasewalk or l.generalclips) and (l.istiny or l.isdiddy)) | 
-| Jungle Japes | Japes Kasplat: In the Minecart Exit |  | 
+| Jungle Japes | Japes Kasplat: Painting Room Hill | (l.lanky and l.handstand) or (l.tiny and l.twirl) or l.CanMoonkick() or ((l.phasewalk or l.generalclips) and (l.istiny or l.isdiddy)) | 
+| Jungle Japes | Japes Kasplat: Minecart Exit |  | 
 </details>
 
 ## Angry Aztec
@@ -33,24 +33,24 @@
 
 | Map | Name | Logic |
 | --- | ---- | ----- |
-| Angry Aztec | Aztec Kasplat: In the Sealed Quicksand Tunnel |  | 
+| Angry Aztec | Aztec Kasplat: DK Quicksand Tunnel |  | 
 | Angry Aztec | Aztec Kasplat: On the Oasis |  | 
-| Angry Aztec | Aztec Kasplat: On the Llama's Cage | l.vines or (l.jetpack and l.isdiddy) or (l.advanced_platforming and (l.istiny or l.isdiddy)) or l.CanMoonkick() | 
-| Angry Aztec | Aztec Kasplat: Near the giant boulder |  | 
-| Angry Aztec | Aztec Kasplat: Behind the DK Stone Door | l.phasewalk or (l.coconut and ((l.strongKong and l.isdonkey) or (l.twirl and l.istiny))) | 
-| Aztec Llama Temple | Aztec Kasplat: In the lava room in Llama Temple |  | 
-| Angry Aztec | Aztec Kasplat: Near the Hunky Chunky Barrel |  | 
+| Angry Aztec | Aztec Kasplat: On Llama Cage | l.vines or (l.jetpack and l.isdiddy) or (l.advanced_platforming and (l.istiny or l.isdiddy)) or l.CanMoonkick() | 
+| Angry Aztec | Aztec Kasplat: Near giant boulder |  | 
+| Angry Aztec | Aztec Kasplat: Behind DK Stone Door | l.phasewalk or (l.coconut and ((l.strongKong and l.isdonkey) or (l.twirl and l.istiny))) | 
+| Aztec Llama Temple | Aztec Kasplat: Llama Temple Lava |  | 
+| Angry Aztec | Aztec Kasplat: Hunky Chunky Barrel |  | 
 | Angry Aztec | Aztec Kasplat: On Tiny Temple | l.jetpack | 
-| Angry Aztec | Aztec Kasplat: In the Vase Room | (l.chunky and l.pineapple) or l.phasewalk | 
-| Angry Aztec | Aztec Kasplat: Behind the 5-Door Temple |  | 
+| Angry Aztec | Aztec Kasplat: In Vase Room | (l.chunky and l.pineapple) or l.phasewalk | 
+| Angry Aztec | Aztec Kasplat: Behind 5-Door Temple |  | 
 | Angry Aztec | Aztec Kasplat: Near Snide's |  | 
-| Aztec Llama Temple | Aztec Kasplat: Below the Llama in Llama Temple |  | 
-| Aztec Tiny Temple | Aztec Kasplat: In the Free Tiny Room |  | 
-| Aztec Chunky5DTemple | Aztec Kasplat: In Chunky 5-Door Temple | (l.pineapple and l.ischunky) or l.phasewalk | 
+| Aztec Llama Temple | Aztec Kasplat: By the Llama in his Temple |  | 
+| Aztec Tiny Temple | Aztec Kasplat: Free Tiny Room |  | 
+| Aztec Chunky5DTemple | Aztec Kasplat: Chunky 5-Door Temple | (l.pineapple and l.ischunky) or l.phasewalk | 
 | Angry Aztec | Aztec Kasplat: Behind the Beetle Race |  | 
-| Aztec Llama Temple | Aztec Kasplat: Inside the Llama Temple Matching Game | l.grape or l.phasewalk | 
-| Aztec Tiny Temple | Aztec Kasplat: Inside Tiny Temple by Mini Monkey Barrel |  | 
-| Aztec Donkey5DTemple | Aztec Kasplat: In Donkey 5-Door Temple | (l.coconut or l.phasewalk) and l.isdonkey | 
+| Aztec Llama Temple | Aztec Kasplat: Lanky Matching Game | l.grape or l.phasewalk | 
+| Aztec Tiny Temple | Aztec Kasplat: Tiny Temple Mini Monkey |  | 
+| Aztec Donkey5DTemple | Aztec Kasplat: Donkey 5-Door Temple | (l.coconut or l.phasewalk) and l.isdonkey | 
 </details>
 
 ## Frantic Factory
@@ -60,22 +60,22 @@
 | Map | Name | Logic |
 | --- | ---- | ----- |
 | Frantic Factory | Factory Kasplat: Starting Area |  | 
-| Frantic Factory | Factory Kasplat: Near the Power Hut |  | 
-| Frantic Factory | Factory Kasplat: Down the pole covered by a Hatch |  | 
-| Frantic Factory | Factory Kasplat: In the Dark Room | (l.punch and l.chunky) or l.phasewalk | 
-| Frantic Factory | Factory Kasplat: On the lowest platform in Production Room |  | 
-| Frantic Factory | Factory Kasplat: Near the slippery pipe in Production Room |  | 
-| Frantic Factory | Factory Kasplat: At the base of Production Room |  | 
-| Frantic Factory | Factory Kasplat: In Research and Development |  | 
-| Frantic Factory | Factory Kasplat: Below the pole to the DK Arcade Machine |  | 
-| Frantic Factory | Factory Kasplat: In Block Tower Room |  | 
+| Frantic Factory | Factory Kasplat: Near Power Hut |  | 
+| Frantic Factory | Factory Kasplat: Down the Hatch Pole |  | 
+| Frantic Factory | Factory Kasplat: Dark Room | (l.punch and l.chunky) or l.phasewalk | 
+| Frantic Factory | Factory Kasplat: Lowest Production Platform |  | 
+| Frantic Factory | Factory Kasplat: Upper Production Pipe |  | 
+| Frantic Factory | Factory Kasplat: Base of Production |  | 
+| Frantic Factory | Factory Kasplat: Research and Development |  | 
+| Frantic Factory | Factory Kasplat: Pole to Arcade |  | 
+| Frantic Factory | Factory Kasplat: Block Tower |  | 
 | Frantic Factory | Factory Kasplat: Near Snide's |  | 
-| Factory Power Hut | Factory Kasplat: In the Power Shed |  | 
-| Frantic Factory | Factory Kasplat: In Research and Development by the Slot Car Race |  | 
-| Frantic Factory | Factory Kasplat: Inside Tiny's Shooting Game | l.mini or l.phasewalk | 
-| Factory Crusher | Factory Kasplat: Inside the Crusher Room |  | 
-| Frantic Factory | Factory Kasplat: Past the Tiny Bonus Barrel in Upper Production | l.twirl | 
-| Frantic Factory | Factory Kasplat: In Lanky's Piano Game | l.trombone or l.CanAccessRNDRoom() | 
+| Factory Power Hut | Factory Kasplat: Power Hut |  | 
+| Frantic Factory | Factory Kasplat: By Car Race |  | 
+| Frantic Factory | Factory Kasplat: Tiny Shooting Game | l.mini or l.phasewalk | 
+| Factory Crusher | Factory Kasplat: Crusher Room |  | 
+| Frantic Factory | Factory Kasplat: Upper Production Twirl | l.twirl | 
+| Frantic Factory | Factory Kasplat: Lanky Piano Game | l.trombone or l.CanAccessRNDRoom() | 
 </details>
 
 ## Gloomy Galleon
@@ -84,22 +84,22 @@
 
 | Map | Name | Logic |
 | --- | ---- | ----- |
-| Gloomy Galleon | Galleon Kasplat: On the Lighthouse island |  | 
-| Gloomy Galleon | Galleon Kasplat: On Diddy's Gold Tower |  | 
-| Gloomy Galleon | Galleon Kasplat: In the Alcove near the Lighthouse |  | 
-| Gloomy Galleon | Galleon Kasplat: On the platforms in Cannon Game Room | l.CanGetOnCannonGamePlatform() | 
-| Gloomy Galleon | Galleon Kasplat: Near the Troff 'n' Scoff near Cranky's |  | 
-| Gloomy Galleon | Galleon Kasplat: On the Cactus near the sunken submarine |  | 
+| Gloomy Galleon | Galleon Kasplat: Lighthouse Platform |  | 
+| Gloomy Galleon | Galleon Kasplat: Diddy Gold Tower |  | 
+| Gloomy Galleon | Galleon Kasplat: Lighthouse Alcove |  | 
+| Gloomy Galleon | Galleon Kasplat: Cannon Game Room | l.CanGetOnCannonGamePlatform() | 
+| Gloomy Galleon | Galleon Kasplat: Past Vines |  | 
+| Gloomy Galleon | Galleon Kasplat: Musical Cactus |  | 
 | Gloomy Galleon | Galleon Kasplat: On the Crown Pad | (l.punch and l.chunky) or l.phasewalk or l.CanSkew(False) | 
 | Gloomy Galleon | Galleon Kasplat: Next to Cranky's |  | 
-| Galleon Lighthouse | Galleon Kasplat: Inside the Lighthouse at the Top |  | 
-| Galleon Mechafish | Galleon Kasplat: Inside the Mechfish |  | 
-| Gloomy Galleon | Galleon Kasplat: On Lanky's Gold Tower | (Events.WaterSwitch in l.Events or (Events.ShipyardEnguarde in l.Events and Events.ShipyardTreasureRoomOpened in l.Events and l.advanced_platforming)) | 
-| Galleon Sick Bay | Galleon Kasplat: In Chunky's Drunk Ship |  | 
-| Gloomy Galleon | Galleon Kasplat: On the Middle Deck of the Shipwreck |  | 
+| Galleon Lighthouse | Galleon Kasplat: Atop Whomp's Lighthouse |  | 
+| Galleon Mechafish | Galleon Kasplat: In the Mechfish |  | 
+| Gloomy Galleon | Galleon Kasplat: Lanky Gold Tower | (Events.WaterSwitch in l.Events or (Events.ShipyardEnguarde in l.Events and Events.ShipyardTreasureRoomOpened in l.Events and l.advanced_platforming)) | 
+| Galleon Sick Bay | Galleon Kasplat: Sickbay |  | 
+| Gloomy Galleon | Galleon Kasplat: Middle Deck of Shipwreck |  | 
 | Gloomy Galleon | Galleon Kasplat: Starting Area |  | 
-| Gloomy Galleon | Galleon Kasplat: Inside a Punchable Chest | l.punch and l.chunky | 
-| Gloomy Galleon | Galleon Kasplat: Also on the Cactus near the sunken submarine |  | 
+| Gloomy Galleon | Galleon Kasplat: Inside Punchable Chest | l.punch and l.chunky | 
+| Gloomy Galleon | Galleon Kasplat: Also Musical Cactus |  | 
 </details>
 
 ## Fungi Forest
@@ -108,27 +108,27 @@
 
 | Map | Name | Logic |
 | --- | ---- | ----- |
-| Fungi Forest | Forest Kasplat: Behind the Diddy Dark Barn |  | 
-| Fungi Forest | Forest Kasplat: Behind the beanstalk |  | 
-| Fungi Forest | Forest Kasplat: Near the rocketbarrel near the Giant Mushroom |  | 
-| Fungi Forest | Forest Kasplat: On the top floor of the Giant Mushroom |  | 
-| Fungi Forest | Forest Kasplat: Near the sleeping Rabbit |  | 
-| Fungi Forest | Forest Kasplat: Near the Troff 'n' Scoff near the Owl's Tree |  | 
+| Fungi Forest | Forest Kasplat: Behind Diddy Barn |  | 
+| Fungi Forest | Forest Kasplat: Behind beanstalk |  | 
+| Fungi Forest | Forest Kasplat: By Giant Mushroom Rocketbarrel |  | 
+| Fungi Forest | Forest Kasplat: Giant Mushroom Top Floor |  | 
+| Fungi Forest | Forest Kasplat: Near the Rabbit |  | 
+| Fungi Forest | Forest Kasplat: Owl Tree Troff |  | 
 | Fungi Forest | Forest Kasplat: Behind DK's Barn |  | 
-| Forest Giant Mushroom | Forest Kasplat: Inside the Giant Mushroom |  | 
-| Fungi Forest | Forest Kasplat: Under the Owl's Tree |  | 
-| Fungi Forest | Forest Kasplat: On a low platform on the exterior of Giant Mushroom |  | 
-| Fungi Forest | Forest Kasplat: On a high platform on the exterior of Giant Mushroom |  | 
-| Fungi Forest | Forest Kasplat: Behind the Cuckoo Clock |  | 
-| Forest Mill Front | Forest Kasplat: Inside the mill |  | 
-| Fungi Forest | Forest Kasplat: In the moat around the Giant Mushroom | l.swim and (l.oranges or l.HasGun(Kongs.any) or l.HasInstrument(Kongs.any)) | 
-| Fungi Forest | Forest Kasplat: At the very top of the Giant Mushroom | l.jetpack or l.handstand | 
-| Fungi Forest | Forest Kasplat: On the Mill Roof |  | 
-| Fungi Forest | Forest Kasplat: In the Minecart Exit Well |  | 
-| Forest Lanky Mushrooms Room | Forest Kasplat: In the Lanky Mushroom Slam Room |  | 
-| Forest Spider | Forest Kasplat: In the Spider Boss |  | 
-| Forest Winch Room | Forest Kasplat: In the Winch Room |  | 
-| Forest Chunky Face Room | Forest Kasplat: In Chunky's Face Shooting Room |  | 
+| Forest Giant Mushroom | Forest Kasplat: Inside Giant Mushroom |  | 
+| Fungi Forest | Forest Kasplat: Under Owl Tree |  | 
+| Fungi Forest | Forest Kasplat: Low Mushroom Exterior |  | 
+| Fungi Forest | Forest Kasplat: Mushroom Night Door |  | 
+| Fungi Forest | Forest Kasplat: Behind Cuckoo Clock |  | 
+| Forest Mill Front | Forest Kasplat: Grinder Room |  | 
+| Fungi Forest | Forest Kasplat: Giant Mushroom Moat | l.swim and (l.oranges or l.HasGun(Kongs.any) or l.HasInstrument(Kongs.any)) | 
+| Fungi Forest | Forest Kasplat: Giant Mushroom Peak | l.jetpack or l.handstand | 
+| Fungi Forest | Forest Kasplat: On Mill Roof |  | 
+| Fungi Forest | Forest Kasplat: Minecart Exit Well |  | 
+| Forest Lanky Mushrooms Room | Forest Kasplat: Lanky Mushroom Slam Room |  | 
+| Forest Spider | Forest Kasplat: Spider Boss |  | 
+| Forest Winch Room | Forest Kasplat: Winch Room |  | 
+| Forest Chunky Face Room | Forest Kasplat: Face Shooting Room |  | 
 </details>
 
 ## Crystal Caves
@@ -138,23 +138,23 @@
 | Map | Name | Logic |
 | --- | ---- | ----- |
 | Crystal Caves | Caves Kasplat: Near Snide's |  | 
-| Crystal Caves | Caves Kasplat: In the room with Tiny's Bonus Barrel |  | 
-| Crystal Caves | Caves Kasplat: Inside an Ice Shield | Events.CavesLargeBoulderButton in l.Events or (l.generalclips and l.ischunky) | 
-| Crystal Caves | Caves Kasplat: On the Cabin with 5 Doors |  | 
-| Crystal Caves | Caves Kasplat: Across the river from Candy's |  | 
-| Crystal Caves | Caves Kasplat: In the room with the Giant Boulder |  | 
-| Crystal Caves | Caves Kasplat: Near the Ice Castle |  | 
-| Crystal Caves | Caves Kasplat: In the Hidden Room by Funky's |  | 
-| Crystal Caves | Caves Kasplat: On the platform near Funky's |  | 
+| Crystal Caves | Caves Kasplat: Bonus Barrel Cave |  | 
+| Crystal Caves | Caves Kasplat: Inside Ice Shield | Events.CavesLargeBoulderButton in l.Events or (l.generalclips and l.ischunky) | 
+| Crystal Caves | Caves Kasplat: On 5-Door Cabin |  | 
+| Crystal Caves | Caves Kasplat: Across river from Candy |  | 
+| Crystal Caves | Caves Kasplat: Giant Boulder Room |  | 
+| Crystal Caves | Caves Kasplat: Near Ice Castle |  | 
+| Crystal Caves | Caves Kasplat: Mini Room by Funky |  | 
+| Crystal Caves | Caves Kasplat: On the Pillar |  | 
 | Crystal Caves | Caves Kasplat: By the Far Warp 2 |  | 
-| Crystal Caves | Caves Kasplat: On the 5-Door Igloo |  | 
-| Crystal Caves | Caves Kasplat: In the water by the Baboon Blast Pad |  | 
-| Crystal Caves | Caves Kasplat: Inbetween Funky's and the Ice Castle |  | 
-| Caves Lanky Race | Caves Kasplat: At the Start of the Beetle Race |  | 
+| Crystal Caves | Caves Kasplat: On 5-Door Igloo |  | 
+| Crystal Caves | Caves Kasplat: Water by Blast Pad |  | 
+| Crystal Caves | Caves Kasplat: Between Funky and Castle |  | 
+| Caves Lanky Race | Caves Kasplat: In the Beetle Race |  | 
 | Crystal Caves | Caves Kasplat: With the Giant Kosha |  | 
-| Caves Diddy Igloo | Caves Kasplat: In Diddy's Igloo |  | 
-| Caves Donkey Cabin | Caves Kasplat: In Donkey's Shooting Cabin |  | 
-| Crystal Caves | Caves Kasplat: In the Gorilla Gone Cave | (l.punch and l.chunky) or l.phasewalk or l.CanPhaseswim() | 
+| Caves Diddy Igloo | Caves Kasplat: In Diddy Igloo |  | 
+| Caves Donkey Cabin | Caves Kasplat: DK Shooting Cabin |  | 
+| Crystal Caves | Caves Kasplat: Gorilla Gone Cave | (l.punch and l.chunky) or l.phasewalk or l.CanPhaseswim() | 
 | Crystal Caves | Caves Kasplat: Starting Area |  | 
 </details>
 
@@ -165,23 +165,23 @@
 | Map | Name | Logic |
 | --- | ---- | ----- |
 | Castle Lower Cave | Castle Kasplat: Behind the Mausoleum |  | 
-| Castle Dungeon | Castle Kasplat: Inside the Dungeon |  | 
-| Creepy Castle | Castle Kasplat: Near the Troff 'n' Scoff at the back of Castle |  | 
-| Castle Ballroom | Castle Kasplat: Inside the Ballroom |  | 
-| Creepy Castle | Castle Kasplat: At the top of the Castle |  | 
+| Castle Dungeon | Castle Kasplat: Dungeon Center |  | 
+| Creepy Castle | Castle Kasplat: Back of Castle Troff |  | 
+| Castle Ballroom | Castle Kasplat: Ballroom |  | 
+| Creepy Castle | Castle Kasplat: Castle Top Level |  | 
 | Castle Tree | Castle Kasplat: Inside the Tree | (l.coconut or l.phasewalk or l.generalclips) and l.isdonkey | 
-| Castle Lower Cave | Castle Kasplat: In the Lower Cave straight ahead |  | 
-| Creepy Castle | Castle Kasplat: Near the upper Warp 2 |  | 
-| Creepy Castle | Castle Kasplat: Near the Crypt Entrance on a lone platform |  | 
+| Castle Lower Cave | Castle Kasplat: Lower Cave Center |  | 
+| Creepy Castle | Castle Kasplat: Near Upper Warp 2 |  | 
+| Creepy Castle | Castle Kasplat: On a lone platform |  | 
 | Castle Upper Cave | Castle Kasplat: Near Candy's |  | 
-| Creepy Castle | Castle Kasplat: In the water near the Tree | l.swim and (l.oranges or l.HasGun(Kongs.any) or l.HasInstrument(Kongs.any)) | 
+| Creepy Castle | Castle Kasplat: Tree Pond | l.swim and (l.oranges or l.HasGun(Kongs.any) or l.HasInstrument(Kongs.any)) | 
 | Creepy Castle | Castle Kasplat: Near Cranky's Hut |  | 
-| Creepy Castle | Castle Kasplat: Near the Rocketbarrel by the drawbridge |  | 
-| Castle Greenhouse | Castle Kasplat: Inside the Greenhouse Maze |  | 
-| Castle Museum | Castle Kasplat: By the Mysterious Pedestal in the Museum | l.monkeyport or l.phasewalk | 
-| Castle Dungeon | Castle Kasplat: In a Cage in the Dungeon | l.punch or l.phasewalk | 
-| Castle Crypt | Castle Kasplat: By the Entrance to the Minecart | l.coconut or l.phasewalk or l.generalclips | 
-| Castle Library | Castle Kasplat: In the Library |  | 
+| Creepy Castle | Castle Kasplat: Lower Rocketbarrel |  | 
+| Castle Greenhouse | Castle Kasplat: Greenhouse |  | 
+| Castle Museum | Castle Kasplat: Museum Mysterious Pedestal | l.monkeyport or l.phasewalk | 
+| Castle Dungeon | Castle Kasplat: Caged in the Dungeon | l.punch or l.phasewalk | 
+| Castle Crypt | Castle Kasplat: Entrance to Minecart | l.coconut or l.phasewalk or l.generalclips | 
+| Castle Library | Castle Kasplat: Library |  | 
 | Creepy Castle | Castle Kasplat: In the Clouds | l.jetpack | 
 </details>
 
@@ -191,23 +191,23 @@
 
 | Map | Name | Logic |
 | --- | ---- | ----- |
-| Isles | Isles Kasplat: On the Beaver Beach |  | 
-| Frantic Factory Lobby | Isles Kasplat: Inside Factory Lobby above the DK Portal | (l.grab and l.donkey) or l.CanMoonkick() or (l.advanced_platforming and (l.istiny or l.isdiddy or l.ischunky)) | 
-| Hideout Helm Lobby | Isles Kasplat: Inside Hideout Helm Lobby | (l.scope and l.coconut) or (l.twirl and l.tiny and l.advanced_platforming) | 
-| Creepy Castle Lobby | Isles Kasplat: Inside Creepy Castle Lobby | (l.coconut and l.donkey) or l.phasewalk | 
-| Crystal Caves Lobby | Isles Kasplat: Inside Crystal Caves Lobby | (l.punch and l.chunky) or l.phasewalk or l.ledgeclip | 
-| Frantic Factory Lobby | Isles Kasplat: Inside Factory Lobby in the ? Box | l.punch and l.chunky | 
-| Gloomy Galleon Lobby | Isles Kasplat: Inside Gloomy Galleon Lobby |  | 
-| Isles | Isles Kasplat: Inside the Rock which is blown up | Events.IslesChunkyBarrelSpawn in l.Events and l.hunkyChunky and l.Slam and l.chunky | 
-| Isles | Isles Kasplat: At the back of Kroc Isle halfway up |  | 
-| Isles | Isles Kasplat: On the Big X Platform |  | 
-| Isles | Isles Kasplat: Behind the house to Fungi Lobby |  | 
-| Crystal Caves Lobby | Isles Kasplat: On the upper platform in Caves Lobby | l.jetpack | 
-| Angry Aztec Lobby | Isles Kasplat: Behind the Feather Gate in Aztec Lobby | l.feather or l.phasewalk | 
-| KLumsy | Isles Kasplat: Inside the Prison Sprint Cage | (l.sprint and l.lanky) or l.phasewalk | 
-| Jungle Japes Lobby | Isles Kasplat: Inside Jungle Japes Lobby |  | 
-| Isles | Isles Kasplat: By the Upper Monkeyport Pad |  | 
+| Isles | Isles Kasplat: Beaver Beach |  | 
+| Frantic Factory Lobby | Isles Kasplat: Factory Lobby above Portal | (l.grab and l.donkey) or l.CanMoonkick() or (l.advanced_platforming and (l.istiny or l.isdiddy or l.ischunky)) | 
+| Hideout Helm Lobby | Isles Kasplat: Helm Lobby | (l.scope and l.coconut) or (l.twirl and l.tiny and l.advanced_platforming) | 
+| Creepy Castle Lobby | Isles Kasplat: Castle Lobby | (l.coconut and l.donkey) or l.phasewalk | 
+| Crystal Caves Lobby | Isles Kasplat: Caves Lobby Punch | (l.punch and l.chunky) or l.phasewalk or l.ledgeclip | 
+| Frantic Factory Lobby | Isles Kasplat: Factory Lobby Box | l.punch and l.chunky | 
+| Gloomy Galleon Lobby | Isles Kasplat: Galleon Lobby |  | 
+| Isles | Isles Kasplat: Inside Big Rock | Events.IslesChunkyBarrelSpawn in l.Events and l.hunkyChunky and l.Slam and l.chunky | 
+| Isles | Isles Kasplat: Back of Kroc Isle Middle |  | 
+| Isles | Isles Kasplat: Big X Platform |  | 
+| Isles | Isles Kasplat: Back of Cabin Isle |  | 
+| Crystal Caves Lobby | Isles Kasplat: Caves Lobby Platform | l.jetpack | 
+| Angry Aztec Lobby | Isles Kasplat: Aztec Lobby Feather Gate | l.feather or l.phasewalk | 
+| KLumsy | Isles Kasplat: Prison Sprint Cage | (l.sprint and l.lanky) or l.phasewalk | 
+| Jungle Japes Lobby | Isles Kasplat: Japes Lobby |  | 
+| Isles | Isles Kasplat: Upper Monkeyport |  | 
 | Isles Snide Room | Isles Kasplat: Near Snide's |  | 
-| Isles | Isles Kasplat: On top of Angry Aztec Lobby |  | 
-| Isles | Isles Kasplat: Beneath the Waterfall | l.swim and (l.oranges or l.HasGun(Kongs.any) or l.HasInstrument(Kongs.any)) | 
+| Isles | Isles Kasplat: Aztec Lobby Roof |  | 
+| Isles | Isles Kasplat: Waterfall Pool | l.swim and (l.oranges or l.HasGun(Kongs.any) or l.HasInstrument(Kongs.any)) | 
 </details>


### PR DESCRIPTION
- Nearly every Kasplat name has been shortened to better accommodate their text in hint windows. This comes in the form of removing grammatical frivolities in favor of delivering as much information as possible in fewer words. The one noteworthy change is "Galleon Kasplat: Near the Troff 'n' Scoff near Cranky's" -> "Galleon Kasplat: Past Vines"
- Dirt patch location names have been slightly shortened by removing "patch"
- The fill now logically places 1.2x the required number of medals/fairies before you can logically access the Rareware Coin/Rareware GB checks respectively. Relevant to Season 2, you will now have at least 6 fairies logically accessible before the Rareware GB check.
- The playthrough will now contain items relevant for your Helm doors more consistently.