### PR TITLE
quick logic fix

### DIFF
--- a/randomizer/LogicFiles/CreepyCastle.py
+++ b/randomizer/LogicFiles/CreepyCastle.py
@@ -248,7 +248,7 @@ LogicRegions = {
 
     Regions.Mausoleum: Region("Mausoleum", "Castle Underground", Levels.CreepyCastle, False, None, [
         LocationLogic(Locations.CastleLankyMausoleum, lambda l: (((l.grape and l.sprint) or l.generalclips or l.phasewalk) and ((l.trombone and l.vines) or (l.advanced_platforming and l.sprint)) and l.islanky) or (l.settings.free_trade_items and l.phasewalk)),
-        LocationLogic(Locations.CastleTinyMausoleum, lambda l: l.CanSlamSwitch(Levels.CreepyCastle, 3) and (l.twirl or l.advanced_platforming or l.phasewalk) and l.istiny),
+        LocationLogic(Locations.CastleTinyMausoleum, lambda l: l.CanSlamSwitch(Levels.CreepyCastle, 3) and l.twirl and l.istiny),
         LocationLogic(Locations.CastleMausoleumEnemy_TinyPath, lambda l: True),
         LocationLogic(Locations.CastleMausoleumEnemy_LankyPath0, lambda l: True),
         LocationLogic(Locations.CastleMausoleumEnemy_LankyPath1, lambda l: True),

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -1381,6 +1381,7 @@ class Settings:
                     Locations.FactoryDonkeyDKArcade,
                     Locations.FactoryTinyDartboard,
                     Locations.JapesLankyFairyCave,
+                    Locations.AztecLankyVulture,
                     Locations.ForestDiddyRafters,
                     Locations.CavesTiny5DoorIgloo,
                     Locations.CavesDiddy5DoorCabinUpper,


### PR DESCRIPTION
- Fixes an Advanced Platforming bug where Krusha can be expected to jump over the gap in Tiny's Mausoleum, and where the Hands part of the GB was not considered anymore.
- Banned ice traps from Aztec Lanky Vulture GB, because it locks a different check.