### PR TITLE
Allows users to set the time for unlocks

### DIFF
--- a/randomizer.html
+++ b/randomizer.html
@@ -258,27 +258,46 @@
                                                            id="generate_spoilerlog"
                                                            name="generate_spoilerlog"
                                                            value="True"
-                                                           checked/>
+                                                           checked
+                                                           onchange="toggleDelayedSpoilerLogInput()"/>
                                                     Generate Spoiler Log
                                                 </label>
                                             </div>
-                                            <div class="form-check form-switch item-switch" style="text-align: center">
-                                                <label data-toggle="tooltip"
+                                            <div class="form-check form-switch item-switch" style="text-align: center; display: flex; flex-direction: column; align-items: center; justify-content: center;">
+                                                <div>
+                                                    <label data-toggle="tooltip"
                                                         title="Enables the homebrew header to be written to the ROM. This makes the ROM viable on some platforms but can break other platforms. Click the link on the icon for more information.">
-                                                    <input class="form-check-input"
-                                                        type="checkbox"
-                                                        name="homebrew_header"
-                                                        id="homebrew_header"
-                                                        value="True"/>
-                                                    Advanced ROM Header
-                                                </label>
-                                                <a href="https://github.com/2dos/DK64-Randomizer/wiki/Advanced-Homebrew-ROM-Header"
-                                                    title="Click me for more information"
-                                                target="_blank">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" viewBox="0 0 24 24" class="warning-icon" stroke="#ffff00" fill="#ffff00">
-                                                        <path d="M14.876,2.672a3.309,3.309,0,0,0-5.752,0L.414,18.19a3.178,3.178,0,0,0,.029,3.189A3.264,3.264,0,0,0,3.29,23H20.71a3.264,3.264,0,0,0,2.847-1.621,3.178,3.178,0,0,0,.029-3.189ZM12,19a1,1,0,1,1,1-1A1,1,0,0,1,12,19Zm1-5a1,1,0,0,1-2,0V8a1,1,0,0,1,2,0Z"/>
-                                                    </svg>
-                                                </a>
+                                                        <input class="form-check-input"
+                                                            type="checkbox"
+                                                            name="homebrew_header"
+                                                            id="homebrew_header"
+                                                            value="True"/>
+                                                        Advanced ROM Header
+                                                    </label>
+                                                    <a href="https://github.com/2dos/DK64-Randomizer/wiki/Advanced-Homebrew-ROM-Header"
+                                                        title="Click me for more information"
+                                                        target="_blank">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" viewBox="0 0 24 24" class="warning-icon" stroke="#ffff00" fill="#ffff00">
+                                                            <path d="M14.876,2.672a3.309,3.309,0,0,0-5.752,0L.414,18.19a3.178,3.178,0,0,0,.029,3.189A3.264,3.264,0,0,0,3.29,23H20.71a3.264,3.264,0,0,0,2.847-1.621,3.178,3.178,0,0,0,.029-3.189ZM12,19a1,1,0,1,1,1-1A1,1,0,0,1,12,19Zm1-5a1,1,0,0,1-2,0V8a1,1,0,0,1,2,0Z"/>
+                                                        </svg>
+                                                    </a>
+                                                </div>
+                                            </div>
+                                            <div id="delayed_spoilerlog_container" hidden class="form-check form-switch item-switch" style="text-align: center; display: flex; flex-direction: column; align-items: center; justify-content: center;">
+                                                <div>
+                                                    <label data-toggle="tooltip"
+                                                           title="If set to 0, the spoiler log is not released. If set to a number higher than 0, the spoiler log will be available for download after that many hours.">
+                                                        <input type="number"
+                                                            id="delayed_spoilerlog_release"
+                                                            name="delayed_spoilerlog_release"
+                                                            value="0"
+                                                            min="0"
+                                                            step="1"
+                                                            max="168"
+                                                            style="margin-right: 5px; max-width: 8ch;"/>
+                                                        Delayed Spoiler Log Release
+                                                    </label>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/randomizer/Patching/ApplyLocal.py
+++ b/randomizer/Patching/ApplyLocal.py
@@ -219,7 +219,7 @@ async def patching_response(data, from_patch_gen=False, lanky_from_history=False
         js.document.getElementById(f"settings_table_{i}").innerHTML = ""
         tables[i] = js.document.getElementById(f"settings_table_{i}")
     for setting, value in loaded_settings.items():
-        hidden_settings = ["Seed", "algorithm"]
+        hidden_settings = ["Seed", "algorithm", "Unlock Time"]
         if setting not in hidden_settings:
             if tables[t].rows.length > math.ceil((len(loaded_settings.items()) - len(hidden_settings)) / len(tables)):
                 t += 1

--- a/randomizer/SettingStrings.py
+++ b/randomizer/SettingStrings.py
@@ -222,6 +222,7 @@ def encrypt_settings_string_enum(dict_data: dict):
         "crosshair_outline",
         "custom_music_proportion",
         "fill_with_custom_music",
+        "delayed_spoilerlog_release",
     ]:
         if pop in dict_data:
             dict_data.pop(pop)

