### PR TITLE
Choose Starting Moves

### DIFF
--- a/generate_rando_ui.py
+++ b/generate_rando_ui.py
@@ -38,7 +38,7 @@ async def initialize():
     # Module of Lists used for list_selector macros
     from randomizer.Enums.Types import ItemRandoSelector, KeySelector
     from randomizer.Lists.EnemyTypes import EnemySelector
-    from randomizer.Lists.Item import HHItemSelector
+    from randomizer.Lists.Item import HHItemSelector, StartingMoveSelector
     from randomizer.Lists.Logic import GlitchSelector
     from randomizer.Lists.Minigame import MinigameSelector
     from randomizer.Lists.QoL import QoLSelector
@@ -94,6 +94,7 @@ async def initialize():
         plando_panels=PlandomizerPanels,
         plando_spawns=PlannableSpawns,
         points_spread=PointSpreadSelector,
+        starting_moves=StartingMoveSelector,
     )
     js.document.documentElement.innerHTML = ""
     js.document.open()

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -1887,7 +1887,7 @@ def compileSpoilerHints(spoiler):
         Levels.Shops: LevelSpoiler(level_list[Levels.Shops]),
     }
     # Sort the items by level they're found in
-    important_items = ItemPool.Keys() + ItemPool.Kongs(spoiler.settings) + ItemPool.AllKongMoves() + ItemPool.ShockwaveTypeItems(spoiler.settings) + ItemPool.TrainingBarrelAbilities()
+    important_items = ItemPool.Keys() + ItemPool.Kongs(spoiler.settings) + ItemPool.AllKongMoves() + ItemPool.ShockwaveTypeItems(spoiler.settings) + ItemPool.TrainingBarrelAbilities() + [Items.Bean]
     for location_id in LocationList.keys():
         location = LocationList[location_id]
         if location.item in important_items:
@@ -1974,6 +1974,8 @@ def CategorizeItem(item):
         return "Kong"
     elif item.type == Types.Key:
         return "Key"
+    elif item.name == Types.Bean:
+        return "Bean"
     elif item.kong == Kongs.donkey:
         return "Yellow Vial"
     elif item.kong == Kongs.diddy:

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -2118,6 +2118,7 @@ def GenerateMultipathDict(spoiler, useless_locations):
         # Join the Key and K. Rool text together into what will be the core of the hint text
         hint_text_components = []
         if len(path_to_keys) > 0:
+            path_to_keys.sort()
             key_text = "\x04Keys "
             if len(path_to_keys) == 1:
                 key_text = "\x04Key "

--- a/randomizer/Enums/Items.py
+++ b/randomizer/Enums/Items.py
@@ -20,6 +20,7 @@ class Items(IntEnum):
     Barrels = auto()
 
     ProgressiveSlam = auto()
+    ProgressiveSlam2 = auto()
 
     ProgressiveDonkeyPotion = auto()
     BaboonBlast = auto()
@@ -54,6 +55,7 @@ class Items(IntEnum):
     HomingAmmo = auto()
     SniperSight = auto()
     ProgressiveAmmoBelt = auto()
+    ProgressiveAmmoBelt2 = auto()
 
     Bongos = auto()
     Guitar = auto()
@@ -61,6 +63,8 @@ class Items(IntEnum):
     Saxophone = auto()
     Triangle = auto()
     ProgressiveInstrumentUpgrade = auto()
+    ProgressiveInstrumentUpgrade2 = auto()
+    ProgressiveInstrumentUpgrade3 = auto()
 
     Camera = auto()
     Shockwave = auto()

