### PR TITLE
Loads of fixes and improvements

### DIFF
--- a/randomizer/Lists/WrinklyHints.py
+++ b/randomizer/Lists/WrinklyHints.py
@@ -24,9 +24,12 @@ class HintLocation:
         self.kong = kong
         self.location = location
         self.hint = hint
+        self.short_hint = None
         self.hint_type = -1
         self.banned_keywords = banned_keywords.copy()
         self.level = level
+        self.related_location = None
+        self.related_flag = None
 
 
 hints = [

--- a/randomizer/LogicFiles/AngryAztec.py
+++ b/randomizer/LogicFiles/AngryAztec.py
@@ -12,7 +12,7 @@ from randomizer.LogicClasses import (Event, LocationLogic, Region,
                                      TransitionFront)
 
 LogicRegions = {
-    Regions.AngryAztecMedals: Region("Angry Aztec Medals", "Angry Aztec Medal Rewards", Levels.AngryAztec, False, None, [
+    Regions.AngryAztecMedals: Region("Angry Aztec Medals", "Aztec Medal Rewards", Levels.AngryAztec, False, None, [
         LocationLogic(Locations.AztecDonkeyMedal, lambda l: l.ColoredBananas[Levels.AngryAztec][Kongs.donkey] >= l.settings.medal_cb_req),
         LocationLogic(Locations.AztecDiddyMedal, lambda l: l.ColoredBananas[Levels.AngryAztec][Kongs.diddy] >= l.settings.medal_cb_req),
         LocationLogic(Locations.AztecLankyMedal, lambda l: l.ColoredBananas[Levels.AngryAztec][Kongs.lanky] >= l.settings.medal_cb_req),

--- a/randomizer/LogicFiles/CreepyCastle.py
+++ b/randomizer/LogicFiles/CreepyCastle.py
@@ -12,7 +12,7 @@ from randomizer.LogicClasses import (Event, LocationLogic, Region,
                                      TransitionFront)
 
 LogicRegions = {
-    Regions.CreepyCastleMedals: Region("Creepy Castle Medals", "Creepy Castle Medal Rewards", Levels.CreepyCastle, False, None, [
+    Regions.CreepyCastleMedals: Region("Creepy Castle Medals", "Castle Medal Rewards", Levels.CreepyCastle, False, None, [
         LocationLogic(Locations.CastleDonkeyMedal, lambda l: l.ColoredBananas[Levels.CreepyCastle][Kongs.donkey] >= l.settings.medal_cb_req),
         LocationLogic(Locations.CastleDiddyMedal, lambda l: l.ColoredBananas[Levels.CreepyCastle][Kongs.diddy] >= l.settings.medal_cb_req),
         LocationLogic(Locations.CastleLankyMedal, lambda l: l.ColoredBananas[Levels.CreepyCastle][Kongs.lanky] >= l.settings.medal_cb_req),

--- a/randomizer/LogicFiles/CrystalCaves.py
+++ b/randomizer/LogicFiles/CrystalCaves.py
@@ -12,7 +12,7 @@ from randomizer.LogicClasses import (Event, LocationLogic, Region,
                                      TransitionFront)
 
 LogicRegions = {
-    Regions.CrystalCavesMedals: Region("Crystal Caves Medals", "Crystal Caves Medal Rewards", Levels.CrystalCaves, False, None, [
+    Regions.CrystalCavesMedals: Region("Crystal Caves Medals", "Caves Medal Rewards", Levels.CrystalCaves, False, None, [
         LocationLogic(Locations.CavesDonkeyMedal, lambda l: l.ColoredBananas[Levels.CrystalCaves][Kongs.donkey] >= l.settings.medal_cb_req),
         LocationLogic(Locations.CavesDiddyMedal, lambda l: l.ColoredBananas[Levels.CrystalCaves][Kongs.diddy] >= l.settings.medal_cb_req),
         LocationLogic(Locations.CavesLankyMedal, lambda l: l.ColoredBananas[Levels.CrystalCaves][Kongs.lanky] >= l.settings.medal_cb_req),

--- a/randomizer/LogicFiles/FranticFactory.py
+++ b/randomizer/LogicFiles/FranticFactory.py
@@ -14,7 +14,7 @@ from randomizer.LogicClasses import (Event, LocationLogic, Region,
                                      TransitionFront)
 
 LogicRegions = {
-    Regions.FranticFactoryMedals: Region("Frantic Factory Medals", "Frantic Factory Medal Rewards", Levels.FranticFactory, False, None, [
+    Regions.FranticFactoryMedals: Region("Frantic Factory Medals", "Factory Medal Rewards", Levels.FranticFactory, False, None, [
         LocationLogic(Locations.FactoryDonkeyMedal, lambda l: l.ColoredBananas[Levels.FranticFactory][Kongs.donkey] >= l.settings.medal_cb_req),
         LocationLogic(Locations.FactoryDiddyMedal, lambda l: l.ColoredBananas[Levels.FranticFactory][Kongs.diddy] >= l.settings.medal_cb_req),
         LocationLogic(Locations.FactoryLankyMedal, lambda l: l.ColoredBananas[Levels.FranticFactory][Kongs.lanky] >= l.settings.medal_cb_req),

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -13,7 +13,7 @@ from randomizer.LogicClasses import (Event, LocationLogic, Region,
                                      TransitionFront)
 
 LogicRegions = {
-    Regions.FungiForestMedals: Region("Fungi Forest Medals", "Fungi Forest Medal Rewards", Levels.FungiForest, False, None, [
+    Regions.FungiForestMedals: Region("Fungi Forest Medals", "Forest Medal Rewards", Levels.FungiForest, False, None, [
         LocationLogic(Locations.ForestDonkeyMedal, lambda l: l.ColoredBananas[Levels.FungiForest][Kongs.donkey] >= l.settings.medal_cb_req),
         LocationLogic(Locations.ForestDiddyMedal, lambda l: l.ColoredBananas[Levels.FungiForest][Kongs.diddy] >= l.settings.medal_cb_req),
         LocationLogic(Locations.ForestLankyMedal, lambda l: l.ColoredBananas[Levels.FungiForest][Kongs.lanky] >= l.settings.medal_cb_req),

--- a/randomizer/LogicFiles/GloomyGalleon.py
+++ b/randomizer/LogicFiles/GloomyGalleon.py
@@ -13,7 +13,7 @@ from randomizer.LogicClasses import (Event, LocationLogic, Region,
                                      TransitionFront)
 
 LogicRegions = {
-    Regions.GloomyGalleonMedals: Region("Gloomy Galleon Medals", "Gloomy Galleon Medal Rewards", Levels.GloomyGalleon, False, None, [
+    Regions.GloomyGalleonMedals: Region("Gloomy Galleon Medals", "Galleon Medal Rewards", Levels.GloomyGalleon, False, None, [
         LocationLogic(Locations.GalleonDonkeyMedal, lambda l: l.ColoredBananas[Levels.GloomyGalleon][Kongs.donkey] >= l.settings.medal_cb_req),
         LocationLogic(Locations.GalleonDiddyMedal, lambda l: l.ColoredBananas[Levels.GloomyGalleon][Kongs.diddy] >= l.settings.medal_cb_req),
         LocationLogic(Locations.GalleonLankyMedal, lambda l: l.ColoredBananas[Levels.GloomyGalleon][Kongs.lanky] >= l.settings.medal_cb_req),

--- a/randomizer/LogicFiles/JungleJapes.py
+++ b/randomizer/LogicFiles/JungleJapes.py
@@ -12,7 +12,7 @@ from randomizer.LogicClasses import (Event, LocationLogic, Region,
                                      TransitionFront)
 
 LogicRegions = {
-    Regions.JungleJapesMedals: Region("Jungle Japes Medals", "Jungle Japes Medal Rewards", Levels.JungleJapes, False, None, [
+    Regions.JungleJapesMedals: Region("Jungle Japes Medals", "Japes Medal Rewards", Levels.JungleJapes, False, None, [
         LocationLogic(Locations.JapesDonkeyMedal, lambda l: l.ColoredBananas[Levels.JungleJapes][Kongs.donkey] >= l.settings.medal_cb_req),
         LocationLogic(Locations.JapesDiddyMedal, lambda l: l.ColoredBananas[Levels.JungleJapes][Kongs.diddy] >= l.settings.medal_cb_req),
         LocationLogic(Locations.JapesLankyMedal, lambda l: l.ColoredBananas[Levels.JungleJapes][Kongs.lanky] >= l.settings.medal_cb_req),

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -426,6 +426,7 @@ class Settings:
         self.kongs_for_progression = False
         self.wrinkly_hints = WrinklyHints.off
         self.spoiler_hints = SpoilerHints.off
+        self.helpful_hints = False
         self.spoiler_include_woth_count = False
         self.spoiler_include_level_order = False
         self.fast_warps = False
@@ -564,6 +565,21 @@ class Settings:
         else:
             self.training_barrels = TrainingBarrels.shuffled
         self.starting_moves_count = self.starting_moves_count + len(self.starting_move_list_selected)
+
+        # If water is lava, then Instrument Upgrades are considered important for the purposes of getting 3rd Melon
+        if self.hard_mode and HardModeSelected.water_is_lava in self.hard_mode_selected:
+            ItemList[Items.ProgressiveInstrumentUpgrade].playthrough = True
+            ItemPool.ImportantSharedMoves = [
+                Items.ProgressiveSlam,
+                Items.ProgressiveSlam,
+                Items.ProgressiveSlam,
+                Items.SniperSight,
+                Items.HomingAmmo,
+                Items.ProgressiveInstrumentUpgrade,
+                Items.ProgressiveInstrumentUpgrade,
+                Items.ProgressiveInstrumentUpgrade,
+            ]
+            ItemPool.JunkSharedMoves = [Items.ProgressiveAmmoBelt, Items.ProgressiveAmmoBelt]
 
         # If we're using the vanilla door shuffle, turn both wrinkly and tns rando on
         if self.vanilla_door_rando:

--- a/templates/progression.html.jinja2
+++ b/templates/progression.html.jinja2
@@ -225,6 +225,23 @@
                             value="True"/>
                     <label for="keys_random"></label>
                 </label></h5>
+            <div class="flex-container" style="justify-content: space-between; width: 90%; margin: auto;">
+                <div style="display: flex;">Start with More Keys</div>
+                <div style="display: flex;">Start with Fewer Keys</div>
+            </div>
+            <div class="flex-container flex-center">
+                <input type="text"
+                        name="krool_key_count"
+                        id="krool_key_count"
+                        data-provide="slider"
+                        data-slider-ticks="[0, 1, 2, 3, 4, 5, 6, 7, 8]"
+                        data-slider-ticks-labels='["0", "1", "2", "3", "4", "5", "6", "7", "8"]'
+                        data-slider-min="0"
+                        data-slider-max="8"
+                        data-slider-step="1"
+                        data-slider-value="8"
+                        style="width: 80%">
+            </div>
             <div class="flex-container">
                 <div class="form-check form-switch item-switch center-flex">
                     <label data-toggle="tooltip" title="Select the exact keys you start with.">
@@ -261,19 +278,6 @@
                             Key 8 Required
                         </label>
                     </div>
-                </div>
-                <div>
-                    <input type="text"
-                            name="krool_key_count"
-                            id="krool_key_count"
-                            data-provide="slider"
-                            data-slider-ticks="[0, 1, 2, 3, 4, 5, 6, 7, 8]"
-                            data-slider-ticks-labels='["0", "1", "2", "3", "4", "5", "6", "7", "8"]'
-                            data-slider-min="0"
-                            data-slider-max="8"
-                            data-slider-step="1"
-                            data-slider-value="8"
-                            style="width: 80%">
                 </div>
                 <hr>
                 <h5 class="select-title">Number of Starting Kongs

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -217,9 +217,9 @@ def test_with_settings_string_1():
     """Confirm that settings strings decryption is working and generate a spoiler log with it."""
     # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
     # This top one is always the S2 Preset (probably up to date, if it isn't go steal it from the season2.json)
-    settings_string = "bKEFiRorPN5ysoQNEB6H1QNCIZEJUtjXPgPxGj12ly+IU5Ym04IAVBkFup6/AkgGTQMgusllgoC6AEGAnUBA4G7AMIBHcCBIK8AUKBnkDBYO9AcMCFCGnj2yFI9RUM5UplzaLeBnB0eotwQqIsAiYigCvVUXCIZCmOhKlsa58IynStrtccjdqv99kUDwDmzwxYkiwAJjAAJjQAHjgAHjwAFkAAFkQADkgADkwADlAADiJTlyhyXCp0whJBF9AnJBhhKmY2mMHFosi0rlgVocthoTiwVGAmDAjEg4ppFJkRh0AlwEMnAA"
+    settings_string = "bKEFiRorPN5ysoQNEB6H1QNCIZEJUtjXPgPxGj12ly+IU5Ym04IAVBkFup6/AkgGTQMgusllgoC6AEGAnUBA4G7AMIBHcCBIK8AUKBnkDBYO9AcMCFCGnj2yFI9RUM5UplzaLeBnB0eotwQqIsAiYigCvWuORu1X++yKB4BzZ4YsSRYAExgAExoADxwADx4ACyAACyIAByQAByYABygABxEpy5Q5LhU6YQkgi+gTkgwwlTMbTGDi0WRaVywK0OWw0JxYKjATBgRiQcU0ikyIw6AKoBLgIZOAA"
     # This one is for ease of testing, go wild with it
-    # settings_string = "bKEFiRorPN5ysoQNEB6H1QNCIZEJUtjXPgPxGj12ly+IU5Ym04IAVBkFup6/AkgGTQMgusllgoC6AEGAnUBA4G7AMIBHcCBIK8AUKBnkDBYO9AcMCFCGnj2yFI9RUM5UplzaLeBnB0eotwQqIsAiYigCvWuORu1X++yKB4BzagYsSRYAExgAExoADxwADx4ACyAACyIAByQAByYABygABxEpy5Q5LhTCEkEX0CckGGEqZjaYwcWiyLSuWBWhy2GhOLBUYCYMCMSDimkUmRGHQBVAJcDHyAMnAUlLhscHQ"
+    # settings_string = "bKsoQBEh6H1QOCIZDpUtjXPhEfiNHrtLl8QttOWItMCAFILdT1+BJAImgnlkqjILzJZYKAugBBgJ1AQOBuwDCAR3AgSCvAFCgZ5AwWDvQHDAhQhto9/RSPUZbPRKpdUWkw4EVcWJBNBQkXrXHI3ar/fZFA8BJrNnhixJFgATGAATGgAPHAAPHgALIAALIgAHJAAHJgAHKAAHESnLlDkuFTphCSCL6BOSDDCVMxjBxaLJBFpXLArQ5bDRgJgwIxoJBxRSZEZCAB0AVQCXAA"
 
     settings_dict = decrypt_settings_string_enum(settings_string)
     settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly


### PR DESCRIPTION
Hints:
- Altered phrasing on path hints from "One item" to "Something" for (hopefully) clarity
- Altered phrasing on path hints to shorten the text slightly
- Kong hints now always show up in your first 20 hints when using Progressive Hints
- Reworded Kong hints so the Kong you are unlocking is always referenced first for consistency. This may trip you up, so make sure you read your hints fully and properly!

Bug Fixes:
- Fixed an issue where too many WotH items would break item hinting hints. For those of you with sicko settings this may literally make your seeds 10% worse.
- Visually adjusted the starting key slider to hopefully be more intuitive at a glance.
- Hard mode lava water now treats Instrument Upgrades as important items. This means they'll be on paths, show in the playthrough, and show up in spoiler hints, counting as clear vials and getting point values.
- Fixed an issue where every enemy in Helm would be given an item in Dropsanity.
- Fixed an issue that could cause Jetpac to be necessary before the logical medal fill requirement was met (thanks Sniperwave).

Future Prep:
- The HintLocation object now has a `related_flag` variable that points to the flag the hint is referring to.
- If a multipath hint is longer than 123 characters, it has a `short_hint` variant that cuts some of the fluff. I don't expect other types of hints to get too long.