### PR TITLE
Fixed issue forcing starting with slam

### DIFF
--- a/randomizer/Lists/CBLocations/GloomyGalleonCBLocations.py
+++ b/randomizer/Lists/CBLocations/GloomyGalleonCBLocations.py
@@ -524,6 +524,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.Shipyard,
         locations=[[5, 1.0, 3604, 1620, 1883], [5, 1.0, 3555, 1620, 1933]],
+        logic=lambda l: Events.WaterSwitch in l.Events,
     ),
     ColoredBananaGroup(
         group=47,
@@ -532,6 +533,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.Shipyard,
         locations=[[5, 1.0, 3930, 1620, 1486], [5, 1.0, 3867, 1620, 1325]],
+        logic=lambda l: Events.WaterSwitch in l.Events,
     ),
     ColoredBananaGroup(
         group=48,

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -228,7 +228,7 @@ class Settings:
         self.bonus_barrel_rando = None
         self.loading_zone_coupled = None
         self.move_rando = MoveRando.off
-        self.start_with_slam = True
+        self.start_with_slam = False
         self.random_patches = None
         self.random_crates = None
         self.random_fairies = None
@@ -550,6 +550,8 @@ class Settings:
         if Items.ProgressiveSlam in self.starting_move_list_selected:
             self.start_with_slam = True
             self.starting_move_list_selected.remove(Items.ProgressiveSlam)
+        else:
+            self.start_with_slam = False
         # If we are *guaranteed* to start with ALL training moves, put them in their vanilla locations and don't make them hintable, as before
         if (
             Items.Vines in self.starting_move_list_selected

--- a/static/presets/default.json
+++ b/static/presets/default.json
@@ -129,7 +129,7 @@
     "spoiler_hints": "off",
     "spoiler_include_level_order": false,
     "spoiler_include_woth_count": false,
-    "start_with_slam": true,
+    "start_with_slam": false,
     "starting_keys_list_selected": [],
     "starting_move_list_selected": [],
     "starting_kongs_count": 3,

--- a/wiki-lists/COLORED_BANANAS.MD
+++ b/wiki-lists/COLORED_BANANAS.MD
@@ -658,8 +658,8 @@
 | On ship part by Candy's store | 10 |  | 
 | By submarine entrance | 5 |  | 
 | On seafloor from 5DS to submarine area | 10 |  | 
-| On floating plank with 4 DK coins | 10 |  | 
-| Plank in front of Funky (Melon crate) | 10 |  | 
+| On floating plank with 4 DK coins | 10 | Events.WaterSwitch in l.Events | 
+| Plank in front of Funky (Melon crate) | 10 | Events.WaterSwitch in l.Events | 
 | On stalactite between 5DS and mech fish | 5 |  | 
 | Around Funky's store | 20 |  | 
 | Cactus on guitar pad | 5 |  | 


### PR DESCRIPTION
- Fixed an issue that prevented starting without a slam
- Some CBs in Galleon above the floating planks now logically require the water to be raised. This isn't all of them, just the ones on the thin planks (not the shop platforms).