### PR TITLE
No hard minigames

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -1950,7 +1950,8 @@ def compileHints(spoiler: Spoiler) -> bool:
     UpdateSpoilerHintList(spoiler)
     spoiler.hint_distribution = hint_distribution
 
-    if spoiler.settings.dim_solved_hints:
+    # Dim hints - these are only useful (and doable) if item rando is on
+    if spoiler.settings.dim_solved_hints and spoiler.settings.shuffle_items:
         AssociateHintsWithFlags(spoiler)
 
     # # DEBUG CODE to alert when a hint is empty

--- a/randomizer/Enums/Settings.py
+++ b/randomizer/Enums/Settings.py
@@ -864,6 +864,7 @@ class SettingsStringEnum(IntEnum):
     switchsanity = 160
     fungi_time = 161
     galleon_water = 162
+    disable_hard_minigames = 163
 
 
 # If a setting needs to be removed, add it to this set instead of removing it
@@ -874,7 +875,6 @@ DeprecatedSettings = {
     SettingsStringEnum.hard_bosses,
     SettingsStringEnum.hard_enemies,
     SettingsStringEnum.choose_starting_moves,
-    SettingsStringEnum.enable_plandomizer,  # May integrate plando strings later
 }
 
 
@@ -1068,6 +1068,7 @@ SettingsStringTypeMap = {
     SettingsStringEnum.switchsanity: SettingsStringDataType.bool,
     SettingsStringEnum.fungi_time: FungiTimeSetting,
     SettingsStringEnum.galleon_water: GalleonWaterSetting,
+    SettingsStringEnum.disable_hard_minigames: SettingsStringDataType.bool,
 }
 
 # ALL LIST SETTINGS NEED AN ENTRY HERE!

--- a/randomizer/Lists/Minigame.py
+++ b/randomizer/Lists/Minigame.py
@@ -61,6 +61,7 @@ MinigameRequirements = {
         name="Busy Barrel Barrage (45 seconds, Slow Respawn)",
         group="Busy Barrel Barrage",
         map_id=Maps.BusyBarrelBarrageEasy,
+        difficulty_lvl=2,
         logic=lambda l: (l.isdonkey and l.coconut) or (l.isdiddy and l.peanut) or (l.istiny and l.feather) or (l.ischunky and l.pineapple),
         kong_list=[Kongs.donkey, Kongs.diddy, Kongs.tiny, Kongs.chunky],
     ),
@@ -68,7 +69,7 @@ MinigameRequirements = {
         name="Busy Barrel Barrage (45 seconds, Medium Respawn)",
         group="Busy Barrel Barrage",
         map_id=Maps.BusyBarrelBarrageNormal,
-        difficulty_lvl=1,
+        difficulty_lvl=3,
         logic=lambda l: (l.isdonkey and l.coconut) or (l.isdiddy and l.peanut) or (l.istiny and l.feather) or (l.ischunky and l.pineapple),
         kong_list=[Kongs.donkey, Kongs.diddy, Kongs.tiny, Kongs.chunky],
     ),
@@ -76,7 +77,7 @@ MinigameRequirements = {
         name="Busy Barrel Barrage (60 seconds, Random Spawns)",
         group="Busy Barrel Barrage",
         map_id=Maps.BusyBarrelBarrageHard,
-        difficulty_lvl=2,
+        difficulty_lvl=4,
         logic=lambda l: (l.isdonkey and l.coconut) or (l.isdiddy and l.peanut) or (l.istiny and l.feather) or (l.ischunky and l.pineapple),
         kong_list=[Kongs.donkey, Kongs.diddy, Kongs.tiny, Kongs.chunky],
     ),
