### PR TITLE
Generate patch from history

### DIFF
--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -396,7 +396,8 @@ class LogicVarHolder:
         self.shockwave = self.shockwave or Items.CameraAndShockwave in ownedItems or Items.Shockwave in ownedItems
 
         self.scope = self.scope or Items.SniperSight in ownedItems
-        self.homing = self.homing or Items.HomingAmmo in ownedItems
+        # Having the homing ammo ability also requires having reliable access to homing ammo. This is not a perfect fix, but should cover 99.9% of cases and won't show up in hint paths.
+        self.homing = self.homing or (Items.HomingAmmo in ownedItems and (Events.ForestEntered in self.Events or Events.CastleEntered in self.Events or self.assumeFillSuccess))
 
         self.superSlam = self.Slam >= 2
         self.superDuperSlam = self.Slam >= 3

--- a/randomizer/Patching/ApplyLocal.py
+++ b/randomizer/Patching/ApplyLocal.py
@@ -33,7 +33,7 @@ class BooleanProperties:
         self.target = target
 
 
-async def patching_response(data, from_patch_gen=False):
+async def patching_response(data, from_patch_gen=False, lanky_from_history=False):
     """Apply the patch data to the ROM in the BROWSER not the server."""
     from datetime import datetime
     import time
@@ -62,8 +62,12 @@ async def patching_response(data, from_patch_gen=False):
     settings = Settings(serialize_settings())
     seed_id = str(extracted_variables["seed_id"].decode("utf-8"))
     spoiler = json.loads(extracted_variables["spoiler_log"])
-    # Make sure we re-load the seed id
-    if settings.download_patch_file and from_patch_gen is False:
+    # Make sure we re-load the seed id for patch file creation
+    if lanky_from_history:
+        js.save_text_as_file(data, f"dk64r-patch-{seed_id}.lanky")
+        loop.run_until_complete(ProgressBar().reset())
+        return
+    elif settings.download_patch_file and from_patch_gen is False:
         js.write_seed_history(seed_id, str(data), json.dumps(settings.seed_hash))
         js.load_old_seeds()
         js.save_text_as_file(data, f"dk64r-patch-{seed_id}.lanky")

--- a/randomizer/SettingStrings.py
+++ b/randomizer/SettingStrings.py
@@ -161,6 +161,7 @@ def encrypt_settings_string_enum(dict_data: dict):
     """
     for pop in [
         "download_patch_file",
+        "load_patch_file",
         "seed",
         "settings_string",
         "chunky_colors",

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -219,6 +219,7 @@ class Settings:
         """Set Default items on main page."""
         self.seed = None
         self.download_patch_file = None
+        self.load_patch_file = None
         self.bonus_barrel_rando = None
         self.loading_zone_coupled = None
         self.move_rando = MoveRando.off

--- a/randomizer/ShuffleCrates.py
+++ b/randomizer/ShuffleCrates.py
@@ -31,7 +31,7 @@ def addCrate(spoiler, MelonCrate: CustomLocation, enum_val: int, name: str, leve
         Levels.HideoutHelm: "Helm",
     }
     spoiler.RegionList[MelonCrate.logic_region].locations.append(LocationLogic(enum_val, MelonCrate.logic))
-    spoiler.LocationList[enum_val].name = f"{level_to_name[level]} MelonCrate: {name}"
+    spoiler.LocationList[enum_val].name = f"{level_to_name[level]} Melon Crate: {name}"
     spoiler.LocationList[enum_val].default_mapid_data[0].map = MelonCrate.map
     spoiler.LocationList[enum_val].level = level
 

--- a/templates/base.html.jinja2
+++ b/templates/base.html.jinja2
@@ -245,7 +245,7 @@
                                                            id="download_patch_file"
                                                            name="download_patch_file"
                                                            value="True"/>
-                                                    Generate Patch File
+                                                    Generate as Patch File
                                                 </label>
                                             </div>
                                             <div class="form-check form-switch item-switch" style="text-align: center">
@@ -397,13 +397,26 @@
                                                    placeholder="No File Chosen"/>
                                         </div>
                                     </div>
+                                    <div class="row">
+                                        <div class="form-check form-switch item-switch" style="text-align: center; padding: 0;">
+                                            <label data-toggle="tooltip"
+                                                    title="Share your past seeds by generating it as a shareable patch file.">
+                                                <input class="form-check-input"
+                                                        type="checkbox"
+                                                        id="load_patch_file"
+                                                        name="load_patch_file"
+                                                        value="True"/>
+                                                Generate as Patch File
+                                            </label>
+                                        </div>
+                                    </div>
                                 </div>
                                 <br id="formbreak" />
                                 <input id="generate_pastgen_seed"
                                        class="btn btn-primary"
                                        style="width: 60%; height: 50px; text-align: center"
                                        type="button"
-                                       value="Generate Seed from history"/>
+                                       value="Generate Seed from History"/>
                             </div>
                         </div>
                     </div>

--- a/templates/cosmetics.html.jinja2
+++ b/templates/cosmetics.html.jinja2
@@ -235,6 +235,7 @@
                             Brighten Boss Door Opening
                         </label>
                     </div>
+                    <div class="spacer"></div>
                 </div>
                 <div class="flex-container">
                     <div class="item-select">

--- a/ui/generate_buttons.py
+++ b/ui/generate_buttons.py
@@ -192,7 +192,8 @@ async def generate_previous_seed(event):
         loop = asyncio.get_event_loop()
         loop.run_until_complete(ProgressBar().update_progress(0, "Loading Previous seed and applying data."))
         js.apply_conversion()
-        await patching_response(str(js.get_previous_seed_data()), True)
+        lanky_from_history = js.document.getElementById("load_patch_file").checked
+        await patching_response(str(js.get_previous_seed_data()), True, lanky_from_history)
 
 
 @bind("click", "generate_lanky_seed")
@@ -263,3 +264,17 @@ def update_seed_text(event):
         js.document.getElementById("generate_seed").value = "Generate Patch File"
     else:
         js.document.getElementById("generate_seed").value = "Generate Seed"
+
+
+@bind("click", "load_patch_file")
+def update_seed_text(event):
+    """Set historical seed text based on the load_patch_file click event.
+
+    Args:
+        event (DOMEvent): Javascript dom click event.
+    """
+    # When we click the download json event just change the button text
+    if js.document.getElementById("load_patch_file").checked:
+        js.document.getElementById("generate_pastgen_seed").value = "Generate Patch File from History"
+    else:
+        js.document.getElementById("generate_pastgen_seed").value = "Generate Seed from History"


### PR DESCRIPTION
You can now take your past seeds and essentially export them as .lanky files for easier sharing post-generation. Also updates phrasing in a few small spots on the UI as well as a wonky input on the cosmetics tab.

Also includes the homing ammo accessibility logic fix that was applied to master.