### PR TITLE
stray fixes

### DIFF
--- a/randomizer/CollectibleLogicFiles/CrystalCaves.py
+++ b/randomizer/CollectibleLogicFiles/CrystalCaves.py
@@ -145,7 +145,7 @@ LogicRegions = {
         Collectible(Collectibles.coin, Kongs.donkey, lambda l: True, None, 2),
     ],
     Regions.DiddyLowerCabin: [
-        Collectible(Collectibles.bunch, Kongs.diddy, lambda l: l.jetpack or l.advanced_platforming, None, 1),
+        Collectible(Collectibles.bunch, Kongs.diddy, lambda l: True, None, 1),
         Collectible(Collectibles.banana, Kongs.diddy, lambda l: True, None, 5),
 
         Collectible(Collectibles.coin, Kongs.diddy, lambda l: True, None, 4),

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -58,8 +58,8 @@ LogicRegions = {
         TransitionFront(Regions.MushroomLower, lambda l: True, Transitions.ForestMainToLowerMushroom),
         TransitionFront(Regions.MushroomLowerExterior, lambda l: (l.jetpack and l.isdiddy) or (l.advanced_platforming and l.twirl and l.istiny)),
         TransitionFront(Regions.MushroomUpperExterior, lambda l: l.jetpack and l.isdiddy),
-        TransitionFront(Regions.HollowTreeArea, lambda l: l.settings.open_levels or Events.HollowTreeGateOpened in l.Events or l.CanPhaseswim() or l.phasewalk or l.CanOStandTBSNoclip()),
-        TransitionFront(Regions.Anthill, lambda l: l.CanSkew(True), Transitions.ForestTreeToAnthill),
+        TransitionFront(Regions.HollowTreeArea, lambda l: l.settings.open_levels or Events.HollowTreeGateOpened in l.Events or l.CanPhaseswim() or l.phasewalk or l.CanOStandTBSNoclip() or l.CanSkew(True)),
+        TransitionFront(Regions.Anthill, lambda l: l.CanSkew(True), Transitions.ForestTreeToAnthill, isGlitchTransition=True),
         TransitionFront(Regions.CrankyForest, lambda l: True),
     ]),
 


### PR DESCRIPTION
- Fixes a bug where the vanilla banana bunch in Diddy's Lower Cabin in Caves logically requires (rocketbarrel or advanced platforming) to obtain, specifically when CB Rando is disabled. Thanks Spikevegeta for finding this one
- Fixes a potential Random Starting Location bug
- Added skew into logic for the transition from Mushroom Area to Owl Tree Area