### PR TITLE
bonus barrel shuffle true random

### DIFF
--- a/randomizer/Lists/BananaCoinLocations.py
+++ b/randomizer/Lists/BananaCoinLocations.py
@@ -3444,8 +3444,9 @@ BananaCoinGroupList = {
             group=36,
             map_id=Maps.FranticFactory,
             name="On the archway to R&D",
-            konglist=[Kongs.diddy, Kongs.lanky, Kongs.tiny],
+            konglist=[Kongs.lanky],
             region=Regions.Testing,
+            logic=lambda l: (l.balloon or l.advanced_platforming) and l.islanky,
             locations=[
                 [1.0, 2786, 1119, 1091],
                 [1.0, 2787, 1136, 1135],

--- a/wiki-lists/COINS.MD
+++ b/wiki-lists/COINS.MD
@@ -470,7 +470,7 @@
 | Near dartboard entry | 5 |  | 
 | In Dartboard Mini Tunnel | 2 | (l.istiny and l.mini) or l.phasewalk | 
 | In Dartboard Room | 4 | (l.istiny and l.mini) or l.phasewalk | 
-| On the archway to R&D | 3 |  | 
+| On the archway to R&D | 3 | (l.balloon or l.advanced_platforming) and l.islanky | 
 | On the number game board | 4 |  | 
 | Behind some elevator blocks (2) | 3 |  | 
 | Around a light in R&D | 3 |  | 


### PR DESCRIPTION
- Fixes Bonus Barrel minigames to be truly random, when randomized. This means that the odds of the same minigame being rolled twice are no longer higher than intended.
- Fixed logic for the coin group above the gate from Factory Testing to R&D