### PR TITLE
Plandomizer UI updates (June 2023)

### DIFF
--- a/generate_rando_ui.py
+++ b/generate_rando_ui.py
@@ -46,7 +46,7 @@ async def initialize():
 
     # Module of lists and utils used for plandomizer
     from randomizer.PlandoUtils import PlandoItemFilter, PlandoMinigameFilter, PlandoOptionClassAnnotation, PlandoShopSortFilter
-    from randomizer.Lists.Plandomizer import PlandomizerPanels, PlannableItems, PlannableMinigames, PlannableSpawns, PlannableStartingMoves
+    from randomizer.Lists.Plandomizer import PlandomizerPanels, PlannableItems, PlannableMinigames, PlannableSpawns
 
     js.listeners = []
     js.progression_presets = []
@@ -88,7 +88,6 @@ async def initialize():
         vanilla_warps=VanillaBananaportSelector,
         plando_items=PlannableItems,
         plando_minigames=PlannableMinigames,
-        plando_moves=PlannableStartingMoves,
         plando_panels=PlandomizerPanels,
         plando_spawns=PlannableSpawns
     )

--- a/randomizer/Lists/Plandomizer.py
+++ b/randomizer/Lists/Plandomizer.py
@@ -120,7 +120,10 @@ PlandomizerPanels = {
     },
     "HideoutHelm": {
         "name": "Hideout Helm",
-        "locations": createPlannableLocationObj()
+        "locations": {
+            "All Kongs": [],
+            "Medals": []
+        }
     },
     "Shops": {
         "name": "Shops",
@@ -130,7 +133,7 @@ PlandomizerPanels = {
     #    "name": "Blueprints",
     #    "locations": createPlannableLocationObj()
     #},
-    # Minigames are grouped by level, not by Kong.
+    # Minigames and hints are grouped by level, not by Kong.
     "Minigames": {
         "name": "Minigames",
         "levels": {
@@ -172,15 +175,37 @@ PlandomizerPanels = {
             }
         }
     },
-    # There are no "All Kongs" hints.
     "Hints": {
         "name": "Hints",
-        "locations": {
-            "Donkey": [],
-            "Diddy": [],
-            "Lanky": [],
-            "Tiny": [],
-            "Chunky": []
+        "levels": {
+            "JungleJapes": {
+                "name": "Jungle Japes",
+                "locations": []
+            },
+            "AngryAztec": {
+                "name": "Angry Aztec",
+                "locations": []
+            },
+            "FranticFactory": {
+                "name": "Frantic Factory",
+                "locations": []
+            },
+            "GloomyGalleon": {
+                "name": "Gloomy Galleon",
+                "locations": []
+            },
+            "FungiForest": {
+                "name": "Fungi Forest",
+                "locations": []
+            },
+            "CrystalCaves": {
+                "name": "Crystal Caves",
+                "locations": []
+            },
+            "CreepyCastle": {
+                "name": "Creepy Castle",
+                "locations": []
+            }
         }
     }
 }
@@ -201,14 +226,18 @@ for locationEnum, locationObj in LocationList.items():
         #PlandomizerPanels["Blueprints"]["locations"][kongString].append(locationJson)
         continue
     elif locationObj.type == Types.Hint:
-        PlandomizerPanels["Hints"]["locations"][kongString].append(locationJson)
+        levelName = locationObj.level.name
+        PlandomizerPanels["Hints"]["levels"][levelName]["locations"].append(locationJson)
         HintLocationList.append(locationEnum.name)
     elif locationObj.type == Types.Shop or locationObj.level == Levels.Shops:
         PlandomizerPanels["Shops"]["locations"][kongString].append(locationJson)
         ShopLocationList.append(locationEnum.name)
     else:
         levelName = locationObj.level.name
-        PlandomizerPanels[levelName]["locations"][kongString].append(locationJson)
+        if locationObj.level == Levels.HideoutHelm and locationObj.type == Types.Medal:
+            PlandomizerPanels[levelName]["locations"]["Medals"].append(locationJson)
+        else:
+            PlandomizerPanels[levelName]["locations"][kongString].append(locationJson)
         ItemLocationList.append(locationEnum.name)
 
         # If this is a minigame location, add it to the Minigames list.

--- a/randomizer/Lists/Plandomizer.py
+++ b/randomizer/Lists/Plandomizer.py
@@ -125,15 +125,48 @@ PlandomizerPanels = {
             "Medals": []
         }
     },
+    # Shops, minigames and hints are grouped by level, not by Kong.
     "Shops": {
         "name": "Shops",
-        "locations": createPlannableLocationObj()
+        "levels": {
+            "DKIsles": {
+                "name": "D.K. Isles",
+                "locations": []
+            },
+            "JungleJapes": {
+                "name": "Jungle Japes",
+                "locations": []
+            },
+            "AngryAztec": {
+                "name": "Angry Aztec",
+                "locations": []
+            },
+            "FranticFactory": {
+                "name": "Frantic Factory",
+                "locations": []
+            },
+            "GloomyGalleon": {
+                "name": "Gloomy Galleon",
+                "locations": []
+            },
+            "FungiForest": {
+                "name": "Fungi Forest",
+                "locations": []
+            },
+            "CrystalCaves": {
+                "name": "Crystal Caves",
+                "locations": []
+            },
+            "CreepyCastle": {
+                "name": "Creepy Castle",
+                "locations": []
+            }
+        }
     },
     #"Blueprints": {
     #    "name": "Blueprints",
     #    "locations": createPlannableLocationObj()
     #},
-    # Minigames and hints are grouped by level, not by Kong.
     "Minigames": {
         "name": "Minigames",
         "levels": {
@@ -229,8 +262,13 @@ for locationEnum, locationObj in LocationList.items():
         levelName = locationObj.level.name
         PlandomizerPanels["Hints"]["levels"][levelName]["locations"].append(locationJson)
         HintLocationList.append(locationEnum.name)
-    elif locationObj.type == Types.Shop or locationObj.level == Levels.Shops:
-        PlandomizerPanels["Shops"]["locations"][kongString].append(locationJson)
+    elif locationObj.type == Types.Shop:
+        levelName = locationObj.level.name
+        PlandomizerPanels["Shops"]["levels"][levelName]["locations"].append(locationJson)
+        ShopLocationList.append(locationEnum.name)
+    elif locationObj.level == Levels.Shops:
+        # This is the Rareware coin.
+        PlandomizerPanels["Shops"]["levels"]["DKIsles"]["locations"].append(locationJson)
         ShopLocationList.append(locationEnum.name)
     else:
         levelName = locationObj.level.name

--- a/randomizer/Lists/Plandomizer.py
+++ b/randomizer/Lists/Plandomizer.py
@@ -345,58 +345,6 @@ PlandomizerPanels["Minigames"]["levels"]["HideoutHelm"]["locations"] = [
 # ITEMS #
 #########
 
-# These moves can be specified as starting moves.
-startingMoves = {
-    PlandoItems.BaboonBlast,
-    PlandoItems.StrongKong,
-    PlandoItems.GorillaGrab,
-    PlandoItems.ChimpyCharge,
-    PlandoItems.RocketbarrelBoost,
-    PlandoItems.SimianSpring,
-    PlandoItems.Orangstand,
-    PlandoItems.BaboonBalloon,
-    PlandoItems.OrangstandSprint,
-    PlandoItems.MiniMonkey,
-    PlandoItems.PonyTailTwirl,
-    PlandoItems.Monkeyport,
-    PlandoItems.HunkyChunky,
-    PlandoItems.PrimatePunch,
-    PlandoItems.GorillaGone,
-    PlandoItems.ProgressiveSlam,
-    PlandoItems.ProgressiveSlam,
-    PlandoItems.ProgressiveSlam,
-    PlandoItems.Coconut,
-    PlandoItems.Peanut,
-    PlandoItems.Grape,
-    PlandoItems.Feather,
-    PlandoItems.Pineapple,
-    PlandoItems.Bongos,
-    PlandoItems.Guitar,
-    PlandoItems.Trombone,
-    PlandoItems.Saxophone,
-    PlandoItems.Triangle,
-    PlandoItems.ProgressiveAmmoBelt,
-    PlandoItems.ProgressiveAmmoBelt,
-    PlandoItems.HomingAmmo,
-    PlandoItems.SniperSight,
-    PlandoItems.ProgressiveInstrumentUpgrade,
-    PlandoItems.ProgressiveInstrumentUpgrade,
-    PlandoItems.ProgressiveInstrumentUpgrade,
-    PlandoItems.Swim,
-    PlandoItems.Oranges,
-    PlandoItems.Barrels,
-    PlandoItems.Vines,
-    PlandoItems.Camera,
-    PlandoItems.Shockwave,
-}
-
-# The below moves may be added multiple times as starting moves.
-multipleStartingMoves = {
-    PlandoItems.ProgressiveSlam: 2,
-    PlandoItems.ProgressiveAmmoBelt: 2,
-    PlandoItems.ProgressiveInstrumentUpgrade: 3,
-}
-
 # These PlandoItems enums have multiple Items enums that map to each of them,
 # and so they should not be automatically added to the list of PlannableItems.
 # Handle these manually.
@@ -410,7 +358,6 @@ doNotAutoAddItemSet = {
 }
 
 PlannableItems = []  # Used to select rewards for locations.
-PlannableStartingMoves = []  # Used to select starting moves.
 
 for itemEnum, itemObj in ItemList.items():
     # Only include items that have a matching item in the plando map.
@@ -427,20 +374,6 @@ for itemEnum, itemObj in ItemList.items():
         "value": plandoItemEnum.name
     }
     PlannableItems.append(itemJson)
-
-    # Add this item to the list of possible starting items, if valid.
-    if plandoItemEnum not in startingMoves:
-        continue
-    if plandoItemEnum in multipleStartingMoves:
-        itemCount = multipleStartingMoves[plandoItemEnum]
-        for i in range(1, itemCount+1):
-            multipleItemJson = {
-                "name": itemObj.name,
-                "value": plandoItemEnum.name
-            }
-            PlannableStartingMoves.append(multipleItemJson)
-    else:
-        PlannableStartingMoves.append(itemJson)
 
 PlannableItems.append({
     "name": "Blueprint (Donkey)",

--- a/templates/plandomizer/plandomizer_general.html.jinja2
+++ b/templates/plandomizer/plandomizer_general.html.jinja2
@@ -138,28 +138,6 @@
                     </label>
                 {% endfor %}
             </div>
-            <div class="flex-container">
-                <div class="item-multiselect wide-select">
-                    <p class="select-title">Starting Moves</p>
-                    <select name="plando_starting_moves_selected"
-                            id="plando_starting_moves_selected"
-                            data-toggle="tooltip"
-                            title
-                            class="form-select multi-select"
-                            aria-label="Starting Moves"
-                            multiple
-                            size="10">
-                        <option selected value="">
-                            Random Move(s)
-                        </option>
-                        {% for move in plando_moves %}
-                            <option value="{{move["value"]}}">
-                                {{move["name"]}}
-                            </option>
-                        {% endfor %}
-                    </select>
-                </div>
-            </div>
         </div>
         <div class="col panel"
              style="border-left: 1px solid #e3e3e3;">

--- a/templates/plandomizer/plandomizer_hints.html.jinja2
+++ b/templates/plandomizer/plandomizer_hints.html.jinja2
@@ -13,10 +13,10 @@
         Hints can be a maximum of 900 characters. The only permitted characters
         are letters, numbers, spaces, and the characters ,.-?!
     </div>
-    {% for kong, locations in panel["locations"].items() %}
-        <h3 class="title">{{kong}}</h3>
+    {% for _, levelObj in panel["levels"].items() %}
+        <h3 class="title">{{levelObj["name"]}}</h3>
         <div class="flex-container flex-center">
-            {% for location in locations %}
+            {% for location in levelObj["locations"] %}
                 <div class="location-picker">
                     <label for="plando_{{location["value"]}}_hint" class="location-label">
                         {{location["name"]}}

--- a/templates/plandomizer/plandomizer_shops.html.jinja2
+++ b/templates/plandomizer/plandomizer_shops.html.jinja2
@@ -14,10 +14,10 @@
      role="tabpanel"
      aria-labelledby="nav-plando-{{panelName}}-tab">
     <h2 class="title">{{panel["name"]}}</h2>
-    {% for kong, locations in panel["locations"].items() %}
-        <h3 class="title">{{kong}}</h3>
+    {% for _, levelObj in panel["levels"].items() %}
+        <h3 class="title">{{levelObj["name"]}}</h3>
         <div class="flex-container flex-center">
-            {% for location in locations|plando_shop_sort %}
+            {% for location in levelObj["locations"]|plando_shop_sort %}
                 <div class="location-picker">
                     <label for="plando_{{location["value"]}}_shop_item" class="location-label">
                         {{location["name"]}}

--- a/templates/plandomizer/plandomizer_shops.html.jinja2
+++ b/templates/plandomizer/plandomizer_shops.html.jinja2
@@ -19,11 +19,11 @@
         <div class="flex-container flex-center">
             {% for location in levelObj["locations"]|plando_shop_sort %}
                 <div class="location-picker">
-                    <label for="plando_{{location["value"]}}_shop_item" class="location-label">
+                    <label for="plando_{{location["value"]}}_item" class="location-label">
                         {{location["name"]}}
                     </label>
-                    <select id="plando_{{location["value"]}}_shop_item"
-                            name="plando_{{location["value"]}}_shop_item"
+                    <select id="plando_{{location["value"]}}_item"
+                            name="plando_{{location["value"]}}_item"
                             data-toggle="tooltip"
                             title
                             class="form-select plando-item-select">
@@ -35,19 +35,21 @@
                             </option>
                         {% endfor %}
                     </select>
-                    <label class="shop-cost-picker flex-container flex-center">
-                        Item Cost:
-                        <input type="number"
-                                min="0"
-                                max="255"
-                                step="1"
-                                data-toggle="tooltip"
-                                title
-                                id="plando_{{location["value"]}}_shop_cost"
-                                name="plando_{{location["value"]}}_shop_cost"
-                                class="form-control shop-cost-input">
-                        Coins
-                    </label>
+                    {% if location["value"] != "RarewareCoin" %}
+                        <label class="shop-cost-picker flex-container flex-center">
+                            Item Cost:
+                            <input type="number"
+                                    min="0"
+                                    max="255"
+                                    step="1"
+                                    data-toggle="tooltip"
+                                    title
+                                    id="plando_{{location["value"]}}_shop_cost"
+                                    name="plando_{{location["value"]}}_shop_cost"
+                                    class="form-control shop-cost-input">
+                            Coins
+                        </label>
+                    {% endif %}
                 </div>
             {% endfor %}
         </div>

--- a/ui/plando_validation.py
+++ b/ui/plando_validation.py
@@ -12,50 +12,6 @@ from randomizer.LogicFiles.Shops import LogicRegions
 from randomizer.PlandoUtils import GetNameFromPlandoItem, PlandoEnumMap
 from ui.bindings import bind, bindList
 
-# A full list of locations for starting moves to be placed.
-startingMoveLocations = [
-    Locations.IslesVinesTrainingBarrel,
-    Locations.IslesSwimTrainingBarrel,
-    Locations.IslesOrangesTrainingBarrel,
-    Locations.IslesBarrelsTrainingBarrel,
-    Locations.PreGiven_Location00,
-    Locations.PreGiven_Location01,
-    Locations.PreGiven_Location02,
-    Locations.PreGiven_Location03,
-    Locations.PreGiven_Location04,
-    Locations.PreGiven_Location05,
-    Locations.PreGiven_Location06,
-    Locations.PreGiven_Location07,
-    Locations.PreGiven_Location08,
-    Locations.PreGiven_Location09,
-    Locations.PreGiven_Location10,
-    Locations.PreGiven_Location11,
-    Locations.PreGiven_Location12,
-    Locations.PreGiven_Location13,
-    Locations.PreGiven_Location14,
-    Locations.PreGiven_Location15,
-    Locations.PreGiven_Location16,
-    Locations.PreGiven_Location17,
-    Locations.PreGiven_Location18,
-    Locations.PreGiven_Location19,
-    Locations.PreGiven_Location20,
-    Locations.PreGiven_Location21,
-    Locations.PreGiven_Location22,
-    Locations.PreGiven_Location23,
-    Locations.PreGiven_Location24,
-    Locations.PreGiven_Location25,
-    Locations.PreGiven_Location26,
-    Locations.PreGiven_Location27,
-    Locations.PreGiven_Location28,
-    Locations.PreGiven_Location29,
-    Locations.PreGiven_Location30,
-    Locations.PreGiven_Location31,
-    Locations.PreGiven_Location32,
-    Locations.PreGiven_Location33,
-    Locations.PreGiven_Location34,
-    Locations.PreGiven_Location35
-]
-
 def invalidate_option(element, tooltip):
     """Add a Bootstrap tooltip to the given element, and mark it as invalid."""
     element.setAttribute("data-bs-original-title", tooltip)
@@ -163,22 +119,6 @@ def validate_starting_kong_count(evt):
         invalidate_option(startingKongs, errString)
     else:
         validate_option(startingKongs)
-
-
-@bind("change", "starting_moves_count")
-@bind("change", "plando_starting_moves_selected")
-def validate_starting_move_count(evt):
-    """Raise an error if the starting moves don't match the selected count."""
-    startingMoves = js.document.getElementById("plando_starting_moves_selected")
-    selectedMoves = {x.value for x in startingMoves.selectedOptions}
-    numStartingMoves = int(js.document.getElementById("starting_moves_count").value)
-    if len(selectedMoves) > numStartingMoves or (len(selectedMoves) < numStartingMoves and "" not in selectedMoves):
-        maybePluralMoveText = "move was selected as a starting move" if len(selectedMoves) == 1 else "moves were selected as starting moves"
-        errSuffix = "." if len(selectedMoves) > numStartingMoves else ", and \"Random Move(s)\" was not chosen."
-        errString = f"The number of starting moves was set to {numStartingMoves}, but {len(selectedMoves)} {maybePluralMoveText}{errSuffix}"
-        invalidate_option(startingMoves, errString)
-    else:
-        validate_option(startingMoves)
 
 
 @bind("change", "plando_level_order_", 7)
@@ -377,21 +317,6 @@ def populate_plando_options(form):
         locations_map[blueprint.id] = PlandoItems.GoldenBanana
     plando_form_data["locations"] = locations_map
 
-    # The starting moves require some extra processing. Instead of passing them
-    # as a list, we will use them to fill in the locations for starting moves.
-    # (The list stays part of the data object until validation, when it gets
-    # removed.)
-    if "plando_starting_moves_selected" in plando_form_data:
-        startingMoveDict = dict()
-        startingMoves = plando_form_data["plando_starting_moves_selected"]
-        if startingMoves[0] == PlandoItems.Randomize:
-            startingMoves = startingMoves[1:]
-        for i in range(len(startingMoves)):
-            move = startingMoves[i]
-            location = startingMoveLocations[i]
-            startingMoveDict[location] = move
-        plando_form_data["locations"].update(startingMoveDict)
-
     shops_map = {}
     for shop_cost in shop_cost_objects:
         # Extract the location name.
@@ -474,17 +399,6 @@ def validate_plando_options(settings_dict):
         maybePluralKongText = "Kong was selected as a starting Kong" if len(chosenKongs) == 1 else "Kongs were selected as starting Kongs"
         errSuffix = "." if len(chosenKongs) > numStartingKongs else ", and \"Random Kong(s)\" was not chosen."
         errString = f"The number of starting Kongs was set to {numStartingKongs}, but {len(chosenKongs)} {maybePluralKongText}{errSuffix}"
-        errList.append(errString)
-    
-    # Ensure that the number of chosen moves matches the "number of starting
-    # moves" setting, or that "Random Move(s)" has been chosen. If too many
-    # moves have been selected, that is always an error.
-    chosenMoves = plando_dict.pop("plando_starting_moves_selected")
-    numStartingMoves = int(settings_dict["starting_moves_count"])
-    if len(chosenMoves) > numStartingMoves or (len(chosenMoves) < numStartingMoves and PlandoItems.Randomize not in chosenMoves):
-        maybePluralMoveText = "move was selected as a starting move" if len(chosenMoves) == 1 else "moves were selected as starting moves"
-        errSuffix = "." if len(chosenMoves) > numStartingMoves else ", and \"Random Move(s)\" was not chosen."
-        errString = f"The number of starting moves was set to {numStartingMoves}, but {len(chosenMoves)} {maybePluralMoveText}{errSuffix}"
         errList.append(errString)
 
     # Ensure that no level was selected more than once in the level order.

--- a/ui/plando_validation.py
+++ b/ui/plando_validation.py
@@ -86,7 +86,7 @@ def validate_item_limits(evt):
 def validate_hint_text(evt):
     """Raise an error if any hint contains invalid characters."""
     hintString = evt.target.value
-    if re.search("[^A-Za-z0-9 ,.-?!]", hintString) is not None:
+    if re.search("[^A-Za-z0-9 \,\.\-\?!]", hintString) is not None:
         invalidate_option(evt.target, "Only letters, numbers, spaces, and the characters ,.-?! are allowed in hints.")
     else:
         validate_option(evt.target)
@@ -448,7 +448,7 @@ def validate_plando_options(settings_dict):
         if len(hint) > 900:
             errString = f"The hint for location \"{hintLocationName}\" is longer than the limit of 900 characters."
             errList.append(errString)
-        if re.search("[^A-Za-z0-9 ,.-?!]", hint) is not None:
+        if re.search("[^A-Za-z0-9 \,\.\-\?!]", hint) is not None:
             errString = f"The hint for location \"{hintLocationName}\" contains invalid characters. Only letters, numbers, spaces, and the characters ,.-?! are valid."
             if "'" in hint:
                 errString += " (Apostrophes are not allowed.)"


### PR DESCRIPTION
- The "Starting Moves" selector has been removed, as it will be part of the non-plando randomizer.
- Hideout Helm has been rearranged so all of the medals are part of one group.
- Both Shops and Hints are now arranged by level, instead of by Kong. Across the entire plandomizer UI, levels are now the top-level grouping, followed by Kong. We should keep this consistent in the future.
- The Jetpac game no longer has a price field. It is still on the Shops tab.
- Internally, shop locations are no longer grouped separately from non-shop locations.
- An error with hint text validation has been fixed. (Regex is hard.)