### PR TITLE
Fixing difficult random settings

### DIFF
--- a/static/presets/weights/difficult.json
+++ b/static/presets/weights/difficult.json
@@ -271,7 +271,7 @@
     "no_healing": 0.5,
     "no_melons": 0.5,
     "open_levels": 0.75,
-    "open_lobbies": 0.9,
+    "open_lobbies": 0.6,
     "perma_death": 0.05,
     "portal_numbers": 0.5,
     "progressive_hint_text": {

--- a/static/presets/weights/difficult.json
+++ b/static/presets/weights/difficult.json
@@ -44,7 +44,7 @@
         "mean": 2
     },
     "crown_enemy_rando": {
-        "vanilla": 0.2,
+        "off": 0.2,
         "medium": 0.5,
         "hard": 0.3
     },

--- a/static/presets/weights/standard.json
+++ b/static/presets/weights/standard.json
@@ -238,7 +238,7 @@
     "no_healing": 0.5,
     "no_melons": 0.2,
     "open_levels": 0.75,
-    "open_lobbies": 0.9,
+    "open_lobbies": 0.6,
     "perma_death": 0,
     "portal_numbers": 0.5,
     "progressive_hint_text": {


### PR DESCRIPTION
Due to a mistyped value by me, it's impossible to randomize "difficult" settings. This should fix that.

This also incorporates a suggested change to Open Lobbies.