@@ -88,24 +89,24 @@ MinigameRequirements = {
         group="Mad Maze Maul",
         map_id=Maps.MadMazeMaulHard,
         helm_enabled=False,
-        difficulty_lvl=2,
+        difficulty_lvl=3,
         logic=lambda l: (l.shockwave or l.oranges) and l.HasGun(Kongs.any),
     ),
     Minigames.MadMazeMaulInsane: Minigame(
         name="Mad Maze Maul (125 seconds, 10 enemies, need gun)", group="Mad Maze Maul", map_id=Maps.MadMazeMaulInsane, difficulty_lvl=3, logic=lambda l: l.HasGun(Kongs.any)
     ),
     # Minecart Mayhem - Higher two difficulties are too hard for those who don't have a guide to do in Helm
-    Minigames.MinecartMayhemEasy: Minigame(name="Minecart Mayhem (30 seconds, 1 TNT)", group="Minecart Mayhem", map_id=Maps.MinecartMayhemEasy, logic=lambda l: True),
+    Minigames.MinecartMayhemEasy: Minigame(name="Minecart Mayhem (30 seconds, 1 TNT)", group="Minecart Mayhem", map_id=Maps.MinecartMayhemEasy, difficulty_lvl=2, logic=lambda l: True),
     Minigames.MinecartMayhemNormal: Minigame(
-        name="Minecart Mayhem (45 seconds, 2 TNT)", group="Minecart Mayhem", map_id=Maps.MinecartMayhemNormal, helm_enabled=False, difficulty_lvl=1, logic=lambda l: True
+        name="Minecart Mayhem (45 seconds, 2 TNT)", group="Minecart Mayhem", map_id=Maps.MinecartMayhemNormal, helm_enabled=False, difficulty_lvl=3, logic=lambda l: True
     ),
     Minigames.MinecartMayhemHard: Minigame(
-        name="Minecart Mayhem (60 seconds, 2 TNT)", group="Minecart Mayhem", map_id=Maps.MinecartMayhemHard, helm_enabled=False, difficulty_lvl=2, logic=lambda l: True
+        name="Minecart Mayhem (60 seconds, 2 TNT)", group="Minecart Mayhem", map_id=Maps.MinecartMayhemHard, helm_enabled=False, difficulty_lvl=4, logic=lambda l: True
     ),
     # Beaver Bother - Banned from Helm due to widespread difficulty