--- a/runner.py
+++ b/runner.py
@@ -152,7 +152,7 @@ def start_gen(gen_key, post_body):
                 unlock_time = time.time() + (post_body.get("delayed_spoilerlog_release", 0) * 3600)
             if setting_data.get("generate_spoilerlog", True):
                 unlock_time = 0
-            
+
             # Append the current time to the spoiler log as unlock_time.
             patch = return_data["patch"]
             spoiler = return_data["spoiler"]

--- a/runner.py
+++ b/runner.py
@@ -1,7 +1,6 @@
 """Server code for the randomizer."""
 import codecs
 import json
-import base64
 import os
 import random
 import time
@@ -145,9 +144,19 @@ def start_gen(gen_key, post_body):
         if type(return_data) is str:
             return return_data
         else:
+            # Assuming post_body.get("delayed_spoilerlog_release") is an int, and its the number of hours to delay the spoiler log release convert that to time.time() + hours as seconds.
+            if post_body.get("delayed_spoilerlog_release", 0) == 0:
+                # Lets set it to 5 years from now if we don't have a delayed spoiler log release, it'll be deleted after 4 weeks anyway.
+                unlock_time = time.time() + 157784760
+            else:
+                unlock_time = time.time() + (post_body.get("delayed_spoilerlog_release", 0) * 3600)
+            if setting_data.get("generate_spoilerlog", True):
+                unlock_time = 0
+            
+            # Append the current time to the spoiler log as unlock_time.
             patch = return_data["patch"]
             spoiler = return_data["spoiler"]
-            return patch, spoiler
+            return patch, spoiler, unlock_time, time.time()
 
     except Exception as e:
         if os.environ.get("HOSTED_SERVER") is not None:
@@ -210,9 +219,11 @@ def lambda_function():
                 return response
             hash = resp_data[1].settings.seed_hash
             spoiler_log = json.loads(resp_data[1].json)
+            unlock_time = resp_data[2]
+            spoiler_log["Unlock Time"] = unlock_time
+            generated_time = resp_data[3]
+            spoiler_log["Generated Time"] = generated_time
             # Only retain the Settings section and the Cosmetics section.
-            unlock_time = None
-            generated_time = time.time()
             if os.environ.get("HOSTED_SERVER") is not None:
                 try:
                     seed_table = dynamodb.Table("seed_db")
@@ -225,23 +236,18 @@ def lambda_function():
                     )
                 except Exception:
                     pass
-            # Encrypt the time and hash with the encryption key.
             current_seed_number = update_total()
             file_name = str(current_seed_number)
-            # Get the current time and add 5 hours to it.
-            unlock_time = time.time() + 36000
-            # Append the current time to the spoiler log as unlock_time.
-            spoiler_log["Unlock_Time"] = unlock_time
-            spoiler_log["Generated_Time"] = generated_time
-            spoiler_log["Seed_Number"] = current_seed_number
             # write the spoiler log to a file in generated_seeds folder. Create the folder if it doesn't exist.
             os.makedirs("generated_seeds", exist_ok=True)
             with open("generated_seeds/" + file_name + ".json", "w") as f:
                 f.write(str(json.dumps(spoiler_log)))
 
-            sections_to_retain = ["Settings", "Cosmetics", "Spoiler Hints", "Spoiler Hints Data", "Generated_Time", "Unlock_Time"]
+            sections_to_retain = ["Settings", "Cosmetics", "Spoiler Hints", "Spoiler Hints Data", "Generated Time"]
             if resp_data[1].settings.generate_spoilerlog is False:
                 spoiler_log = {k: v for k, v in spoiler_log.items() if k in sections_to_retain}
+            else:
+                del spoiler_log["Unlock Time"]
 
             patch = resp_data[0]
             # Zip all the data into a single file.
@@ -313,7 +319,7 @@ def get_spoiler_log():
             current_time = time.time()
             # if the unlock time is less than the current time, return the spoiler log
             file_contents = json.load(f)
