### PR TITLE
Prevent users from plandoing shops if Smaller Shops is enabled

### DIFF
--- a/ui/plando_validation.py
+++ b/ui/plando_validation.py
@@ -95,6 +95,27 @@ def validate_item_limits(evt):
                 mark_option_valid(js.document.getElementById(loc))
 
 
+@bindList("change", ShopLocationList, prefix="plando_", suffix="_item")
+@bind("change", "smaller_shops")
+def validate_smaller_shops_no_conflict(evt):
+    """Raise an error if we have a conflict with Smaller Shops.
+    
+    If the user is using the Smaller Shops setting, they cannot place anything
+    in the shops. This causes fill issues.
+    """
+    assignedShops = []
+    for locationName in ShopLocationList:
+        shopElem = js.document.getElementById(f"plando_{locationName}_item")
+        mark_option_valid(shopElem)
+        if shopElem.value != "":
+            assignedShops.append(shopElem)
+    useSmallerShops = js.document.getElementById("smaller_shops").checked
+    if not useSmallerShops:
+        return
+    for assignedShop in assignedShops:
+        mark_option_invalid(assignedShop, 'Shop locations cannot be assigned if "Smaller Shops" is selected.')
+
+
 @bindList("change", HintLocationList, prefix="plando_", suffix="_hint")
 @bindList("keyup", HintLocationList, prefix="plando_", suffix="_hint")
 def validate_hint_text(evt):
@@ -305,6 +326,7 @@ async def import_plando_options(file):
     plando_hide_krool_options(None)
     plando_lock_key_8_in_helm(None)
     validate_item_limits(None)
+    validate_smaller_shops_no_conflict(None)
     validate_hint_text(None)
     validate_shop_costs(None)
     validate_starting_kong_count(None)
@@ -682,6 +704,17 @@ def validate_plando_options(settings_dict):
             if item == PlandoItems.GoldenBanana:
                 errString += " (40 Golden Bananas are always allocated to blueprint rewards.)"
             errList.append(errString)
+    
+    # Ensure that no shops are assigned if "Smaller Shops" is used.
+    useSmallerShops = js.document.getElementById("smaller_shops").checked
+    if useSmallerShops:
+        for locationName in ShopLocationList:
+            locationEnum = Locations[locationName]
+            locEnumStr = str(locationEnum.value)
+            if locEnumStr in plando_dict["locations"] and plando_dict["locations"][locEnumStr] != PlandoItems.Randomize:
+                shopName = LocationList[locationEnum].name
+                errString = f'Shop locations cannot be assigned if "Smaller Shops" is selected, but shop "{shopName}" has an assigned value.'
+                errList.append(errString)
 
     # Ensure that shop costs are within allowed limits.
     for shopLocation, price in plando_dict["prices"].items():

--- a/ui/plando_validation.py
+++ b/ui/plando_validation.py
@@ -99,7 +99,7 @@ def validate_item_limits(evt):
 @bind("change", "smaller_shops")
 def validate_smaller_shops_no_conflict(evt):
     """Raise an error if we have a conflict with Smaller Shops.
-    
+
     If the user is using the Smaller Shops setting, they cannot place anything
     in the shops. This causes fill issues.
     """
@@ -704,7 +704,7 @@ def validate_plando_options(settings_dict):
             if item == PlandoItems.GoldenBanana:
                 errString += " (40 Golden Bananas are always allocated to blueprint rewards.)"
             errList.append(errString)
-    
+
     # Ensure that no shops are assigned if "Smaller Shops" is used.
     useSmallerShops = js.document.getElementById("smaller_shops").checked
     if useSmallerShops:


### PR DESCRIPTION
This causes fill issues and it's better to weed it out in the UI.