-    Minigames.BeaverBotherEasy: Minigame(name="Beaver Bother (12 Beavers)", group="Beaver Bother", map_id=Maps.BeaverBotherEasy, helm_enabled=False, logic=lambda l: True),
-    Minigames.BeaverBotherNormal: Minigame(name="Beaver Bother (15 Slow Beavers)", group="Beaver Bother", map_id=Maps.BeaverBotherNormal, helm_enabled=False, difficulty_lvl=1, logic=lambda l: True),
-    Minigames.BeaverBotherHard: Minigame(name="Beaver Bother (15 Fast Beavers)", group="Beaver Bother", map_id=Maps.BeaverBotherHard, helm_enabled=False, difficulty_lvl=2, logic=lambda l: True),
+    Minigames.BeaverBotherEasy: Minigame(name="Beaver Bother (12 Beavers)", group="Beaver Bother", map_id=Maps.BeaverBotherEasy, helm_enabled=False, difficulty_lvl=2, logic=lambda l: True),
+    Minigames.BeaverBotherNormal: Minigame(name="Beaver Bother (15 Slow Beavers)", group="Beaver Bother", map_id=Maps.BeaverBotherNormal, helm_enabled=False, difficulty_lvl=3, logic=lambda l: True),
+    Minigames.BeaverBotherHard: Minigame(name="Beaver Bother (15 Fast Beavers)", group="Beaver Bother", map_id=Maps.BeaverBotherHard, helm_enabled=False, difficulty_lvl=4, logic=lambda l: True),
     # Teetering Turtle Trouble
     Minigames.TeeteringTurtleTroubleVEasy: Minigame(
         name="Teetering Turtle Trouble (45 seconds, 2.5% help chance)", group="Teetering Turtle Trouble", map_id=Maps.TeeteringTurtleTroubleVEasy, logic=lambda l: True
@@ -122,15 +123,15 @@ MinigameRequirements = {
     # Stealthy Snoop
     Minigames.StealthySnoopVEasy: Minigame(name="Stealthy Snoop (50 seconds)", group="Stealthy Snoop", map_id=Maps.StealthySnoopVEasy, logic=lambda l: True),
     Minigames.StealthySnoopEasy: Minigame(name="Stealthy Snoop (60 seconds)", group="Stealthy Snoop", map_id=Maps.StealthySnoopEasy, difficulty_lvl=1, logic=lambda l: True),
-    Minigames.StealthySnoopNormal: Minigame(name="Stealthy Snoop (70 seconds)", group="Stealthy Snoop", map_id=Maps.StealthySnoopNormal, difficulty_lvl=2, logic=lambda l: True),
-    Minigames.StealthySnoopHard: Minigame(name="Stealthy Snoop (90 seconds)", group="Stealthy Snoop", map_id=Maps.StealthySnoopHard, difficulty_lvl=3, logic=lambda l: True),
+    Minigames.StealthySnoopNormal: Minigame(name="Stealthy Snoop (70 seconds)", group="Stealthy Snoop", map_id=Maps.StealthySnoopNormal, difficulty_lvl=3, logic=lambda l: True),
+    Minigames.StealthySnoopHard: Minigame(name="Stealthy Snoop (90 seconds)", group="Stealthy Snoop", map_id=Maps.StealthySnoopHard, difficulty_lvl=4, logic=lambda l: True),
     # Stash Snatch - SSnatch Hybrid determined too difficulty for Helm
     Minigames.StashSnatchEasy: Minigame(name="Stash Snatch (60 seconds, 6 coins)", group="Stash Snatch", map_id=Maps.StashSnatchEasy, logic=lambda l: True),
     Minigames.StashSnatchNormal: Minigame(name="Stash Snatch (60 seconds, 16 coins)", group="Stash Snatch", map_id=Maps.StashSnatchNormal, difficulty_lvl=1, logic=lambda l: True),
     Minigames.StashSnatchHard: Minigame(
-        name="Stash Snatch (120 seconds, 4 coins, Stash Snatch Hybrid)", group="Stash Snatch", map_id=Maps.StashSnatchHard, helm_enabled=False, difficulty_lvl=2, logic=lambda l: True
+        name="Stash Snatch (120 seconds, 4 coins, Stash Snatch Hybrid)", group="Stash Snatch", map_id=Maps.StashSnatchHard, helm_enabled=False, difficulty_lvl=4, logic=lambda l: True
     ),
-    Minigames.StashSnatchInsane: Minigame(name="Stash Snatch (120 seconds, 33 coins)", group="Stash Snatch", map_id=Maps.StashSnatchInsane, difficulty_lvl=3, logic=lambda l: True),
+    Minigames.StashSnatchInsane: Minigame(name="Stash Snatch (120 seconds, 33 coins)", group="Stash Snatch", map_id=Maps.StashSnatchInsane, difficulty_lvl=4, logic=lambda l: True),
     # Splish Splash Salvage
     Minigames.SplishSplashSalvageEasy: Minigame(name="Splish Splash Salvage (8 coins)", group="Splish Splash Salvage", map_id=Maps.SplishSplashSalvageEasy, logic=lambda l: l.swim and l.vines),
     Minigames.SplishSplashSalvageNormal: Minigame(
@@ -148,7 +149,7 @@ MinigameRequirements = {
         kong_list=[Kongs.tiny],
     ),
     Minigames.SpeedySwingSortieHard: Minigame(
-        name="Speedy Swing Sortie (60 seconds, 6 coins)", group="Speedy Swing Sortie", map_id=Maps.SpeedySwingSortieHard, helm_enabled=False, difficulty_lvl=2, logic=lambda l: l.vines
+        name="Speedy Swing Sortie (60 seconds, 6 coins)", group="Speedy Swing Sortie", map_id=Maps.SpeedySwingSortieHard, helm_enabled=False, difficulty_lvl=3, logic=lambda l: l.vines
     ),
     # Krazy Kong Klamour - Fast flicker games banned from Helm because Wii U semi-requires pause buffer to hit Bananas. Not expecting users to know this trick
     Minigames.KrazyKongKlamourEasy: Minigame(name="Krazy Kong Klamour (10 Bananas, Slow Flicker)", group="Krazy Kong Klamour", map_id=Maps.KrazyKongKlamourEasy, logic=lambda l: True),
@@ -156,10 +157,10 @@ MinigameRequirements = {
         name="Krazy Kong Klamour (15 Bananas, Slow Flicker)", group="Krazy Kong Klamour", map_id=Maps.KrazyKongKlamourNormal, difficulty_lvl=1, logic=lambda l: True
     ),
     Minigames.KrazyKongKlamourHard: Minigame(
-        name="Krazy Kong Klamour (5 Bananas, Fast Flicker)", group="Krazy Kong Klamour", map_id=Maps.KrazyKongKlamourHard, helm_enabled=False, difficulty_lvl=2, logic=lambda l: True
+        name="Krazy Kong Klamour (5 Bananas, Fast Flicker)", group="Krazy Kong Klamour", map_id=Maps.KrazyKongKlamourHard, helm_enabled=False, difficulty_lvl=3, logic=lambda l: True
     ),
     Minigames.KrazyKongKlamourInsane: Minigame(
-        name="Krazy Kong Klamour (10 Bananas, Fast Flicker)", group="Krazy Kong Klamour", map_id=Maps.KrazyKongKlamourInsane, helm_enabled=False, difficulty_lvl=3, logic=lambda l: True
+        name="Krazy Kong Klamour (10 Bananas, Fast Flicker)", group="Krazy Kong Klamour", map_id=Maps.KrazyKongKlamourInsane, helm_enabled=False, difficulty_lvl=4, logic=lambda l: True
     ),
     # Searchlight Seek
     Minigames.SearchlightSeekVEasy: Minigame(name="Searchlight Seek (4 Klaptraps)", group="Searchlight Seek", map_id=Maps.SearchlightSeekVEasy, logic=lambda l: True),
@@ -178,7 +179,7 @@ MinigameRequirements = {
     Minigames.PerilPathPanicHard: Minigame(name="Peril Path Panic (12 points)", group="Peril Path Panic", map_id=Maps.PerilPathPanicHard, difficulty_lvl=3, logic=lambda l: True),
     # Helm barrels
     Minigames.DonkeyRambi: Minigame(name="Hideout Helm: DK Rambi", group="Helm Minigames", map_id=Maps.HelmBarrelDKRambi, can_repeat=True, logic=lambda l: True),
-    Minigames.DonkeyTarget: Minigame(name="Hideout Helm: DK Targets", group="Helm Minigames", map_id=Maps.HelmBarrelDKTarget, can_repeat=True, logic=lambda l: l.isdonkey, kong_list=[Kongs.donkey]),
+    Minigames.DonkeyTarget: Minigame(name="Hideout Helm: DK Targets", group="Helm Minigames", map_id=Maps.HelmBarrelDKTarget, can_repeat=True, difficulty_lvl=3, logic=lambda l: l.isdonkey, kong_list=[Kongs.donkey]),
     Minigames.DiddyKremling: Minigame(name="Hideout Helm: Diddy Kremlings", group="Helm Minigames", map_id=Maps.HelmBarrelDiddyKremling, can_repeat=True, logic=lambda l: l.Slam),
     Minigames.DiddyRocketbarrel: Minigame(
         name="Hideout Helm: Diddy Rocketbarrel",
@@ -221,6 +222,7 @@ MinigameRequirements = {
         group="Helm Minigames",
         map_id=Maps.HelmBarrelChunkyShooting,
         can_repeat=True,
+        difficulty_lvl=3,
         logic=lambda l: (l.scope or l.homing or l.settings.hard_shooting)
         and ((l.isdonkey and l.coconut) or (l.isdiddy and l.peanut) or (l.islanky and l.grape) or (l.istiny and l.feather) or (l.ischunky and l.pineapple)),
     ),

--- a/randomizer/SettingStrings.py
+++ b/randomizer/SettingStrings.py
@@ -104,7 +104,7 @@ settingsExclusionMap = {
     "shuffle_items": {False: ["item_rando_list_selected"]},
     "starting_moves_count": {0: ["random_starting_move_list_selected"]},
     "enemy_rando": {False: ["enemies_selected"]},
-    "bonus_barrel_rando": {False: ["minigames_list_selected"]},
+    "bonus_barrel_rando": {False: ["minigames_list_selected", "disable_hard_minigames"]},
     "bananaport_rando": {BananaportRando.off: ["warp_level_list_selected"]},
     "logic_type": {LogicType.glitchless: ["glitches_selected"], LogicType.nologic: ["glitches_selected"]},
     "select_keys": {False: ["starting_keys_list_selected"], True: ["krool_key_count"]},
@@ -141,7 +141,7 @@ settingsExclusionMap = {
 
 def prune_settings(settings_dict: dict):
     """Remove certain settings based on the values of other settings."""
-    settings_to_remove = ["enable_plandomizer", "plandomizer_data", "enable_song_select", "music_selections"]
+    settings_to_remove = ["plandomizer_data", "enable_song_select", "music_selections"]
     # Remove settings based on the exclusion map above.
     for keySetting, exclusions in settingsExclusionMap.items():
         if settings_dict[keySetting] in exclusions:
@@ -369,6 +369,7 @@ def decrypt_settings_string_enum(encrypted_string: str) -> Dict[str, Any]:
             val = key_data_type(int_val)
             bit_index += max_value.bit_length()
         # If this setting is not deprecated, add it.
-        if key_enum not in DeprecatedSettings:
+        # The plando setting needs to be encoded in settings strings but not applied when decoding for logging purposes.
+        if key_enum not in DeprecatedSettings and key_enum != SettingsStringEnum.enable_plandomizer:
             settings_dict[key_name] = val
     return settings_dict

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -256,6 +256,7 @@ class Settings:
         self.download_patch_file = None
         self.load_patch_file = None
         self.bonus_barrel_rando = None
+        self.disable_hard_minigames = None
         self.loading_zone_coupled = None
         self.move_rando = MoveRando.off
         self.start_with_slam = False
@@ -896,8 +897,8 @@ class Settings:
             self.helm_phase_count = 5
         if self.helm_phase_count < 5:
             rooms = random.sample(rooms, self.helm_phase_count)
-        # Plandomized Helm room algorithm
-        if self.enable_plandomizer:
+        # Plandomized Helm room algorithm - only applies when we're already shuffling Helm Order!
+        if self.enable_plandomizer and not self.helm_phase_order_rando:
             planned_rooms = []
             # Place planned rooms and clear out others
             for i in range(len(rooms)):

--- a/randomizer/ShuffleBarrels.py
+++ b/randomizer/ShuffleBarrels.py
@@ -128,6 +128,8 @@ def BarrelShuffle(settings: Settings) -> None:
                 minigamePool.extend([x for x in MinigameRequirements.keys() if x in value])
     else:
         minigamePool = [x for x in MinigameRequirements.keys() if x != Minigames.NoGame]
+    if settings.disable_hard_minigames:
+        minigamePool = [game for game in minigamePool if MinigameRequirements[game].difficulty < 3]
     # Shuffle barrels
     Reset(barrelLocations)
     ShuffleBarrels(settings, barrelLocations.copy(), minigamePool.copy())

--- a/static/presets/default.json
+++ b/static/presets/default.json
@@ -26,6 +26,7 @@
     "crown_placement_rando": false,
     "damage_amount": "default",
     "enable_shop_hints": true,
+    "disable_hard_minigames": false,
     "disable_tag_barrels": false,
     "dpad_display": "on",
     "enable_progressive_hints": false,

--- a/templates/macros.html.jinja2
+++ b/templates/macros.html.jinja2
@@ -52,6 +52,20 @@
                         </div>
                     </div>
                 </div>
+                {% if name == "minigames_list" %}
+                    <div class="form-check form-switch" style="padding-left: 1.5em;">
+                        <label data-toggle="tooltip"
+                            style="font-size:14px;"
+                            title="The hardest variants of minigames are removed.">
+                            <input class="form-check-input"
+                                type="checkbox"
+                                name="disable_hard_minigames"
+                                id="disable_hard_minigames"
+                                value="True"/>
+                            No Hard Minigames
+                        </label>
+                    </div>
+                {% endif %}
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary" id="{{ name }}_select_all">Select All</button>

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -219,7 +219,7 @@ def test_with_settings_string_1():
     # This top one is always the S2 Preset (probably up to date, if it isn't go steal it from the season2.json)
     settings_string = "bKEFiRorPN5ysoQNEB6H1QNCIZEJUtjXPgPxGj12ly+IU5Ym04IAVBkFup6/AkgGTRQkZBdZLLBQF0AIMBOoCBwN2AYQCO4ECQV4AoUDPIGCwd6A4YEKENPHtkKR6ioZypTLm0W8DODo9Rbgp+ioiwCJiKAK9a45G7Vf77IoHMWIoBzZ5EkWABMYABMaAA8cAA8eAAsgAAsiAAckAAcmAAcoAAanLlDkudMISQRfQJyQYYSpmNpjUAOLRZFpXLArQ5bDQnFgqMBMGBGJBxTSeRSZEYdAFUAlwEMnAA"
     # This one is for ease of testing, go wild with it
-    settings_string = "bKEHCRorPNXm96soQMSwVfjGVokPQ+qB4RDIhKlsa58IyH4jR67S5fELNoKcsTacEA6BUGQW6nr9iSAZNFCaJGQXWSywUBdACDATqAgcDdgGEAjuBAkFeAKFAzyBgsHegOGBChDUZ7fSlQoqGcqUy5tFvAzg6PUW4Kfoq4sHicCgIvWuORu1X++yKBzEiKAM2eRJFgATGAATGgAPHAAPHgALIAALIgAHJAAHJgAHKAAGpy5Q5LnTCgTkgzaYy0WRaVywK0OWw0JxYKjATBgRiQcU0nkUmRGHQBVAJcBDJwA"
+    settings_string = "bKEFiRorPN5ysoQNEB6H1QQCIZCmOhKlsa58KOPxGj12ly+IU5Ym04IAVBkFup6/AkgGTRQkZBdZLLBQF0AIMBOoCBwN2AYQCO4ECQV4AoUDPIGCwd6A4YEKENPHtkKR6ioZypTLm0W8DODo9Rbgp+ioiwCJiKAK9a45G7Vf77IoHMWIoCTZ5EkWABMYABMaAA8cAA8eAAsgAAsiAAckAAcmAAcoAAanLlDkuFTphCSCL6BOSDDCVMxtMagBxaLItK5YFaHLYaE4sFRgJgwIxIOKaTyKTIjDoAqgEuAhk4AA"
 
     settings_dict = decrypt_settings_string_enum(settings_string)
     settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly


### PR DESCRIPTION
- Added "No Hard Minigames" toggle. This generally removes the hardest variant(s) of each minigame type from the pool of potential minigames.
- Fixed a rare issue where a certain joke hint could crash hint generation depending on the settings
- Fixed an issue where plando settings would override a vanilla Helm order
- Re-added the `enable_plandomizer` setting to settings strings. This is (hopefully) for logging purposes, as the enable plandomizer toggle will not be affected by settings string imports.