### PR TITLE
Updates for plandomizer and random settings

### DIFF
--- a/randomizer/PlandoUtils.py
+++ b/randomizer/PlandoUtils.py
@@ -350,6 +350,8 @@ badFakeItemLocationList = [
     Locations.FactoryDonkeyDKArcade.name,
     Locations.FactoryTinyDartboard.name,
     Locations.JapesLankyFairyCave.name,
+    Locations.AztecLankyVulture.name,
+    Locations.AztecDiddyRamGongs.name,
     Locations.ForestDiddyRafters.name,
     Locations.CavesTiny5DoorIgloo.name,
     Locations.CavesDiddy5DoorCabinUpper.name,

--- a/static/presets/weights/difficult.json
+++ b/static/presets/weights/difficult.json
@@ -80,7 +80,9 @@
         "dusk": 0.15,
         "progressive": 0.15
     },
-    "galleon_water": 0.5,
+    "galleon_water": {
+        "random": 1
+    },
     "glitches_selected": {
         "advanced_platforming": 1
     },

--- a/static/presets/weights/difficult.json
+++ b/static/presets/weights/difficult.json
@@ -80,6 +80,7 @@
         "dusk": 0.15,
         "progressive": 0.15
     },
+    "galleon_water": 0.5,
     "glitches_selected": {
         "advanced_platforming": 1
     },

--- a/static/presets/weights/easy.json
+++ b/static/presets/weights/easy.json
@@ -76,6 +76,7 @@
         "dusk": 0.15,
         "progressive": 0.15
     },
+    "galleon_water": 0.5,
     "glitches_selected": {},
     "hard_blockers": 0,
     "hard_level_progression": 0,

--- a/static/presets/weights/easy.json
+++ b/static/presets/weights/easy.json
@@ -76,7 +76,9 @@
         "dusk": 0.15,
         "progressive": 0.15
     },
-    "galleon_water": 0.5,
+    "galleon_water": {
+        "random": 1
+    },
     "glitches_selected": {},
     "hard_blockers": 0,
     "hard_level_progression": 0,

--- a/static/presets/weights/standard.json
+++ b/static/presets/weights/standard.json
@@ -81,6 +81,7 @@
         "dusk": 0.15,
         "progressive": 0.15
     },
+    "galleon_water": 0.5,
     "glitches_selected": {},
     "hard_blockers": 0.2,
     "hard_level_progression": 0.4,

--- a/static/presets/weights/standard.json
+++ b/static/presets/weights/standard.json
@@ -81,7 +81,9 @@
         "dusk": 0.15,
         "progressive": 0.15
     },
-    "galleon_water": 0.5,
+    "galleon_water": {
+        "random": 1
+    },
     "glitches_selected": {},
     "hard_blockers": 0.2,
     "hard_level_progression": 0.4,


### PR DESCRIPTION
Adding updates for recent changes:

- Plando users cannot place ice traps on the locations "AztecLankyVulture" and "AztecDiddyRamGongs".
- The Galleon water level setting is now added to the random settings button.