### PR TITLE
Add colors to plandomized hints

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -2339,14 +2339,45 @@ def AssociateHintsWithFlags(spoiler):
             spoiler.tied_hint_flags[hint.name] = hint.related_flag if hint.related_flag is not None else 0xFFFF
 
 
+def ApplyColorToPlandoHint(hint):
+    """Replace plandomizer color tags with the appropriate characters."""
+    new_hint = hint
+    color_replace_dict = {
+        "[orange]": "\x04",
+        "[/orange]": "\x04",
+        "[red]": "\x05",
+        "[/red]": "\x05",
+        "[blue]": "\x06",
+        "[/blue]": "\x06",
+        "[purple]": "\x07",
+        "[/purple]": "\x07",
+        "[lightgreen]": "\x08",
+        "[/lightgreen]": "\x08",
+        "[magenta]": "\x09",
+        "[/magenta]": "\x09",
+        "[cyan]": "\x0a",
+        "[/cyan]": "\x0a",
+        "[rust]": "\x0b",
+        "[/rust]": "\x0b",
+        "[paleblue]": "\x0c",
+        "[/paleblue]": "\x0c",
+        "[green]": "\x0d",
+        "[/green]": "\x0d",
+    }
+    for color_tag, color_character in color_replace_dict.items():
+        new_hint = new_hint.replace(color_tag, color_character)
+    return new_hint
+
+
 def ApplyPlandoHints(spoiler):
     """Apply plandomizer hint messages, returning the number of hints placed."""
     plando_hints_placed = 0
     for loc_id, message in spoiler.settings.plandomizer_dict["hints"].items():
         if message != "":
+            final_message = ApplyColorToPlandoHint(message)
             location = spoiler.LocationList[int(loc_id)]
             hint_location = [hint_loc for hint_loc in hints if hint_loc.level == location.level and hint_loc.kong == location.kong][0]  # Matches exactly one hint
-            UpdateHint(hint_location, message)
+            UpdateHint(hint_location, final_message)
             hint_location.hint_type = HintType.Plando
             plando_hints_placed += 1
     return plando_hints_placed

--- a/templates/plandomizer/plandomizer_hints.html.jinja2
+++ b/templates/plandomizer/plandomizer_hints.html.jinja2
@@ -3,6 +3,15 @@
     .hint-info {
         margin: 16px 16px;
     }
+
+    .color-guide-toggle {
+        cursor: pointer;
+        text-decoration: underline;
+    }
+
+    .color-table {
+        max-width: 300px;
+    }
 </style>
 <div class="tab-pane plando-pane fade"
      id="nav-plando-{{panelName}}"
@@ -11,8 +20,64 @@
     <h2 class="title">{{panel["name"]}}</h2>
     <div class="hint-info">
         Hints can be a maximum of 123 characters. The only permitted characters
-        are letters, numbers, spaces, and the characters ',.-?! 
+        are letters, numbers, spaces, the characters ',.-?! and color tags.
         Any blank hints will be filled by the selected hint algorithm.