-            if file_contents.get("Unlock_Time", 0) < current_time:
+            if file_contents.get("Unlock Time", 0) < current_time:
                 return make_response(file_contents, 200)
             else:
                 # Return an error
@@ -344,7 +350,7 @@ def get_presets():
 
 
 def delete_old_files():
-    """Delete files that are older than 7 days."""
+    """Delete files that are older than 4 weeks."""
     folder_path = "generated_seeds"
     current_time = time.time()
     os.makedirs("generated_seeds", exist_ok=True)
@@ -353,10 +359,10 @@ def delete_old_files():
             file_path = os.path.join(folder_path, filename)
             with open(file_path, "r") as file:
                 data = json.load(file)
-                unlock_time = data.get("Unlock_Time", 0)
+                generated_time = data.get("Generated Time", 0)
 
-                # Check if it's been seven days since unlock_time
-                if current_time - unlock_time >= 604800:  # 7 days in seconds
+                # Check if it's been 4 weeks since unlock_time
+                if current_time - generated_time >= 2419200:  # 4 weeks in seconds
                     os.remove(file_path)
                     print(f"Deleted file: {filename}")
                     # also delete the lanky file
@@ -471,8 +477,6 @@ def get_seed_data():
             hash = resp_data[1].settings.seed_hash
             spoiler_log = json.loads(resp_data[1].json)
             # Only retain the Settings section and the Cosmetics section.
-            unlock_time = None
-            generated_time = time.time()
             if os.environ.get("HOSTED_SERVER") is not None:
                 try:
                     seed_table = dynamodb.Table("seed_db")
@@ -488,20 +492,20 @@ def get_seed_data():
             # Encrypt the time and hash with the encryption key.
             current_seed_number = update_total()
             file_name = str(current_seed_number)
-            # Get the current time and add 5 hours to it.
-            unlock_time = time.time() + 18000
-            # Append the current time to the spoiler log as unlock_time.
-            spoiler_log["Unlock_Time"] = unlock_time
-            spoiler_log["Generated_Time"] = generated_time
-            spoiler_log["Seed_Number"] = current_seed_number
+            unlock_time = resp_data[2]
+            generated_time = resp_data[3]
+            spoiler_log["Unlock Time"] = unlock_time
+            spoiler_log["Generated Time"] = generated_time
             # write the spoiler log to a file in generated_seeds folder. Create the folder if it doesn't exist.
             os.makedirs("generated_seeds", exist_ok=True)
             with open("generated_seeds/" + file_name + ".json", "w") as f:
                 f.write(str(json.dumps(spoiler_log)))
 
-            sections_to_retain = ["Settings", "Cosmetics", "Spoiler Hints", "Spoiler Hints Data", "Generated_Time", "Unlock_Time"]
+            sections_to_retain = ["Settings", "Cosmetics", "Spoiler Hints", "Spoiler Hints Data", "Generated Time"]
             if resp_data[1].settings.generate_spoilerlog is False:
                 spoiler_log = {k: v for k, v in spoiler_log.items() if k in sections_to_retain}
+            else:
+                del spoiler_log["Unlock Time"]
 
             patch = resp_data[0]
             # Zip all the data into a single file.

--- a/static/js/initalize.js
+++ b/static/js/initalize.js
@@ -861,6 +861,18 @@ function check_seed_info_tab() {
     document.getElementById("generate_seed").onclick = function() {document.getElementById("trigger_download_event").click()};
   }
 }
+function toggleDelayedSpoilerLogInput() {
+  var generateSpoilerLogCheckbox = document.getElementById('delayed_spoilerlog_container');
+  if (!document.getElementById('generate_spoilerlog').checked) {
+      generateSpoilerLogCheckbox.removeAttribute('hidden');
+  }
+  else {
+      generateSpoilerLogCheckbox.setAttribute('hidden', '');
+  }
+}
+
+// Call the function on page load to set the initial state
+toggleDelayedSpoilerLogInput();
 // check on any button with the nav-item class is clicked
 document.querySelectorAll(".nav-item").forEach((item) => {
   item.addEventListener("click", () => {


### PR DESCRIPTION
Adds the ability for users to set their unlock times

Removes some data from the spoiler log.
Dealing with trying to parse out the Generation Time and Unlock Time from the spoiler on the site seems to be a bit of a pain so I've opted to leave the EPOCH timestamps in the spoiler log, it might confuse people but could be worse. We can always do something later if we care.

Solves https://github.com/2dos/DK64-Randomizer/issues/1774 and https://github.com/2dos/DK64-Randomizer/issues/1797