--- a/randomizer/Enums/Settings.py
+++ b/randomizer/Enums/Settings.py
@@ -637,6 +637,7 @@ SettingsMap = {
     "shuffle_loading_zones": ShuffleLoadingZones,
     "sound_type": SoundType,
     "starting_keys_list_selected": Items,
+    "starting_move_list_selected": Items,
     "tiny_colors": CharacterColors,
     "training_barrels": TrainingBarrels,
     "warp_level_list_selected": Maps,
@@ -808,6 +809,8 @@ class SettingsStringEnum(IntEnum):
     points_list_active_moves = 147
     points_list_bean = 148
     random_crates = 149
+    choose_starting_moves = 150
+    starting_move_list_selected = 151
 
 
 # If a setting needs to be removed, add it to this set instead of removing it
@@ -998,6 +1001,8 @@ SettingsStringTypeMap = {
     SettingsStringEnum.points_list_barrel_moves: SettingsStringDataType.int16,
     SettingsStringEnum.points_list_active_moves: SettingsStringDataType.int16,
     SettingsStringEnum.points_list_bean: SettingsStringDataType.int16,
+    SettingsStringEnum.choose_starting_moves: SettingsStringDataType.bool,
+    SettingsStringEnum.starting_move_list_selected: SettingsStringDataType.list,
 }
 
 # ALL LIST SETTINGS NEED AN ENTRY HERE!
@@ -1011,6 +1016,7 @@ SettingsStringListTypeMap = {
     SettingsStringEnum.starting_keys_list_selected: Items,
     SettingsStringEnum.warp_level_list_selected: Maps,
     SettingsStringEnum.hard_mode_selected: HardModeSelected,
+    SettingsStringEnum.starting_move_list_selected: Items,
 }
 
 # This map specifies the minimum and maximum values for numeric settings.

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1975,8 +1975,6 @@ def FillKongsAndMoves(spoiler, placedTypes):
             locationsNeedingMoves.append(locationLogic.id)
     # Fill the empty starting locations
     if any(locationsNeedingMoves):
-        startingMovePool = spoiler.settings.starting_move_list_selected.copy()
-        shuffle(startingMovePool)
         newlyPlacedItems = []
         toBeUnplaced = []
         possibleStartingMoves = ItemPool.AllKongMoves().copy()
@@ -1992,6 +1990,8 @@ def FillKongsAndMoves(spoiler, placedTypes):
         if spoiler.settings.shockwave_status in (ShockwaveStatus.shuffled, ShockwaveStatus.shuffled_decoupled):
             possibleStartingMoves.extend(ItemPool.ShockwaveTypeItems(spoiler.settings))
         shuffle(possibleStartingMoves)
+        startingMovePool = [move for move in spoiler.settings.starting_move_list_selected if move in possibleStartingMoves]  # Moves in the selector must be eligible items - this is to filter out training moves if they are not shuffled
+        shuffle(startingMovePool)
         # For each location needing a move, put in a random valid move
         for locationId in locationsNeedingMoves:
             # If there are moves in the starting move pool, always pick from there first

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1990,7 +1990,9 @@ def FillKongsAndMoves(spoiler, placedTypes):
         if spoiler.settings.shockwave_status in (ShockwaveStatus.shuffled, ShockwaveStatus.shuffled_decoupled):
             possibleStartingMoves.extend(ItemPool.ShockwaveTypeItems(spoiler.settings))
         shuffle(possibleStartingMoves)
-        startingMovePool = [move for move in spoiler.settings.starting_move_list_selected if move in possibleStartingMoves]  # Moves in the selector must be eligible items - this is to filter out training moves if they are not shuffled
+        startingMovePool = [
+            move for move in spoiler.settings.starting_move_list_selected if move in possibleStartingMoves
+        ]  # Moves in the selector must be eligible items - this is to filter out training moves if they are not shuffled
         shuffle(startingMovePool)
         # For each location needing a move, put in a random valid move
         for locationId in locationsNeedingMoves:

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1446,12 +1446,14 @@ def Fill(spoiler):
     FillKongsAndMoves(spoiler, placed_types)
     if spoiler.settings.extreme_debugging:
         DebugCheckAllReachable(spoiler.settings, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types), "all moves")
+
     # Then place Keys
     if Types.Key in spoiler.settings.shuffled_location_types:
         placed_types.append(Types.Key)
         FillShuffledKeys(spoiler, placed_types)
     if spoiler.settings.extreme_debugging:
         DebugCheckAllReachable(spoiler.settings, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types), "Keys")
+
     # Then place misc progression items
     if Types.Bean in spoiler.settings.shuffled_location_types:
         placed_types.append(Types.Bean)