+    </div>
+    <div class="hint-info">
+        To apply color to hint text, surround that text with the appropriate
+        color tag. <pre>[red]This text is colored with red.[/red]</pre>
+    </div>
+    <div class="hint-info">
+        There are ten colors to choose from.
+        <span class="color-guide-toggle" id="plando_toggle_color_table">Show/Hide Color Guide</span>
+    </div>
+    <div class="flex-container flex-center hidden" id="plando_hint_color_table">
+        <table class="color-table">
+            <tr>
+                <th style="background-color: #fff; color: #000;">Light</th>
+                <th>Dark</th>
+            </tr>
+            <tr>
+                <td style="background-color: #fff; color: #a36200;">orange</td>
+                <td style="color: #ffa010;">orange</td>
+            </tr>
+            <tr>
+                <td style="background-color: #fff; color: #b00000;">red</td>
+                <td style="color: #ff0000;">red</td>
+            </tr>
+            <tr>
+                <td style="background-color: #fff; color: #2828ff;">blue</td>
+                <td style="color: #0c7ded;">blue</td>
+            </tr>
+            <tr>
+                <td style="background-color: #fff; color: #8000ff;">purple</td>
+                <td style="color: #bb1cff;">purple</td>
+            </tr>
+            <tr>
+                <td style="background-color: #fff; color: #008000;">lightgreen</td>
+                <td style="color: #59ff64;">lightgreen</td>
+            </tr>
+            <tr>
+                <td style="background-color: #fff; color: #b00058;">magenta</td>
+                <td style="color: #e84898;">magenta</td>
+            </tr>
+            <tr>
+                <td style="background-color: #fff; color: #008080;">cyan</td>
+                <td style="color: #3ee1e1;">cyan</td>
+            </tr>
+            <tr>
+                <td style="background-color: #fff; color: #c04040;">rust</td>
+                <td style="color: #d25757;">rust</td>
+            </tr>
+            <tr>
+                <td style="background-color: #fff; color: #132958;">paleblue</td>
+                <td style="color: #b5cdff;">paleblue</td>
+            </tr>
+            <tr>
+                <td style="background-color: #fff; color: #275e1e;">green</td>
+                <td style="color: #00ce0e;">green</td>
+            </tr>
+        </table>
     </div>
     {% for _, levelObj in panel["levels"].items() %}
         <h3 class="title">{{levelObj["name"]}}</h3>

--- a/ui/plando_validation.py
+++ b/ui/plando_validation.py
@@ -191,6 +191,64 @@ def shop_has_assigned_item(shopElement) -> bool:
     return shopElement.value and shopElement.value != "NoItem"
 
 
+########################
+# VALIDATION FUNCTIONS #
+########################
+
+
+def hint_text_validation_fn(hintString: str) -> str:
+    """Return an error if the element's hint contains invalid characters."""
+    colors = ["orange", "red", "blue", "purple", "lightgreen", "magenta", "cyan", "rust", "paleblue", "green"]
+    # Test the hint string without color tags.
+    trimmedHintString = hintString
+    for color in colors:
+        trimmedHintString = trimmedHintString.replace(f"[{color}]", "")
+        trimmedHintString = trimmedHintString.replace(f"[/{color}]", "")
+    if re.search("[^A-Za-z0-9 \,\.\-\?!]", trimmedHintString) is not None:
+        errString = "Only letters, numbers, spaces, the characters ',.-?! and color tags are allowed in hints."
+        return errString
+    if len(trimmedHintString) > 123:
+        errString = "Hints can be a maximum of 123 characters (excluding color tags)."
+        return errString
+    
+    # Ensure that the color tags are correctly utilized.
+    tagRegex = r'\[\/?(?:orange|red|blue|purple|lightgreen|magenta|cyan|rust|paleblue|green)\]'
+    tags = re.finditer(tagRegex, hintString)
+    currentTag = None
+    for tag in tags:
+        if currentTag is None:
+            # Is there a closing tag before an opening one?
+            if "/" in tag[0]:
+                errString = f"Closing color tag {tag[0]} has no opening tag."
+                return errString
+            currentTag = tag
+        else:
+            # Is the next tag a closing tag?
+            if "/" not in tag[0]:
+                errString = f"Color tag {tag[0]} overlaps color tag {currentTag[0]}."
+                return errString
+            # Do the two tags match in color?
+            currentTagColor = re.search("^\[\/?(.+)\]$", currentTag[0])[1]
+            newTagColor = re.search("^\[\/?(.+)\]$", tag[0])[1]
+            if currentTagColor != newTagColor:
+                errString = f"Color tag {currentTag[0]} has non-matching closing tag {tag[0]}."
+                return errString
+            # Is there any text at all between the tags?
+            if currentTag.end(0) == tag.start(0):
+                errString = f"There is no text within color tag {currentTag[0]}."
+                return errString
+            # Erase the current tag, as it's been matched.
+            currentTag = None
+
+    # If we still have a tag, they are unmatched.
+    if currentTag:
+        errString = f"Color tag {currentTag[0]} is unmatched."
+        return errString
+
+    # If we've made it to this point, the element is valid.
+    return None
+
+
 ############
 # BINDINGS #
 ############
