### PR TITLE
minor bug fixes

### DIFF
--- a/randomizer/Lists/CBLocations/FranticFactoryCBLocations.py
+++ b/randomizer/Lists/CBLocations/FranticFactoryCBLocations.py
@@ -1553,6 +1553,7 @@ BalloonList = [
         speed=4,
         konglist=[Kongs.chunky],
         region=Regions.RandD,
+        logic=lambda l: l.punch and l.triangle,
         points=[[5086, 1580, 1562], [4830, 1560, 1948]],
     ),
     Balloon(

--- a/randomizer/Prices.py
+++ b/randomizer/Prices.py
@@ -57,12 +57,12 @@ VanillaPrices = {
     Items.Trombone: 3,
     Items.Saxophone: 3,
     Items.Triangle: 3,
-    Items.ProgressiveSlam: [5, 7],
+    Items.ProgressiveSlam: [0, 5, 7],
     Items.ProgressiveAmmoBelt: [3, 5],
     Items.ProgressiveInstrumentUpgrade: [5, 7, 9],
 }
 
-ProgressiveMoves = {Items.ProgressiveSlam: 2, Items.ProgressiveAmmoBelt: 2, Items.ProgressiveInstrumentUpgrade: 3}
+ProgressiveMoves = {Items.ProgressiveSlam: 3, Items.ProgressiveAmmoBelt: 2, Items.ProgressiveInstrumentUpgrade: 3}
 
 
 def CompleteVanillaPrices():

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -652,6 +652,7 @@ def disable_move_shuffles(evt):
     shockwave_status = js.document.getElementById("shockwave_status")
     starting_moves_count = js.document.getElementById("starting_moves_count")
     choose_starting_moves = js.document.getElementById("choose_starting_moves")
+    start_with_slam = js.document.getElementById("start_with_slam")
     try:
         if moves.value == "start_with":
             prices.setAttribute("disabled", "disabled")
@@ -663,6 +664,8 @@ def disable_move_shuffles(evt):
             starting_moves_count.setAttribute("disabled", "disabled")
             choose_starting_moves.checked = False
             choose_starting_moves.setAttribute("disabled", "disabled")
+            start_with_slam.checked = True
+            start_with_slam.setAttribute("disabled", "disabled")
         elif moves.value == "off":
             prices.removeAttribute("disabled")
             training_barrels.value = "normal"
@@ -673,12 +676,15 @@ def disable_move_shuffles(evt):
             starting_moves_count.setAttribute("disabled", "disabled")
             choose_starting_moves.checked = False
             choose_starting_moves.setAttribute("disabled", "disabled")
+            start_with_slam.checked = True
+            start_with_slam.setAttribute("disabled", "disabled")
         else:
             prices.removeAttribute("disabled")
             training_barrels.removeAttribute("disabled")
             shockwave_status.removeAttribute("disabled")
             starting_moves_count.removeAttribute("disabled")
             choose_starting_moves.removeAttribute("disabled")
+            start_with_slam.removeAttribute("disabled")
     except AttributeError:
         pass
 

--- a/wiki-lists/COLORED_BANANAS.MD
+++ b/wiki-lists/COLORED_BANANAS.MD
@@ -551,7 +551,7 @@
 | Piano game right side | Balloon | l.trombone | 
 | In window by car race Mini Monkey | Balloon |  | 
 | Tunnel to car race | Balloon |  | 
-| Chunky R&D room | Balloon |  | 
+| Chunky R&D room | Balloon | l.punch and l.triangle | 
 | Cranky/Candy room | Balloon |  | 
 | Chunky room above blue switch | Balloon |  | 
 | Chunky room above dark room entrance | Balloon |  | 

--- a/wiki-lists/CUSTOM_LOCATIONS.MD
+++ b/wiki-lists/CUSTOM_LOCATIONS.MD
@@ -191,7 +191,7 @@
 | Gloomy Galleon | Next to Lighthouse ladder |  | 
 | Gloomy Galleon | Lighthouse: Under Enguarde Box | Events.LighthouseEnguarde in l.Events | 
 | Gloomy Galleon | In Enguarde Alcove | Events.LighthouseEnguarde in l.Events | 
-| Gloomy Galleon | In Front of Mermaid Palace | logic=lambda l:Events.LighthouseEnguarde in l.Events | 
+| Gloomy Galleon | In Front of Mermaid Palace | Events.LighthouseEnguarde in l.Events | 
 | Gloomy Galleon | On Rocketbarrel platform |  | 
 | Gloomy Galleon | Blueprint Alcove |  | 
 | Gloomy Galleon | Behind Snide's |  | 


### PR DESCRIPTION
- Fixed a bug preventing seeds from generating if 3 slams were placed in shops
- Fixed a bug where seeds with vanilla prices wouldn't generate if Start with Simian Slam was disabled
- Fixed logic for the custom balloon location in Chunky's R&D room
- Fixed a UI bug where it was possible to select vanilla move locations and choose not to start with Simian Slam