### PR TITLE
New hints, better filler

### DIFF
--- a/randomizer/Enums/HintType.py
+++ b/randomizer/Enums/HintType.py
@@ -23,6 +23,8 @@ class HintType(IntEnum):
     WothLocation = auto()
     FoolishMove = auto()
     FoolishRegion = auto()
+    ForeseenPathless = auto()
     Multipath = auto()
+    RegionItemCount = auto()
     ItemRegion = auto()
     Plando = auto()

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -930,7 +930,7 @@ def CalculateFoolish(spoiler: Spoiler, WothLocations: List[Union[Locations, int]
     spoiler.region_hintable_count = {}
     if Types.Coin not in spoiler.settings.shuffled_location_types:
         nonHintableNames.add("Jetpac Game")  # If this is vanilla, it's never useful to hint
-    bossLocations = [location for id, location in spoiler.LocationList.items() if location.type == Types.Key]  # expand me
+    bossLocations = [location for id, location in spoiler.LocationList.items() if location.type == Types.Key]
     # In order for a region to be foolish, it can contain none of these Major Items
     for id, region in spoiler.RegionList.items():
         locations = [spoiler.LocationList[loc.id] for loc in region.locations if loc.id in spoiler.LocationList.keys()]

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -855,60 +855,23 @@ def CalculateWothPaths(spoiler: Spoiler, WothLocations: List[Union[Locations, in
 
 def CalculateFoolish(spoiler: Spoiler, WothLocations: List[Union[Locations, int]]) -> None:
     """Calculate the items and regions that are foolish (blocking no major items)."""
-    # FOOLISH MOVES - unable to verify the accuracy of foolish moves, so these have to go :(
-    # The problem that needs to be solved: How do you guarantee neither part of a required either/or is foolish?
-    # The cases you have to handle in order to solve this:
-    # - Both are WotH: this should be straightforward, neither is foolish
-    # - Neither is WotH: you have to check that items are individually foolish (the code below) and all individually foolish items are collectively foolish
-    # - ONE is WotH: this is hard, as you don't know what of your WotH items could be part of the either/or with an individually foolish move
-    # The current state of affairs could guarantee that you couldn't get both parts of an either/or as foolish, but I don't think either should be
-    # Until this problem is solved, foolish moves will remain dormant
-
-    # wothItems = [LocationList[loc].item for loc in WothLocations]
-    # # First we need to determine what Major Items are foolish
-    # foolishItems = []
-    # # Determine which of our major items we need to check
-    # majorItems = ItemPool.AllKongMoves()
-    # if spoiler.settings.training_barrels != TrainingBarrels.normal:
-    #     # I don't trust oranges quite yet - you can put an item in Diddy's upper cabin and it might think oranges is foolish still
-    #     majorItems.extend([Items.Vines, Items.Swim, Items.Barrels, Items.Oranges])
-    # if spoiler.settings.shockwave_status != ShockwaveStatus.shuffled_decoupled:
-    #     majorItems.append(Items.CameraAndShockwave)
-    # if spoiler.settings.shockwave_status == ShockwaveStatus.shuffled_decoupled:
-    #     majorItems.append(Items.Camera)
-    #     if spoiler.settings.shuffle_items and Types.RainbowCoin in spoiler.settings.shuffled_location_types:
-    #         majorItems.append(Items.Shockwave)  # Shockwave foolish is virtually useless to hint as foolish unless rainbow coins are in the pool
-    # # We want to know if the bean and pearls are foolish so we can use them in the regional foolish checks later
-    # if Types.Bean in spoiler.settings.shuffled_location_types:
-    #     majorItems.append(Items.Bean)
-    # if Types.Pearl in spoiler.settings.shuffled_location_types:
-    #     majorItems.append(Items.Pearl)
-    # for item in majorItems:
-    #     # If this item is in the WotH, it can't possibly be foolish so we can skip it
-    #     if item in wothItems:
-    #         continue
-    #     # Check the item to see if it locks *any* progression (even non-critical)
-    #     Reset()
-    #     # Because of how much overlap there is between these two, either they're both foolish or neither is
-    #     # if item in (Items.HomingAmmo, Items.SniperSight):
-    #     #     LogicVariables.BanItems([Items.HomingAmmo, Items.SniperSight])
-    #     # else:
-    #     LogicVariables.BanItems([item])  # Ban this item from being picked up
-    #     GetAccessibleLocations(spoiler, [], SearchMode.GetReachable)  # Check what's reachable
-    #     if LogicVariables.HasAllItems():  # If you still have all the items, this one blocks no progression and is foolish
-    #         foolishItems.append(item)
-    # spoiler.foolish_moves = [item for item in foolishItems if item not in (Items.Bean, Items.Pearl)]  # Don't hint Bean and Pearl as foolish
-
     # Use the settings to determine non-progression Major Items
-    # majorItems = [item for item in majorItems if item not in foolishItems]
     majorItems = ItemPool.AllKongMoves()
+    regionCountHintableItems = ItemPool.AllKongMoves()
+    regionCountHintableItems.extend(ItemPool.JunkSharedMoves)
     if spoiler.settings.training_barrels != TrainingBarrels.normal:
         majorItems.extend(ItemPool.TrainingBarrelAbilities())
+        regionCountHintableItems.extend(ItemPool.TrainingBarrelAbilities())
     if spoiler.settings.shockwave_status != ShockwaveStatus.shuffled_decoupled:
         majorItems.append(Items.CameraAndShockwave)
+        if spoiler.settings.shockwave_status != ShockwaveStatus.start_with:
+            regionCountHintableItems.append(Items.CameraAndShockwave)
     if spoiler.settings.shockwave_status == ShockwaveStatus.shuffled_decoupled:
         majorItems.append(Items.Shockwave)
         majorItems.append(Items.Camera)
+        if spoiler.settings.shockwave_status != ShockwaveStatus.start_with:
+            regionCountHintableItems.append(Items.Shockwave)
+            regionCountHintableItems.append(Items.Camera)
     majorItems.extend(ItemPool.Keys())
     majorItems.extend(ItemPool.Kongs(spoiler.settings))
     requires_rareware = spoiler.settings.coin_door_item == HelmDoorItem.vanilla
@@ -964,22 +927,55 @@ def CalculateFoolish(spoiler: Spoiler, WothLocations: List[Union[Locations, int]
             newFoolishItems = True
 
     nonHintableNames = {"Game Start", "K. Rool Arena", "Snide", "Candy Generic", "Funky Generic", "Credits"}  # These regions never have anything useful so shouldn't be hinted
+    spoiler.region_hintable_count = {}
     if Types.Coin not in spoiler.settings.shuffled_location_types:
         nonHintableNames.add("Jetpac Game")  # If this is vanilla, it's never useful to hint
-    bossLocations = [location for id, location in spoiler.LocationList.items() if location.type == Types.Key]
+    bossLocations = [location for id, location in spoiler.LocationList.items() if location.type == Types.Key]  # expand me
     # In order for a region to be foolish, it can contain none of these Major Items
     for id, region in spoiler.RegionList.items():
-        locations = [loc for loc in region.locations if loc.id in spoiler.LocationList.keys()]
+        locations = [spoiler.LocationList[loc.id] for loc in region.locations if loc.id in spoiler.LocationList.keys()]
         # If this region's valid locations (exclude starting moves) DO contain a major item, add it the name to the set of non-hintable hint regions
-        if any([loc for loc in locations if spoiler.LocationList[loc.id].type not in (Types.TrainingBarrel, Types.PreGivenMove) and spoiler.LocationList[loc.id].item in majorItems]):
+        if any([loc for loc in locations if loc.type not in (Types.TrainingBarrel, Types.PreGivenMove) and loc.item in majorItems]):
             nonHintableNames.add(region.hint_name)
         # In addition to being empty, medal regions need the corresponding boss location to be empty to be hinted foolish - this lets us say "CBs are foolish" which is more helpful
         elif "Medal Rewards" in region.hint_name:
             bossLocation = [location for location in bossLocations if location.level == region.level][0]  # Matches only one
             if bossLocation.item in majorItems:
                 nonHintableNames.add(region.hint_name)
+        # Ban shops from region count hinting. These are significantly worse regions to hint than any others.
+        if "Shops" not in region.hint_name:
+            # Count the number of region count hintable items in the region (again, ignore training moves)
+            regionItemCount = sum(1 for loc in locations if loc.type not in (Types.TrainingBarrel, Types.PreGivenMove) and loc.item in regionCountHintableItems)
+            if regionItemCount > 0:
+                # If we need to create a new entry due to this region, do so
+                if region.hint_name not in spoiler.region_hintable_count.keys():
+                    spoiler.region_hintable_count[region.hint_name] = 0
+                # Keep a running tally of found vials in each region
+                spoiler.region_hintable_count[region.hint_name] += regionItemCount
     # The regions that are foolish are all regions not in this list (that have locations in them!)
     spoiler.foolish_region_names = list(set([region.hint_name for id, region in spoiler.RegionList.items() if any(region.locations) and region.hint_name not in nonHintableNames]))
+
+    # Determine non-path items (foolish v2)
+    # Non-path items are items that are not on the path to anything. This is similar but different to a foolish hint, so the phrasing on the hint will be different.
+    wothItems = [spoiler.LocationList[loc].item for loc in WothLocations]
+    # First we need to determine what Major Items are interesting - this is basically just all Kong moves
+    spoiler.pathless_moves = []
+    shuffledPotionItems = set(ItemPool.AllKongMoves())
+    if spoiler.settings.training_barrels != TrainingBarrels.normal:  # If the training barrels aren't shuffled, they don't end up in the WotH so watch out
+        shuffledPotionItems.update(ItemPool.TrainingBarrelAbilities())
+    if spoiler.settings.shockwave_status not in (ShockwaveStatus.start_with, ShockwaveStatus.shuffled_decoupled):
+        shuffledPotionItems.add(Items.CameraAndShockwave)
+    elif spoiler.settings.shockwave_status == ShockwaveStatus.shuffled_decoupled:
+        shuffledPotionItems.add(Items.Shockwave)
+        shuffledPotionItems.add(Items.Camera)
+    for item in shuffledPotionItems:
+        # If this item is in the WotH, it can't possibly be foolish
+        if item in wothItems:
+            continue
+        spoiler.pathless_moves.append(item)
+    # Saying slams aren't on the path to anything is usually utterly useless due to the progressive nature. I'm not even gonna try to pretend to make these work.
+    while Items.ProgressiveSlam in spoiler.pathless_moves:
+        spoiler.pathless_moves.remove(Items.ProgressiveSlam)
 
 
 def RandomFill(spoiler: Spoiler, itemsToPlace: List[Items], inOrder: bool = False) -> int:

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -1466,6 +1466,28 @@ class Settings:
                     [loc for loc in shuffledNonMoveLocations if loc not in banned_kong_locations]
                 )  # No items can be in Kong cages but Kongs can be in all other locations
 
+            # If our Helm fairy locations are unshuffled, ban any item used for helm doors from being on either location.
+            # This is because the two locations are always behind both doors. If you put a door-required crown here, you may as well have deleted it.
+            if self.random_fairies and Types.Fairy in self.shuffled_location_types:
+                # Going in order of the HelmDoorItem enum:
+                # GBs cannot be in Helm
+                # Blueprints cannot be on fairies
+                # Company coins cannot be on fairies
+                # Keys can be on fairies, but this is staggeringly rare
+                if Types.Key in self.shuffled_location_types and (self.crown_door_item == HelmDoorItem.req_key or self.coin_door_item == HelmDoorItem.req_key):
+                    self.valid_locations[Types.Key].remove(Locations.HelmBananaFairy1)
+                    self.valid_locations[Types.Key].remove(Locations.HelmBananaFairy2)
+                # Medals cannot be on fairies
+                # The big winner: Crowns will not be locked behind a crown door requirement
+                if Types.Crown in self.shuffled_location_types and (
+                    self.crown_door_item == HelmDoorItem.vanilla or self.crown_door_item == HelmDoorItem.req_crown or self.coin_door_item == HelmDoorItem.req_crown
+                ):
+                    self.valid_locations[Types.Crown].remove(Locations.HelmBananaFairy1)
+                    self.valid_locations[Types.Crown].remove(Locations.HelmBananaFairy2)
+                # Fairies are the one exception: these are allowed to be vanilla
+                # Rainbow coins cannot be on fairies
+                # The Bean/Pearls cannot be on fairies (you might be sensing a pattern here)
+
     def GetValidLocationsForItem(self, item_id):
         """Return the valid locations the input item id can be placed in."""
         item_obj = ItemList[item_id]

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -369,44 +369,6 @@ class Spoiler:
             "Unknown": {},
         }
 
-        # Playthrough data
-        humanspoiler["Playthrough"] = self.playthrough
-
-        # Woth data
-        humanspoiler["Way of the Hoard"] = self.woth
-        # Paths for Woth items - does not show up on the site, just for debugging
-        humanspoiler["Paths"] = {}
-        wothSlams = 0
-        for loc, path in self.woth_paths.items():
-            destination_item = ItemList[self.LocationList[loc].item]
-            path_dict = {}
-            for path_loc_id in path:
-                path_location = self.LocationList[path_loc_id]
-                path_item = ItemList[path_location.item]
-                path_dict[path_location.name] = path_item.name
-            extra = ""
-            if self.LocationList[loc].item == Items.ProgressiveSlam:
-                wothSlams += 1
-                extra = " " + str(wothSlams)
-            humanspoiler["Paths"][destination_item.name + extra] = path_dict
-        # Paths for K. Rool phases - also do not show up on the site, just for debugging
-        for kong, path in self.krool_paths.items():
-            path_dict = {}
-            for path_loc_id in path:
-                path_location = self.LocationList[path_loc_id]
-                path_item = ItemList[path_location.item]
-                path_dict[path_location.name] = path_item.name
-            phase_name = "K. Rool Donkey Phase"
-            if kong == Kongs.diddy:
-                phase_name = "K. Rool Diddy Phase"
-            elif kong == Kongs.lanky:
-                phase_name = "K. Rool Lanky Phase"
-            elif kong == Kongs.tiny:
-                phase_name = "K. Rool Tiny Phase"
-            elif kong == Kongs.chunky:
-                phase_name = "K. Rool Chunky Phase"
-            humanspoiler["Paths"][phase_name] = path_dict
-
         self.pregiven_items = []
         for location_id, location in self.LocationList.items():
             # No need to spoiler constants or hints
@@ -471,80 +433,6 @@ class Spoiler:
                 humanspoiler["Items"][level][location.name] = item.name
                 humanspoiler[sorted_item_name][self.getItemGroup(location.item)][location.name] = item.name
 
-        if self.settings.shuffle_loading_zones == ShuffleLoadingZones.levels:
-            # Just show level order
-            shuffled_exits = OrderedDict()
-            lobby_entrance_order = {
-                Transitions.IslesMainToJapesLobby: Levels.JungleJapes,
-                Transitions.IslesMainToAztecLobby: Levels.AngryAztec,
-                Transitions.IslesMainToFactoryLobby: Levels.FranticFactory,
-                Transitions.IslesMainToGalleonLobby: Levels.GloomyGalleon,
-                Transitions.IslesMainToForestLobby: Levels.FungiForest,
-                Transitions.IslesMainToCavesLobby: Levels.CrystalCaves,
-                Transitions.IslesMainToCastleLobby: Levels.CreepyCastle,
-            }
-            lobby_exit_order = {
-                Transitions.IslesJapesLobbyToMain: Levels.JungleJapes,
-                Transitions.IslesAztecLobbyToMain: Levels.AngryAztec,
-                Transitions.IslesFactoryLobbyToMain: Levels.FranticFactory,
-                Transitions.IslesGalleonLobbyToMain: Levels.GloomyGalleon,
-                Transitions.IslesForestLobbyToMain: Levels.FungiForest,
-                Transitions.IslesCavesLobbyToMain: Levels.CrystalCaves,
-                Transitions.IslesCastleLobbyToMain: Levels.CreepyCastle,
-            }
-            for transition, vanilla_level in lobby_entrance_order.items():
-                shuffled_level = lobby_exit_order[self.shuffled_exit_data[transition].reverse]
-                shuffled_exits[vanilla_level.name] = shuffled_level.name
-            humanspoiler["Shuffled Level Order"] = shuffled_exits
-        elif self.settings.shuffle_loading_zones != ShuffleLoadingZones.none:
-            # Show full shuffled_exits data if more than just levels are shuffled
-            shuffled_exits = OrderedDict()
-            level_starts = {
-                "DK Isles": [
-                    "DK Isles",
-                    "Japes Lobby",
-                    "Aztec Lobby",
-                    "Factory Lobby",
-                    "Galleon Lobby",
-                    "Fungi Lobby",
-                    "Caves Lobby",
-                    "Castle Lobby",
-                    "Snide's Room",
-                    "Training Grounds",
-                    "Banana Fairy Isle",
-                    "DK's Treehouse",
-                ],
-                "Jungle Japes": ["Jungle Japes"],
-                "Angry Aztec": ["Angry Aztec"],
-                "Frantic Factory": ["Frantic Factory"],
-                "Gloomy Galleon": ["Gloomy Galleon"],
-                "Fungi Forest": ["Fungi Forest"],
-                "Crystal Caves": ["Crystal Caves"],
-                "Creepy Castle": ["Creepy Castle"],
-            }
-            level_data = {"Other": {}}
-            for level in level_starts:
-                level_data[level] = {}
-            for exit, dest in self.shuffled_exit_data.items():
-                level_name = "Other"
-                for level in level_starts:
-                    for search_name in level_starts[level]:
-                        if dest.spoilerName.find(search_name) == 0:
-                            level_name = level
-                shuffled_exits[ShufflableExits[exit].name] = dest.spoilerName
-                level_data[level_name][ShufflableExits[exit].name] = dest.spoilerName
-            humanspoiler["Shuffled Exits"] = shuffled_exits
-            humanspoiler["Shuffled Exits (Sorted by destination)"] = level_data
-        if self.settings.alter_switch_allocation:
-            humanspoiler["Level Switch Strength"] = {
-                "Jungle Japes": self.settings.switch_allocation[Levels.JungleJapes],
-                "Angry Aztec": self.settings.switch_allocation[Levels.AngryAztec],
-                "Frantic Factory": self.settings.switch_allocation[Levels.FranticFactory],
-                "Gloomy Galleon": self.settings.switch_allocation[Levels.GloomyGalleon],
-                "Fungi Forest": self.settings.switch_allocation[Levels.FungiForest],
-                "Crystal Caves": self.settings.switch_allocation[Levels.CrystalCaves],
-                "Creepy Castle": self.settings.switch_allocation[Levels.CreepyCastle],
-            }
         if self.settings.enemy_rando:
             placement_dict = {}
             for map_id in self.enemy_rando_data:
@@ -615,37 +503,7 @@ class Spoiler:
             shuffled_warp_levels = [x.name for x in self.settings.warp_level_list_selected]
             humanspoiler["Shuffled Bananaport Levels"] = shuffled_warp_levels
             humanspoiler["Shuffled Bananaports"] = self.human_warp_locations
-        if len(self.microhints) > 0:
-            human_microhints = {}
-            for name, hint in self.microhints.items():
-                filtered_hint = hint.replace("\x04", "")
-                filtered_hint = filtered_hint.replace("\x05", "")
-                filtered_hint = filtered_hint.replace("\x06", "")
-                filtered_hint = filtered_hint.replace("\x07", "")
-                filtered_hint = filtered_hint.replace("\x08", "")
-                filtered_hint = filtered_hint.replace("\x09", "")
-                filtered_hint = filtered_hint.replace("\x0a", "")
-                filtered_hint = filtered_hint.replace("\x0b", "")
-                filtered_hint = filtered_hint.replace("\x0c", "")
-                filtered_hint = filtered_hint.replace("\x0d", "")
-                human_microhints[name] = filtered_hint
-            humanspoiler["Direct Item Hints"] = human_microhints
-        if len(self.hint_list) > 0:
-            human_hint_list = {}
-            # Here it filters out the coloring from the hints to make it actually readable in the spoiler log
-            for name, hint in self.hint_list.items():
-                filtered_hint = hint.replace("\x04", "")
-                filtered_hint = filtered_hint.replace("\x05", "")
-                filtered_hint = filtered_hint.replace("\x06", "")
-                filtered_hint = filtered_hint.replace("\x07", "")
-                filtered_hint = filtered_hint.replace("\x08", "")
-                filtered_hint = filtered_hint.replace("\x09", "")
-                filtered_hint = filtered_hint.replace("\x0a", "")
-                filtered_hint = filtered_hint.replace("\x0b", "")
-                filtered_hint = filtered_hint.replace("\x0c", "")
-                filtered_hint = filtered_hint.replace("\x0d", "")
-                human_hint_list[name] = filtered_hint
-            humanspoiler["Wrinkly Hints"] = human_hint_list
+
         if self.settings.wrinkly_location_rando:
             humanspoiler["Wrinkly Door Locations"] = self.human_hint_doors
         if self.settings.tns_location_rando:
@@ -751,6 +609,151 @@ class Spoiler:
                     if combo in map_name:
                         map_name = map_name.replace(combo, combo.replace(" ", ""))
                 humanspoiler["Coin Locations"][f"{lvl_name.split(' ')[idx]} {NameFromKong(group['kong'])}"].append(f"{map_name.strip()}: {group['name']}")
+
+        # Playthrough data
+        humanspoiler["Playthrough"] = self.playthrough
+
+        # Woth data
+        humanspoiler["Way of the Hoard"] = self.woth
+        # Paths for Woth items - does not show up on the site, just for debugging
+        humanspoiler["Paths"] = {}
+        wothSlams = 0
+        for loc, path in self.woth_paths.items():
+            destination_item = ItemList[self.LocationList[loc].item]
+            path_dict = {}
+            for path_loc_id in path:
+                path_location = self.LocationList[path_loc_id]
+                path_item = ItemList[path_location.item]
+                path_dict[path_location.name] = path_item.name
+            extra = ""
+            if self.LocationList[loc].item == Items.ProgressiveSlam:
+                wothSlams += 1
+                extra = " " + str(wothSlams)
+            humanspoiler["Paths"][destination_item.name + extra] = path_dict
+        # Paths for K. Rool phases - also do not show up on the site, just for debugging
+        for kong, path in self.krool_paths.items():
+            path_dict = {}
+            for path_loc_id in path:
+                path_location = self.LocationList[path_loc_id]
+                path_item = ItemList[path_location.item]
+                path_dict[path_location.name] = path_item.name
+            phase_name = "K. Rool Donkey Phase"
+            if kong == Kongs.diddy:
+                phase_name = "K. Rool Diddy Phase"
+            elif kong == Kongs.lanky:
+                phase_name = "K. Rool Lanky Phase"
+            elif kong == Kongs.tiny:
+                phase_name = "K. Rool Tiny Phase"
+            elif kong == Kongs.chunky:
+                phase_name = "K. Rool Chunky Phase"
+            humanspoiler["Paths"][phase_name] = path_dict
+
+        if self.settings.shuffle_loading_zones == ShuffleLoadingZones.levels:
+            # Just show level order
+            shuffled_exits = OrderedDict()
+            lobby_entrance_order = {
+                Transitions.IslesMainToJapesLobby: Levels.JungleJapes,
+                Transitions.IslesMainToAztecLobby: Levels.AngryAztec,
+                Transitions.IslesMainToFactoryLobby: Levels.FranticFactory,
+                Transitions.IslesMainToGalleonLobby: Levels.GloomyGalleon,
+                Transitions.IslesMainToForestLobby: Levels.FungiForest,
+                Transitions.IslesMainToCavesLobby: Levels.CrystalCaves,
+                Transitions.IslesMainToCastleLobby: Levels.CreepyCastle,
+            }
+            lobby_exit_order = {
+                Transitions.IslesJapesLobbyToMain: Levels.JungleJapes,
+                Transitions.IslesAztecLobbyToMain: Levels.AngryAztec,
+                Transitions.IslesFactoryLobbyToMain: Levels.FranticFactory,
+                Transitions.IslesGalleonLobbyToMain: Levels.GloomyGalleon,
+                Transitions.IslesForestLobbyToMain: Levels.FungiForest,
+                Transitions.IslesCavesLobbyToMain: Levels.CrystalCaves,
+                Transitions.IslesCastleLobbyToMain: Levels.CreepyCastle,
+            }
+            for transition, vanilla_level in lobby_entrance_order.items():
+                shuffled_level = lobby_exit_order[self.shuffled_exit_data[transition].reverse]
+                shuffled_exits[vanilla_level.name] = shuffled_level.name
+            humanspoiler["Shuffled Level Order"] = shuffled_exits
+        elif self.settings.shuffle_loading_zones != ShuffleLoadingZones.none:
+            # Show full shuffled_exits data if more than just levels are shuffled
+            shuffled_exits = OrderedDict()
+            level_starts = {
+                "DK Isles": [
+                    "DK Isles",
+                    "Japes Lobby",
+                    "Aztec Lobby",
+                    "Factory Lobby",
+                    "Galleon Lobby",
+                    "Fungi Lobby",
+                    "Caves Lobby",
+                    "Castle Lobby",
+                    "Snide's Room",
+                    "Training Grounds",
+                    "Banana Fairy Isle",
+                    "DK's Treehouse",
+                ],
+                "Jungle Japes": ["Jungle Japes"],
+                "Angry Aztec": ["Angry Aztec"],
+                "Frantic Factory": ["Frantic Factory"],
+                "Gloomy Galleon": ["Gloomy Galleon"],
+                "Fungi Forest": ["Fungi Forest"],
+                "Crystal Caves": ["Crystal Caves"],
+                "Creepy Castle": ["Creepy Castle"],
+            }
+            level_data = {"Other": {}}
+            for level in level_starts:
+                level_data[level] = {}
+            for exit, dest in self.shuffled_exit_data.items():
+                level_name = "Other"
+                for level in level_starts:
+                    for search_name in level_starts[level]:
+                        if dest.spoilerName.find(search_name) == 0:
+                            level_name = level
+                shuffled_exits[ShufflableExits[exit].name] = dest.spoilerName
+                level_data[level_name][ShufflableExits[exit].name] = dest.spoilerName
+            humanspoiler["Shuffled Exits"] = shuffled_exits
+            humanspoiler["Shuffled Exits (Sorted by destination)"] = level_data
+        if self.settings.alter_switch_allocation:
+            humanspoiler["Level Switch Strength"] = {
+                "Jungle Japes": self.settings.switch_allocation[Levels.JungleJapes],
+                "Angry Aztec": self.settings.switch_allocation[Levels.AngryAztec],
+                "Frantic Factory": self.settings.switch_allocation[Levels.FranticFactory],
+                "Gloomy Galleon": self.settings.switch_allocation[Levels.GloomyGalleon],
+                "Fungi Forest": self.settings.switch_allocation[Levels.FungiForest],
+                "Crystal Caves": self.settings.switch_allocation[Levels.CrystalCaves],
+                "Creepy Castle": self.settings.switch_allocation[Levels.CreepyCastle],
+            }
+
+        if len(self.microhints) > 0:
+            human_microhints = {}
+            for name, hint in self.microhints.items():
+                filtered_hint = hint.replace("\x04", "")
+                filtered_hint = filtered_hint.replace("\x05", "")
+                filtered_hint = filtered_hint.replace("\x06", "")
+                filtered_hint = filtered_hint.replace("\x07", "")
+                filtered_hint = filtered_hint.replace("\x08", "")
+                filtered_hint = filtered_hint.replace("\x09", "")
+                filtered_hint = filtered_hint.replace("\x0a", "")
+                filtered_hint = filtered_hint.replace("\x0b", "")
+                filtered_hint = filtered_hint.replace("\x0c", "")
+                filtered_hint = filtered_hint.replace("\x0d", "")
+                human_microhints[name] = filtered_hint
+            humanspoiler["Direct Item Hints"] = human_microhints
+        if len(self.hint_list) > 0:
+            human_hint_list = {}
+            # Here it filters out the coloring from the hints to make it actually readable in the spoiler log
+            for name, hint in self.hint_list.items():
+                filtered_hint = hint.replace("\x04", "")
+                filtered_hint = filtered_hint.replace("\x05", "")
+                filtered_hint = filtered_hint.replace("\x06", "")
+                filtered_hint = filtered_hint.replace("\x07", "")
+                filtered_hint = filtered_hint.replace("\x08", "")
+                filtered_hint = filtered_hint.replace("\x09", "")
+                filtered_hint = filtered_hint.replace("\x0a", "")
+                filtered_hint = filtered_hint.replace("\x0b", "")
+                filtered_hint = filtered_hint.replace("\x0c", "")
+                filtered_hint = filtered_hint.replace("\x0d", "")
+                human_hint_list[name] = filtered_hint
+            humanspoiler["Wrinkly Hints"] = human_hint_list
 
         self.json = json.dumps(humanspoiler, indent=4)
 

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -219,7 +219,7 @@ def test_with_settings_string_1():
     # This top one is always the S2 Preset (probably up to date, if it isn't go steal it from the season2.json)
     settings_string = "bKEFiRorPN5ysoQNEB6H1QNCIZEJUtjXPgPxGj12ly+IU5Ym04IAVBkFup6/AkgGTRQkZBdZLLBQF0AIMBOoCBwN2AYQCO4ECQV4AoUDPIGCwd6A4YEKENPHtkKR6ioZypTLm0W8DODo9Rbgp+ioiwCJiKAK9a45G7Vf77IoHMWIoBzZ5EkWABMYABMaAA8cAA8eAAsgAAsiAAckAAcmAAcoAAanLlDkudMISQRfQJyQYYSpmNpjUAOLRZFpXLArQ5bDQnFgqMBMGBGJBxTSeRSZEYdAFUAlwEMnAA"
     # This one is for ease of testing, go wild with it
-    # settings_string = "bKEFiRorPN5ysoQNEB6H1QNCIZEJUtjXPgPxGj12ly+IU5Ym04IAVBkFup6/AkgGTRQyiRkF1kssFAXQAgwE6gIHA3YBhAI7gQJBXgChQM8gYLB3oDhgQoQ08e2QpHqKhnKlMubRbwM4Oj1FuCn6KiLAImIoAr1rjkbtV/vsigcxYigHNnkSRYAExgAExoADxwADx4ACyAACyIAByQAByYABygABqcuUOS50whJBF9AnJBhhKmY2mNQA4tFkWlcsCtDlsNCcWCowEwYEYkHFNJ5FJkRh0AVQCXAQycAA"
+    # settings_string = "bKEHCRorPNXm96soQMSwVEh6H1QPCIZEJUtjXPhGQ/EaPXaXL4hZqcsTacEA6BUGQW6nr9iSAZNFCaJGQXWSywUBdACDATqAgcDdgGEAjuBAkFeAKFAzyBgsHegOGBChDUZ7fSlQoqGcqUy5tFvAzg6PUW4Kfoq4sHicCgIvWuORu1X++yKBzFiKAM2eRJFgATGAATGgAPHAAPHgALIAALIgAHJAAHJgAHKAAGpy5Q5LnTCX0CckGGEqbTGoC0WRaVywK0OWw0JxYKjATBgRiQcU0nkUmRGHQBVAJcBDJwA"
 
     settings_dict = decrypt_settings_string_enum(settings_string)
     settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
@@ -229,6 +229,7 @@ def test_with_settings_string_1():
     # settings_dict["plandomizer_data"] = '{"plando_starting_kongs_selected": [-1], "plando_kong_rescue_diddy": -1, "plando_kong_rescue_lanky": -1, "plando_kong_rescue_tiny": -1, "plando_kong_rescue_chunky": -1, "plando_level_order_0": -1, "plando_level_order_1": -1, "plando_level_order_2": -1, "plando_level_order_3": -1, "plando_level_order_4": -1, "plando_level_order_5": -1, "plando_level_order_6": -1, "plando_krool_order_0": -1, "plando_krool_order_1": -1, "plando_krool_order_2": -1, "plando_krool_order_3": -1, "plando_krool_order_4": -1, "plando_helm_order_0": -1, "plando_helm_order_1": -1, "plando_helm_order_2": -1, "plando_helm_order_3": -1, "plando_helm_order_4": -1, "locations": {"238": 25}, "prices": {}, "hints": {}}'
 
     settings = Settings(settings_dict)
+    settings.wrinkly_hints = WrinklyHints.standard
     # settings.extreme_debugging = True  # Greatly slows seed gen, use with caution
     spoiler = Spoiler(settings)
     Generate_Spoiler(spoiler)

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -219,7 +219,7 @@ def test_with_settings_string_1():
     # This top one is always the S2 Preset (probably up to date, if it isn't go steal it from the season2.json)
     settings_string = "bKEFiRorPN5ysoQNEB6H1QNCIZEJUtjXPgPxGj12ly+IU5Ym04IAVBkFup6/AkgGTRQkZBdZLLBQF0AIMBOoCBwN2AYQCO4ECQV4AoUDPIGCwd6A4YEKENPHtkKR6ioZypTLm0W8DODo9Rbgp+ioiwCJiKAK9a45G7Vf77IoHMWIoBzZ5EkWABMYABMaAA8cAA8eAAsgAAsiAAckAAcmAAcoAAanLlDkudMISQRfQJyQYYSpmNpjUAOLRZFpXLArQ5bDQnFgqMBMGBGJBxTSeRSZEYdAFUAlwEMnAA"
     # This one is for ease of testing, go wild with it
-    # settings_string = "bKEHCRorPNXm96soQMSwVEh6H1QPCIZEJUtjXPhGQ/EaPXaXL4hZqcsTacEA6BUGQW6nr9iSAZNFCaJGQXWSywUBdACDATqAgcDdgGEAjuBAkFeAKFAzyBgsHegOGBChDUZ7fSlQoqGcqUy5tFvAzg6PUW4Kfoq4sHicCgIvWuORu1X++yKBzFiKAM2eRJFgATGAATGgAPHAAPHgALIAALIgAHJAAHJgAHKAAGpy5Q5LnTCX0CckGGEqbTGoC0WRaVywK0OWw0JxYKjATBgRiQcU0nkUmRGHQBVAJcBDJwA"
+    settings_string = "bKEHCRorPNXm96soQMSwVEh6H1QPCIZEJUtjXPhGQ/EaPXaXL4hZqcsTacEA6BUGQW6nr9iSAZNFCaJGQXWSywUBdACDATqAgcDdgGEAjuBAkFeAKFAzyBgsHegOGBChDUZ7fSlQoqGcqUy5tFvAzg6PUW4Kfoq4sHicCgIvWuORu1X++yKBzFiKAM2eRJFgATGAATGgAPHAAPHgALIAALIgAHJAAHJgAHKAAGpy5Q5LnTCX0CckGGEqbTGoC0WRaVywK0OWw0JxYKjATBgRiQcU0nkUmRGHQBVAJcBDJwA"
 
     settings_dict = decrypt_settings_string_enum(settings_string)
     settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
@@ -229,7 +229,6 @@ def test_with_settings_string_1():
     # settings_dict["plandomizer_data"] = '{"plando_starting_kongs_selected": [-1], "plando_kong_rescue_diddy": -1, "plando_kong_rescue_lanky": -1, "plando_kong_rescue_tiny": -1, "plando_kong_rescue_chunky": -1, "plando_level_order_0": -1, "plando_level_order_1": -1, "plando_level_order_2": -1, "plando_level_order_3": -1, "plando_level_order_4": -1, "plando_level_order_5": -1, "plando_level_order_6": -1, "plando_krool_order_0": -1, "plando_krool_order_1": -1, "plando_krool_order_2": -1, "plando_krool_order_3": -1, "plando_krool_order_4": -1, "plando_helm_order_0": -1, "plando_helm_order_1": -1, "plando_helm_order_2": -1, "plando_helm_order_3": -1, "plando_helm_order_4": -1, "locations": {"238": 25}, "prices": {}, "hints": {}}'
 
     settings = Settings(settings_dict)
-    settings.wrinkly_hints = WrinklyHints.standard
     # settings.extreme_debugging = True  # Greatly slows seed gen, use with caution
     spoiler = Spoiler(settings)
     Generate_Spoiler(spoiler)


### PR DESCRIPTION
- 2 new hint types: Region Potion Counts and Foreseen Pathless. All About Hints will be updated with details.
- Removed garbage hints from being used as filler in item rando. The new hint types are intended to be "better filler."
- Rebalanced hint distributions to favor key path lengths over win condition path lengths.
- Banned items required for helm doors from being on the vanilla helm fairy locations. This mainly affects NSAK and crowns.
- Reorganized the spoiler log to my liking. More important stuff is now grouped at the bottom. Hopefully this didn't break the site cause I didn't check it.