@@ -325,9 +383,8 @@ def validate_hint_text_binding(evt):
 
 def validate_hint_text(element) -> None:
     """Raise an error if the element's hint contains invalid characters."""
-    hintString = element.value
-    if re.search("[^A-Za-z0-9 \,\.\-\?!]", hintString) is not None:
-        errString = "Only letters, numbers, spaces, and the characters ',.-?! are allowed in hints."
+    errString = hint_text_validation_fn(element.value)
+    if errString is not None:
         mark_option_invalid(element, ValidationError.invalid_hint_text, errString)
     else:
         mark_option_valid(element, ValidationError.invalid_hint_text)
@@ -1143,13 +1200,11 @@ def validate_plando_options(settings_dict: dict) -> list[str]:
     for hintLocation, hint in plando_dict["hints"].items():
         if hint == PlandoItems.Randomize:
             continue
-        hintLocationName = LocationList[int(hintLocation)].name
-        if len(hint) > 123:
-            errString = f'The hint for location "{hintLocationName}" is longer than the limit of 123 characters.'
-            errList.append(errString)
-        if re.search("[^A-Za-z0-9 '\,\.\-\?!]", hint) is not None:
-            errString = f'The hint for location "{hintLocationName}" contains invalid characters. Only letters, numbers, spaces, and the characters \',.-?! are valid.'
-            errList.append(errString)
+        errString = hint_text_validation_fn(hint)
+        if errString is not None:
+            hintLocationName = LocationList[int(hintLocation)].name
+            fullErrString = f'Error in hint for location "{hintLocationName}": {errString}'
+            errList.append(fullErrString)
 
     # Ensure there aren't too many hints for the current settings.
     if js.document.getElementById("wrinkly_hints").value == "fixed_racing":

--- a/ui/plando_validation.py
+++ b/ui/plando_validation.py
@@ -204,7 +204,7 @@ def hint_text_validation_fn(hintString: str) -> str:
     for color in colors:
         trimmedHintString = trimmedHintString.replace(f"[{color}]", "")
         trimmedHintString = trimmedHintString.replace(f"[/{color}]", "")
-    if re.search("[^A-Za-z0-9 \,\.\-\?!]", trimmedHintString) is not None:
+    if re.search("[^A-Za-z0-9 '\,\.\-\?!]", trimmedHintString) is not None:
         errString = "Only letters, numbers, spaces, the characters ',.-?! and color tags are allowed in hints."
         return errString
     if len(trimmedHintString) > 123:

--- a/ui/plando_validation.py
+++ b/ui/plando_validation.py
@@ -210,9 +210,9 @@ def hint_text_validation_fn(hintString: str) -> str:
     if len(trimmedHintString) > 123:
         errString = "Hints can be a maximum of 123 characters (excluding color tags)."
         return errString
-    
+
     # Ensure that the color tags are correctly utilized.
-    tagRegex = r'\[\/?(?:orange|red|blue|purple|lightgreen|magenta|cyan|rust|paleblue|green)\]'
+    tagRegex = r"\[\/?(?:orange|red|blue|purple|lightgreen|magenta|cyan|rust|paleblue|green)\]"
     tags = re.finditer(tagRegex, hintString)
     currentTag = None
     for tag in tags:

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -1422,3 +1422,10 @@ def toggle_settings_table(evt):
     settingsTable.classList.toggle("collapsed")
     settingsArrow = js.document.getElementsByClassName("settings-expand-arrow").item(0)
     settingsArrow.classList.toggle("flipped")
+
+
+@bind("click", "plando_toggle_color_table")
+def toggle_plando_hint_color_table(evt):
+    """Show or hide the table that shows possible hint colors."""
+    hintColorTable = js.document.getElementById("plando_hint_color_table")
+    hintColorTable.classList.toggle("hidden")


### PR DESCRIPTION
Users can use HTML-like tags to apply colors to their hints, [blue]like this[/blue].

Color tags do not count against the user's character count for their hints. The frontend enforces correct usage of tags.