### PR TITLE
lzr logic fixes

### DIFF
--- a/randomizer/Enums/Regions.py
+++ b/randomizer/Enums/Regions.py
@@ -15,6 +15,7 @@ class Regions(IntEnum):
     IslesMain = auto()
     OuterIsles = auto()
     IslesMainUpper = auto()
+    IslesEar = auto()
     Prison = auto()
     BananaFairyRoom = auto()
     RarewareGBRoom = auto()

--- a/randomizer/Lists/FairyLocations.py
+++ b/randomizer/Lists/FairyLocations.py
@@ -567,7 +567,7 @@ fairy_locations = {
             region=Regions.ThornvineBarn,
             is_vanilla=True,
             spawn_xyz=[497, 162, 502],
-            logic=lambda l: l.Slam and l.camera,
+            logic=lambda l: l.isdonkey and l.Slam and l.camera,
             natural_index=1,
         ),
         FairyData(

--- a/randomizer/Lists/MapsAndExits.py
+++ b/randomizer/Lists/MapsAndExits.py
@@ -232,6 +232,7 @@ RegionMapList = {
     Regions.IslesMain: Maps.Isles,
     Regions.OuterIsles: Maps.Isles,
     Regions.IslesMainUpper: Maps.Isles,
+    Regions.IslesEar: Maps.Isles,
     Regions.KremIsle: Maps.Isles,
     Regions.KremIsleBeyondLift: Maps.Isles,
     Regions.KremIsleTopLevel: Maps.Isles,

--- a/randomizer/LogicFiles/AngryAztec.py
+++ b/randomizer/LogicFiles/AngryAztec.py
@@ -199,7 +199,7 @@ LogicRegions = {
     ], [
         TransitionFront(Regions.AngryAztecMedals, lambda l: True),
         TransitionFront(Regions.AngryAztecMain, lambda l: True),
-        TransitionFront(Regions.LlamaTempleBack, lambda l: (l.mini and l.tiny) or l.phasewalk or l.ledgeclip or l.CanPhaseswim() or l.CanOStandTBSNoclip()),
+        TransitionFront(Regions.LlamaTempleBack, lambda l: (l.mini and l.tiny) or l.phasewalk or l.ledgeclip or l.CanOStandTBSNoclip()),
     ]),
 
     Regions.LlamaTempleBack: Region("Llama Temple Back", "Llama Temple", Levels.AngryAztec, False, -1, [

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -131,7 +131,13 @@ LogicRegions = {
         TransitionFront(Regions.IslesMain, lambda l: True),
         TransitionFront(Regions.AztecLobbyRoof, lambda l: l.CanMoonkick()),
         TransitionFront(Regions.AngryAztecLobby, lambda l: l.settings.open_lobbies or Events.JapesKeyTurnedIn in l.Events or l.phasewalk, Transitions.IslesMainToAztecLobby),
-        TransitionFront(Regions.CrystalCavesLobby, lambda l: (l.settings.open_lobbies or Events.ForestKeyTurnedIn in l.Events) and (l.isdonkey or l.ischunky or (l.istiny and l.twirl) or ((l.isdiddy or l.islanky) and l.advanced_platforming) or l.CanMoonkick()), Transitions.IslesMainToCavesLobby),
+        TransitionFront(Regions.IslesEar, lambda l: (l.settings.open_lobbies or Events.ForestKeyTurnedIn in l.Events) and (l.isdonkey or l.ischunky or (l.istiny and l.twirl) or ((l.isdiddy or l.islanky) and l.advanced_platforming) or l.CanMoonkick())),
+    ]),
+
+    Regions.IslesEar: Region("Isles Ear", "Main Isle", Levels.DKIsles, False, None, [], [], [
+        TransitionFront(Regions.CrystalCavesLobby, lambda l: True, Transitions.IslesMainToCavesLobby),
+        TransitionFront(Regions.IslesMain, lambda l: True),
+        TransitionFront(Regions.IslesMainUpper, lambda l: l.isdonkey or l.ischunky or (l.istiny and l.twirl) or ((l.isdiddy or l.islanky) and l.advanced_platforming)),
     ]),
 
     Regions.Prison: Region("Prison", "Krem Isle", Levels.DKIsles, False, None, [
@@ -294,7 +300,7 @@ LogicRegions = {
         TransitionFront(Regions.CabinIsle, lambda l: True),
         TransitionFront(Regions.AztecLobbyRoof, lambda l: True),
         TransitionFront(Regions.IslesAboveWaterfall, lambda l: True),
-        TransitionFront(Regions.CrystalCavesLobby, lambda l: (l.settings.open_lobbies or Events.ForestKeyTurnedIn in l.Events)),  # This is likely never relevant because it takes Chunky to spawn the Rocketbarrel
+        TransitionFront(Regions.IslesEar, lambda l: (l.settings.open_lobbies or Events.ForestKeyTurnedIn in l.Events)),  # This is likely never relevant because it takes Chunky to spawn the Rocketbarrel
     ]),
 
     Regions.AztecLobbyRoof: Region("Aztec Lobby Roof", "Main Isle", Levels.DKIsles, False, None, [
@@ -332,7 +338,7 @@ LogicRegions = {
     ], [
         Event(Events.CavesLobbyAccessed, lambda l: True),
     ], [
-        TransitionFront(Regions.IslesMainUpper, lambda l: True, Transitions.IslesCavesLobbyToMain),  # TODO: Possibly add a region for the outside of CrystalCavesLobby
+        TransitionFront(Regions.IslesEar, lambda l: True, Transitions.IslesCavesLobbyToMain),
         TransitionFront(Regions.CrystalCavesMain, lambda l: l.IsLevelEnterable(Levels.CrystalCaves), Transitions.IslesToCaves),
     ]),
 

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -259,7 +259,7 @@ LogicRegions = {
 
     Regions.ThornvineBarn: Region("Thornvine Barn", "Forest Mills", Levels.FungiForest, False, -1, [
         LocationLogic(Locations.ForestDonkeyBarn, lambda l: l.CanSlamSwitch(Levels.FungiForest, 1) and l.isdonkey and (l.vines or l.advanced_platforming), MinigameType.BonusBarrel),  # Krusha can make it by jumping onto the beam first.
-        LocationLogic(Locations.ForestBananaFairyThornvines, lambda l: l.Slam and l.camera),
+        LocationLogic(Locations.ForestBananaFairyThornvines, lambda l: l.isdonkey and l.Slam and l.camera),
     ], [], [
         TransitionFront(Regions.FungiForestMedals, lambda l: True),
         TransitionFront(Regions.ThornvineArea, lambda l: True, Transitions.ForestBarnToMain),

--- a/randomizer/LogicFiles/GloomyGalleon.py
+++ b/randomizer/LogicFiles/GloomyGalleon.py
@@ -27,8 +27,8 @@ LogicRegions = {
         LocationLogic(Locations.GalleonBananaFairybyCranky, lambda l: l.camera and l.punch and l.chunky),
     ], [
         Event(Events.GalleonEntered, lambda l: True),
-        Event(Events.GalleonLankySwitch, lambda l: l.CanSlamSwitch(Levels.GloomyGalleon, 1) and l.lanky),
-        Event(Events.GalleonTinySwitch, lambda l: l.CanSlamSwitch(Levels.GloomyGalleon, 1) and l.tiny),
+        Event(Events.GalleonLankySwitch, lambda l: l.CanSlamSwitch(Levels.GloomyGalleon, 1) and l.lanky and (l.swim or l.settings.high_req)),
+        Event(Events.GalleonTinySwitch, lambda l: l.CanSlamSwitch(Levels.GloomyGalleon, 1) and l.tiny and (l.swim or l.settings.high_req)),
         Event(Events.LighthouseGateOpened, lambda l: l.coconut and l.donkey),
         # Gate to shipyard always open in rando
         Event(Events.ShipyardGateOpened, lambda l: True),
@@ -263,6 +263,8 @@ LogicRegions = {
     ], [], [
         TransitionFront(Regions.GloomyGalleonMedals, lambda l: True),
         TransitionFront(Regions.ShipyardUnderwater, lambda l: True, Transitions.GalleonGuitarToShipyard),
+        TransitionFront(Regions.TriangleShip, lambda l: l.CanPhaseswim()),
+        TransitionFront(Regions.TromboneShip, lambda l: l.CanPhaseswim()),
     ]),
 
     Regions.TromboneShip: Region("Trombone Ship", "5 Door Ship", Levels.GloomyGalleon, False, None, [
@@ -270,6 +272,8 @@ LogicRegions = {
     ], [], [
         TransitionFront(Regions.GloomyGalleonMedals, lambda l: True),
         TransitionFront(Regions.ShipyardUnderwater, lambda l: True, Transitions.GalleonTromboneToShipyard),
+        TransitionFront(Regions.GuitarShip, lambda l: l.CanPhaseswim()),
+        TransitionFront(Regions.TriangleShip, lambda l: l.CanPhaseswim()),
     ]),
 
     Regions.SaxophoneShip: Region("Saxophone Ship", "5 Door Ship", Levels.GloomyGalleon, False, None, [
@@ -278,6 +282,7 @@ LogicRegions = {
     ], [], [
         TransitionFront(Regions.GloomyGalleonMedals, lambda l: True),
         TransitionFront(Regions.ShipyardUnderwater, lambda l: True, Transitions.GalleonSaxophoneToShipyard),
+        TransitionFront(Regions.BongosShip, lambda l: l.CanPhaseswim()),
     ]),
 
     Regions.TriangleShip: Region("Triangle Ship", "5 Door Ship", Levels.GloomyGalleon, False, None, [
@@ -286,6 +291,7 @@ LogicRegions = {
         TransitionFront(Regions.GloomyGalleonMedals, lambda l: True),
         TransitionFront(Regions.ShipyardUnderwater, lambda l: True, Transitions.GalleonTriangleToShipyard),
         TransitionFront(Regions.GuitarShip, lambda l: l.CanPhaseswim()),
+        TransitionFront(Regions.TromboneShip, lambda l: l.CanPhaseswim()),
     ]),
 
     Regions.GalleonBossLobby: Region("Galleon Boss Lobby", "Troff 'N' Scoff", Levels.GloomyGalleon, True, None, [], [], [

--- a/wiki-lists/FAIRIES.MD
+++ b/wiki-lists/FAIRIES.MD
@@ -103,7 +103,7 @@
 
 | Map | Name | Logic |
 | --- | ---- | ----- |
-| Forest Thornvine Barn | DK's Barn | l.Slam and l.camera | 
+| Forest Thornvine Barn | DK's Barn | l.isdonkey and l.Slam and l.camera | 
 | Forest Rafters | Dark Attic | l.guitar and l.isdiddy and l.camera | 
 | Fungi Forest | Above Blue Tunnel | l.camera | 
 | Fungi Forest | Above the Clock | l.camera | 


### PR DESCRIPTION
Some LZR logic fixes discovered yesterday:
- Added better glitch transitions between rooms in the galleon 5 door ship
- Removed a crappy technically possible glitch transition into the back of the llama temple
- Fixed an issue where Caves Lobby could be way too accessible
- It turns out the thornvine barn fairy requires DK to open the box
- Fixed a potential problem with the 2 door ship and not having High Requirements on