@@ -1965,17 +1967,16 @@ def FillKongsAndMoves(spoiler, placedTypes):
     placedMoves = [Items.Donkey, Items.Diddy, Items.Lanky, Items.Tiny, Items.Chunky]  # Kongs are now placed, either in the above method or by default
 
     # First place our starting moves randomly
-    startingMoves = []
     locationsNeedingMoves = []
     # We can expect that all locations in this region are starting move locations or Training Barrels
     for locationLogic in RegionList[Regions.GameStart].locations:
         location = LocationList[locationLogic.id]
         if location.item is None and not location.inaccessible:
             locationsNeedingMoves.append(locationLogic.id)
-        elif location.item not in (None, Items.NoItem):
-            startingMoves.append(location.item)
     # Fill the empty starting locations
     if any(locationsNeedingMoves):
+        startingMovePool = spoiler.settings.starting_move_list_selected.copy()
+        shuffle(startingMovePool)
         newlyPlacedItems = []
         toBeUnplaced = []
         possibleStartingMoves = ItemPool.AllKongMoves().copy()
@@ -1991,12 +1992,16 @@ def FillKongsAndMoves(spoiler, placedTypes):
         if spoiler.settings.shockwave_status in (ShockwaveStatus.shuffled, ShockwaveStatus.shuffled_decoupled):
             possibleStartingMoves.extend(ItemPool.ShockwaveTypeItems(spoiler.settings))
         shuffle(possibleStartingMoves)
-        if spoiler.settings.start_with_a_slam:  # Force a slam to be the first item chosen from the random list of moves
-            possibleStartingMoves.remove(Items.ProgressiveSlam)
-            possibleStartingMoves.append(Items.ProgressiveSlam)
         # For each location needing a move, put in a random valid move
         for locationId in locationsNeedingMoves:
-            startingMove = possibleStartingMoves.pop()
+            # If there are moves in the starting move pool, always pick from there first
+            if len(startingMovePool) > 0:
+                startingMove = startingMovePool.pop()
+                if startingMove in possibleStartingMoves:  # Make sure to ward off issues of duplication
+                    possibleStartingMoves.remove(startingMove)
+            # Otherwise, pick from any random eligible move
+            else:
+                startingMove = possibleStartingMoves.pop()
             # If we picked a move to place that we already placed, we have to go Unplace it later
             if startingMove in placedMoves:
                 toBeUnplaced.append(startingMove)

