### PR TITLE
Fixing random weights

### DIFF
--- a/static/presets/weights/standard.json
+++ b/static/presets/weights/standard.json
@@ -222,7 +222,7 @@
         "vanilla": 0.2,
         "level_order": 0.5,
         "loadingzone": 0.25,
-        "loadingzonesdecoupled": 0.5
+        "loadingzonesdecoupled": 0.05
     },
     "logic_type": {
         "glitchless": 0.8,


### PR DESCRIPTION
Decoupled loading zones currently appear much more often than they should, because of a missing 0.