--- a/randomizer/Lists/Item.py
+++ b/randomizer/Lists/Item.py
@@ -100,6 +100,7 @@ ItemList = {
     Items.Oranges: Item("Oranges", True, Types.TrainingBarrel, Kongs.any, [MoveTypes.Flag, "orange", 388]),
     Items.Barrels: Item("Barrels", True, Types.TrainingBarrel, Kongs.any, [MoveTypes.Flag, "barrel", 389]),
     Items.ProgressiveSlam: Item("Progressive Slam", True, Types.Shop, Kongs.any, [MoveTypes.Slam, 2, -1]),
+    Items.ProgressiveSlam2: Item("Progressive Slam ", False, Types.Constant, Kongs.any),  # Only used for the starting move list selector modal
     Items.ProgressiveDonkeyPotion: Item("Progressive Donkey Potion", True, Types.Shop, Kongs.donkey, [MoveTypes.Moves, 1, -1]),
     Items.BaboonBlast: Item("Baboon Blast", True, Types.Shop, Kongs.donkey, [MoveTypes.Moves, 1, 0x8001]),
     Items.StrongKong: Item("Strong Kong", True, Types.Shop, Kongs.donkey, [MoveTypes.Moves, 2, 0x8002]),
@@ -128,12 +129,15 @@ ItemList = {
     Items.HomingAmmo: Item("Homing Ammo", True, Types.Shop, Kongs.any, [MoveTypes.Guns, 2, 0xD202]),
     Items.SniperSight: Item("Sniper Sight", True, Types.Shop, Kongs.any, [MoveTypes.Guns, 3, 0xD203]),
     Items.ProgressiveAmmoBelt: Item("Progressive Ammo Belt", False, Types.Shop, Kongs.any, [MoveTypes.AmmoBelt, 1, -1]),
+    Items.ProgressiveAmmoBelt2: Item("Progressive Ammo Belt ", False, Types.Constant, Kongs.any),  # Only used for the starting move list selector modal
     Items.Bongos: Item("Bongos", True, Types.Shop, Kongs.donkey, [MoveTypes.Instruments, 1, 0x8401]),
     Items.Guitar: Item("Guitar", True, Types.Shop, Kongs.diddy, [MoveTypes.Instruments, 1, 0x9401]),
     Items.Trombone: Item("Trombone", True, Types.Shop, Kongs.lanky, [MoveTypes.Instruments, 1, 0xA401]),
     Items.Saxophone: Item("Saxophone", True, Types.Shop, Kongs.tiny, [MoveTypes.Instruments, 1, 0xB401]),
     Items.Triangle: Item("Triangle", True, Types.Shop, Kongs.chunky, [MoveTypes.Instruments, 1, 0xC401]),
     Items.ProgressiveInstrumentUpgrade: Item("Progressive Instrument Upgrade", False, Types.Shop, Kongs.any, [MoveTypes.Instruments, 2, -1]),
+    Items.ProgressiveInstrumentUpgrade2: Item("Progressive Instrument Upgrade ", False, Types.Constant, Kongs.any),  # Only used for the starting move list selector modal
+    Items.ProgressiveInstrumentUpgrade3: Item("Progressive Instrument Upgrade  ", False, Types.Constant, Kongs.any),  # Only used for the starting move list selector modal
     Items.Camera: Item("Fairy Camera", True, Types.Shockwave, Kongs.any, [MoveTypes.Flag, "camera", 0x2FD]),
     Items.Shockwave: Item("Shockwave", True, Types.Shockwave, Kongs.any, [MoveTypes.Flag, "shockwave", 377]),
     Items.CameraAndShockwave: Item(
@@ -306,12 +310,12 @@ StartingMoveOptions = [
     Items.HomingAmmo,
     Items.SniperSight,
     Items.ProgressiveSlam,
-    Items.ProgressiveSlam,
+    Items.ProgressiveSlam2,
     Items.ProgressiveAmmoBelt,
-    Items.ProgressiveAmmoBelt,
+    Items.ProgressiveAmmoBelt2,
     Items.ProgressiveInstrumentUpgrade,
-    Items.ProgressiveInstrumentUpgrade,
-    Items.ProgressiveInstrumentUpgrade,
+    Items.ProgressiveInstrumentUpgrade2,
+    Items.ProgressiveInstrumentUpgrade3,
 ]
 
 for item in StartingMoveOptions:

--- a/randomizer/Lists/Item.py
+++ b/randomizer/Lists/Item.py
@@ -271,3 +271,48 @@ HHItems = [
 ]
 for item in HHItems:
     HHItemSelector.append({"name": item[0], "value": item[0].lower().replace(" ", "_"), "tooltip": "", "default": item[1]})
+
+StartingMoveSelector = []
+StartingMoveOptions = [
+    Items.Vines,
+    Items.Swim,
+    Items.Oranges,
+    Items.Barrels,
+    Items.Coconut,
+    Items.Bongos,
+    Items.BaboonBlast,
+    Items.StrongKong,
+    Items.GorillaGrab,
+    Items.Peanut,
+    Items.Guitar,
+    Items.ChimpyCharge,
+    Items.RocketbarrelBoost,
+    Items.SimianSpring,
+    Items.Grape,
+    Items.Trombone,
+    Items.Orangstand,
+    Items.BaboonBalloon,
+    Items.OrangstandSprint,
+    Items.Feather,
+    Items.Saxophone,
+    Items.MiniMonkey,
+    Items.PonyTailTwirl,
+    Items.Monkeyport,
+    Items.Pineapple,
+    Items.Triangle,
+    Items.HunkyChunky,
+    Items.PrimatePunch,
+    Items.GorillaGone,
+    Items.HomingAmmo,
+    Items.SniperSight,
+    Items.ProgressiveSlam,
+    Items.ProgressiveSlam,
+    Items.ProgressiveAmmoBelt,
+    Items.ProgressiveAmmoBelt,
+    Items.ProgressiveInstrumentUpgrade,
+    Items.ProgressiveInstrumentUpgrade,
+    Items.ProgressiveInstrumentUpgrade,
+]
+
+for item in StartingMoveOptions:
+    StartingMoveSelector.append({"name": ItemList[item].name, "value": item.name, "tooltip": ""})

--- a/randomizer/SettingStrings.py
+++ b/randomizer/SettingStrings.py
@@ -103,6 +103,7 @@ settingsExclusionMap = {
         ]
     },
     "shuffle_items": {False: ["item_rando_list_selected"]},
+    "choose_starting_moves": {False: ["starting_move_list_selected"]},
     "enemy_rando": {False: ["enemies_selected"]},
     "bonus_barrel_rando": {False: ["minigames_list_selected"]},
     "bananaport_rando": {BananaportRando.off: ["warp_level_list_selected"]},

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -237,7 +237,6 @@ class Settings:
         self.kasplat_rando_setting = None
         self.puzzle_rando = None
         self.shuffle_shops = None
-        self.start_with_a_slam = False
         self.extreme_debugging = False  # Use when you want to know VERY specifically where things fail in the fill - unnecessarily slows seed generation!
 
         # The major setting for item randomization
@@ -461,6 +460,7 @@ class Settings:
         self.excluded_songs_selected = []
         self.enemies_selected = []
         self.glitches_selected = []
+        self.starting_move_list_selected = []
         self.starting_keys_list_selected = []
         self.warp_level_list_selected = []
         self.select_keys = False

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -515,6 +515,19 @@ class Settings:
 
     def resolve_settings(self):
         """Resolve settings which are not directly set through the UI."""
+        # Correct the invalid items in the starting move selector
+        copy_of_starting_move_list_selected = self.starting_move_list_selected.copy()
+        for item in copy_of_starting_move_list_selected:
+            if item == Items.ProgressiveSlam2:
+                self.starting_move_list_selected.remove(item)
+                self.starting_move_list_selected.append(Items.ProgressiveSlam)
+            if item == Items.ProgressiveAmmoBelt2:
+                self.starting_move_list_selected.remove(item)
+                self.starting_move_list_selected.append(Items.ProgressiveAmmoBelt)
+            elif item in (Items.ProgressiveInstrumentUpgrade2, Items.ProgressiveInstrumentUpgrade3):
+                self.starting_move_list_selected.remove(item)
+                self.starting_move_list_selected.append(Items.ProgressiveInstrumentUpgrade)
+
         # If we're using the vanilla door shuffle, turn both wrinkly and tns rando on
         if self.vanilla_door_rando:
             self.wrinkly_location_rando = True

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -70,6 +70,19 @@
                             default="0"
                             placeholder="0"/>
                 </div>
+                <div class="item-select">
+                    <div class="form-check form-switch">
+                        <label data-toggle="tooltip" title="Items are shuffled amongst each other.">
+                            <input class="form-check-input"
+                                    type="checkbox"
+                                    name="choose_starting_moves"
+                                    id="choose_starting_moves"
+                                    value="True"/>
+                            Choose Starting Moves
+                        </label>
+                        {{ list_selector(starting_moves, "starting_move_list", "CHOOSE STARTING MOVES", "This will open a popup that will let you pick the moves that are eligible to be starting moves.", 38) }}
+                        {# Remove end </div> as it's included in the macro for formatting #}
+                </div>
             </div>
             <hr>
             <h2 class="title">SHUFFLED LOCATIONS</h2>

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -25,6 +25,7 @@ from ui.rando_options import (
     max_starting_moves_count,
     set_preset_options,
     toggle_b_locker_boxes,
+    toggle_choose_starting_items,
     toggle_counts_boxes,
     toggle_item_rando,
     toggle_key_settings,
@@ -71,3 +72,4 @@ toggle_key_settings(None)
 disable_helm_hurry(None)
 toggle_vanilla_door_rando(None)
 enable_plandomizer(None)
+toggle_choose_starting_items(None)

--- a/ui/generate_buttons.py
+++ b/ui/generate_buttons.py
@@ -33,6 +33,7 @@ from ui.rando_options import (
     max_starting_moves_count,
     toggle_b_locker_boxes,
     toggle_bananaport_selector,
+    toggle_choose_starting_items,
     toggle_counts_boxes,
     toggle_item_rando,
     toggle_key_settings,
@@ -135,6 +136,7 @@ def import_settings_string(event):
     disable_helm_phases(None)
     max_starting_moves_count(None)
     enable_plandomizer(None)
+    toggle_choose_starting_items(None)
 
 
 @bind("change", "patchfileloader")

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -651,6 +651,7 @@ def disable_move_shuffles(evt):
     training_barrels = js.document.getElementById("training_barrels")
     shockwave_status = js.document.getElementById("shockwave_status")
     starting_moves_count = js.document.getElementById("starting_moves_count")
+    choose_starting_moves = js.document.getElementById("choose_starting_moves")
     try:
         if moves.value == "start_with":
             prices.setAttribute("disabled", "disabled")
@@ -660,6 +661,8 @@ def disable_move_shuffles(evt):
             shockwave_status.setAttribute("disabled", "disabled")
             starting_moves_count.value = 40
             starting_moves_count.setAttribute("disabled", "disabled")
+            choose_starting_moves.checked = False
+            choose_starting_moves.setAttribute("disabled", "disabled")
         elif moves.value == "off":
             prices.removeAttribute("disabled")
             training_barrels.value = "normal"
@@ -668,11 +671,14 @@ def disable_move_shuffles(evt):
             shockwave_status.setAttribute("disabled", "disabled")
             starting_moves_count.value = 40
             starting_moves_count.setAttribute("disabled", "disabled")
+            choose_starting_moves.checked = False
+            choose_starting_moves.setAttribute("disabled", "disabled")
         else:
             prices.removeAttribute("disabled")
             training_barrels.removeAttribute("disabled")
             shockwave_status.removeAttribute("disabled")
             starting_moves_count.removeAttribute("disabled")
+            choose_starting_moves.removeAttribute("disabled")
     except AttributeError:
         pass
 
@@ -938,6 +944,7 @@ def preset_select_changed(event):
     toggle_logic_type(None)
     toggle_key_settings(None)
     max_starting_moves_count(None)
+    toggle_choose_starting_items(None)
 
 
 @bind("click", "enable_plandomizer")
@@ -1215,3 +1222,19 @@ def toggle_vanilla_door_rando(evt):
     else:
         wrinkly_rando.removeAttribute("disabled")
         tns_rando.removeAttribute("disabled")
+
+
+@bind("click", "choose_starting_moves")
+def toggle_choose_starting_items(evt):
+    """Enable or disable the starting item selector modal."""
+    disabled = True
+    selector = js.document.getElementById("starting_move_list_modal")
+    if js.document.getElementById("choose_starting_moves").checked:
+        disabled = False
+    try:
+        if disabled:
+            selector.setAttribute("disabled", "disabled")
+        else:
+            selector.removeAttribute("disabled")
+    except AttributeError:
+        pass

--- a/wiki-lists/CUSTOM_LOCATIONS.MD
+++ b/wiki-lists/CUSTOM_LOCATIONS.MD
@@ -135,7 +135,7 @@
 | Frantic Factory | Storage Room Corner |  | 
 | Frantic Factory | Cranky/Candy Room |  | 
 | Frantic Factory | Near Candy |  | 
-| Frantic Factory | Dark Room Corner | (l.punch and l.chunky) or l.phasewalk, group=4) | 
+| Frantic Factory | Dark Room Corner | (l.punch and l.chunky) or l.phasewalk, group=4 | 
 | Frantic Factory | Arcade Room Bench |  | 
 | Frantic Factory | Next to DK Arcade |  | 
 | Frantic Factory | Near Snide (1) |  | 


### PR DESCRIPTION
Added a starting move selector. You can pick any number of moves in the modal and one of the following will happen:
- If the number of selected moves matches the number of starting moves, you start with those moves
- If the number of selected moves is less than the number of starting moves, you start with the selected moves and random moves to reach the appropriate number of starting moves
- If the number of selected moves is greater than the number of starting moves, you start with a random selection of the selected moves up to the appropriate number of starting moves

Also some small hint fixes:
- Fixed an issue where the Bean would never have any point value
- Added Bean to Vials spoilers
- Taught Wrinkly how to count keys in order