### PR TITLE
Starting move count, caching, logic fixes

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -2058,10 +2058,14 @@ def PlaceKongsInKongLocations(spoiler: Spoiler, kongItems, kongLocations):
     if spoiler.settings.chunky_freeing_kong == Kongs.any:
         spoiler.settings.chunky_freeing_kong = choice(GetKongs())
     # Update the locations' assigned kong with the set freeing kong list
+    spoiler.LocationList[Locations.DiddyKong].kong = spoiler.settings.diddy_freeing_kong
     spoiler.LocationList[Locations.JapesDonkeyFrontofCage].kong = spoiler.settings.diddy_freeing_kong
     spoiler.LocationList[Locations.JapesDonkeyFreeDiddy].kong = spoiler.settings.diddy_freeing_kong
+    spoiler.LocationList[Locations.LankyKong].kong = spoiler.settings.lanky_freeing_kong
     spoiler.LocationList[Locations.AztecDonkeyFreeLanky].kong = spoiler.settings.lanky_freeing_kong
+    spoiler.LocationList[Locations.TinyKong].kong = spoiler.settings.tiny_freeing_kong
     spoiler.LocationList[Locations.AztecDiddyFreeTiny].kong = spoiler.settings.tiny_freeing_kong
+    spoiler.LocationList[Locations.ChunkyKong].kong = spoiler.settings.chunky_freeing_kong
     spoiler.LocationList[Locations.FactoryLankyFreeChunky].kong = spoiler.settings.chunky_freeing_kong
     spoiler.settings.update_valid_locations(spoiler)
 

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -2177,7 +2177,7 @@ def FillKongsAndMoves(spoiler: Spoiler, placedTypes: List[Types], placedItems: L
         if spoiler.settings.shockwave_status in (ShockwaveStatus.shuffled, ShockwaveStatus.shuffled_decoupled):
             possibleStartingMoves.extend(ItemPool.ShockwaveTypeItems(spoiler.settings))
         # Any placed items placed before this method can't be random starting items
-        for item in placedItems:
+        for item in placedMoves:
             if item in possibleStartingMoves:
                 possibleStartingMoves.remove(item)
         shuffle(possibleStartingMoves)

--- a/randomizer/LogicFiles/GloomyGalleon.py
+++ b/randomizer/LogicFiles/GloomyGalleon.py
@@ -91,7 +91,7 @@ LogicRegions = {
     Regions.LighthousePlatform: Region("Lighthouse Platform", "Lighthouse Area", Levels.GloomyGalleon, False, None, [
         LocationLogic(Locations.GalleonDiddyShipSwitch, lambda l: Events.ActivatedLighthouse in l.Events and l.jetpack and l.Slam and l.isdiddy),
     ], [
-        Event(Events.MechafishSummoned, lambda l: l.jetpack and l.guitar and l.isdiddy),
+        Event(Events.MechafishSummoned, lambda l: l.jetpack and l.guitar and l.swim and l.isdiddy),
         Event(Events.GalleonW1bTagged, lambda l: True),
         Event(Events.GalleonW5aTagged, lambda l: True),
     ], [

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -751,7 +751,7 @@ class Settings:
 
         # Move Location Rando
         if self.move_rando == MoveRando.start_with:
-            self.starting_moves_count = 40
+            self.starting_moves_count = 41
             self.training_barrels = TrainingBarrels.normal
             self.shockwave_status = ShockwaveStatus.start_with
 
@@ -1323,7 +1323,7 @@ class Settings:
         spoiler.LocationList[Locations.IslesBarrelsTrainingBarrel].type = Types.TrainingBarrel
         spoiler.LocationList[Locations.IslesOrangesTrainingBarrel].default = Items.Oranges
         spoiler.LocationList[Locations.IslesOrangesTrainingBarrel].type = Types.TrainingBarrel
-        location_cap = 36
+        location_cap = 37  # Increment this for every new potential starting move added
         if self.shockwave_status in (ShockwaveStatus.vanilla, ShockwaveStatus.start_with):
             location_cap -= 2
         if self.shockwave_status == ShockwaveStatus.shuffled:

--- a/templates/qualityoflife.html.jinja2
+++ b/templates/qualityoflife.html.jinja2
@@ -244,7 +244,7 @@
                                 <input class="form-check-input"
                                         type="checkbox"
                                         name="spoiler_include_woth_count"
-                                        value="False"/>
+                                        value="True"/>
                                 Include WotH Counts
                             </label>
                         </div>
@@ -255,7 +255,7 @@
                                 <input class="form-check-input"
                                         type="checkbox"
                                         name="spoiler_include_level_order"
-                                        value="False"/>
+                                        value="True"/>
                                 Include Level Order
                             </label>
                         </div>

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -77,7 +77,7 @@
                     <div class="item-select">
                         <p class="select-title">Random Starting Move Count</p>
                         <input min="0"
-                                max="40"
+                                max="41"
                                 name="starting_moves_count"
                                 id="starting_moves_count"
                                 style="width: 15%; display: inline-block; margin-top: 0;"

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -217,9 +217,9 @@ def test_with_settings_string_1():
     """Confirm that settings strings decryption is working and generate a spoiler log with it."""
     # INPUT YOUR SETTINGS STRING OF CHOICE HERE:
     # This top one is always the S2 Preset (probably up to date, if it isn't go steal it from the season2.json)
-    # settings_string = "bKEFiRorPN5ysoQNEB6OkWMAhuIMtYhBevn8A2ePhhNHO7qV7KzM4ps6ti+FOB9UDQiGRCVLY1z4D8Ro9dpcviFOWJtOCFAUekB0Vpq+ApBbqevwJIBk0UJokZBdZLLBQF0AIMBOoCBwN2AYQCO4ECQV4AoUDPIGCwd6A4YEKENPHtkKR6ioZypTLm0W8DODo9Rbgp+ioiwCJiKAK9a45G7Vf77IoHMWIoAzZ5EkWABMYABMaAA8cAA8eAAsgAAsiAAckAAcmAAcoAAanLlDkuFTphCSCL6BOSDDCVU5mNpjBxaFpXLArQ5bDQnFgqMBMGBGJCmOKaTyKTIjUoAqgEuAhk4AA"
+    settings_string = "bKEFiRorPN5ysoQNEB6OkWMAhuIMtYhBevn8A2ePhhNHO7qV7KzM4ps6ti+FOB9UDQiGRCVLY1z4D8Ro9dpcviFOWJtOCFAUekB0Vpq+ApBbqevwJIBk0UJokZBdZLLBQF0AIMBOoCBwN2AYQCO4ECQV4AoUDPIGCwd6A4YEKENPHtkKR6ioZypTLm0W8DODo9Rbgp+ioiwCJiKAK9a45G7Vf77IoHMWIoAzZ5EkWABMYABMaAA8cAA8eAAsgAAsiAAckAAcmAAcoAAanLlDkuFTphCSCL6BOSDDCVU5mNpjBxaFpXLArQ5bDQnFgqMBMGBGJCmOKaTyKTIjUoAqgEuAhk4AA"
     # This one is for ease of testing, go wild with it
-    settings_string = "bKEFiRorPN5ysoShEB6OkWMAhuIMtYhBevn8A2ePhhNHO7qV7KzM4ps6ti+FOB9UDQiGRCVLY1z4D8Ro9dpcviFOWJtOCFAUekB0Vpq+ApBbqevwJIBk0UJokZBdZLLBQF0AIMBOoCBwN2AYQCO4ECQV4AoUDPIGCwd6A4YEKENPHtkKR6ioZypTLm0W8DODo9Rbgp+ioiwCJiKAK9a45G7Vf77IoHMWIoCTZ5EkWABMYABMaAA8cAA8eAAsgAAsiAAckAAcmAAcoAAanLlDkuFTphCSCL6BOSDDCVU5mNpjBxaFpXLArQ5bDQnFgqMBMGBGJCmOKaTyKTIjUoAqgEuAhk4AA"
+    # settings_string = "bKEFiRorPN5ysoShEB6OkWMAhuIMtYhBevn8A2ePhhNHO7qV7KzM4ps6ti+FOB9UDQiGRCVLY1z4D8Ro9dpcviFOWJtOCFAUekB0Vpq+ApBbqevwJIBk0UJokZBdZLLBQF0AIMBOoCBwN2AYQCO4ECQV4AoUDPIGCwd6A4YEKENPHtkKR6ioZypTLm0W8DODo9Rbgp+ioiwCJiKAK9a45G7Vf77IoHMWIoCTZ5EkWABMYABMaAA8cAA8eAAsgAAsiAAckAAcmAAcoAAanLlDkuFTphCSCL6BOSDDCVU5mNpjBxaFpXLArQ5bDQnFgqMBMGBGJCmOKaTyKTIjUoAqgEuAhk4AA"
 
     settings_dict = decrypt_settings_string_enum(settings_string)
     settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly

--- a/ui/generate_buttons.py
+++ b/ui/generate_buttons.py
@@ -14,40 +14,7 @@ from randomizer.Worker import background
 from ui.bindings import bind
 from ui.plando_validation import validate_plando_options
 from ui.progress_bar import ProgressBar
-from ui.rando_options import (
-    disable_barrel_modal,
-    disable_colors,
-    disable_enemy_modal,
-    disable_excluded_songs_modal,
-    disable_hard_mode_modal,
-    disable_helm_hurry,
-    disable_remove_barriers,
-    disable_faster_checks,
-    disable_helm_phases,
-    disable_krool_phases,
-    disable_move_shuffles,
-    disable_music,
-    enable_plandomizer,
-    handle_progressive_hint_text,
-    item_rando_list_changed,
-    max_music,
-    max_music_proportion,
-    max_randomized_blocker,
-    max_randomized_troff,
-    max_sfx,
-    max_starting_moves_count,
-    toggle_b_locker_boxes,
-    toggle_bananaport_selector,
-    toggle_counts_boxes,
-    toggle_item_rando,
-    toggle_key_settings,
-    toggle_logic_type,
-    update_boss_required,
-    updateDoorOneCountText,
-    updateDoorOneNumAccess,
-    updateDoorTwoCountText,
-    updateDoorTwoNumAccess,
-)
+from ui.rando_options import update_ui_states
 from ui.serialize_settings import serialize_settings
 
 
@@ -127,36 +94,8 @@ def import_settings_string(event):
         except Exception as e:
             print(e)
             pass
-    toggle_counts_boxes(None)
-    toggle_b_locker_boxes(None)
-    update_boss_required(None)
-    disable_colors(None)
-    disable_music(None)
-    disable_move_shuffles(None)
-    max_randomized_blocker(None)
-    handle_progressive_hint_text(None)
-    max_randomized_troff(None)
-    max_music(None)
-    max_music_proportion(None)
-    max_sfx(None)
-    disable_barrel_modal(None)
-    updateDoorOneCountText(None)
-    updateDoorTwoCountText(None)
-    item_rando_list_changed(None)
-    toggle_item_rando(None)
-    disable_enemy_modal(None)
-    disable_excluded_songs_modal(None)
-    disable_hard_mode_modal(None)
-    toggle_bananaport_selector(None)
-    disable_helm_hurry(None)
-    disable_remove_barriers(None)
-    disable_faster_checks(None)
-    toggle_logic_type(None)
-    toggle_key_settings(None)
-    disable_krool_phases(None)
-    disable_helm_phases(None)
-    max_starting_moves_count(None)
-    enable_plandomizer(None)
+    update_ui_states(None)
+    js.savesettings()
 
 
 @bind("change", "patchfileloader")

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -713,7 +713,7 @@ def disable_move_shuffles(evt):
             training_barrels.setAttribute("disabled", "disabled")
             shockwave_status.value = "vanilla"
             shockwave_status.setAttribute("disabled", "disabled")
-            starting_moves_count.value = 40
+            starting_moves_count.value = 41
             starting_moves_count.setAttribute("disabled", "disabled")
             start_with_slam.checked = True
             start_with_slam.setAttribute("disabled", "disabled")
@@ -723,7 +723,7 @@ def disable_move_shuffles(evt):
             training_barrels.setAttribute("disabled", "disabled")
             shockwave_status.value = "vanilla"
             shockwave_status.setAttribute("disabled", "disabled")
-            starting_moves_count.value = 40
+            starting_moves_count.value = 41
             starting_moves_count.setAttribute("disabled", "disabled")
             start_with_slam.checked = True
             start_with_slam.setAttribute("disabled", "disabled")
@@ -1048,6 +1048,18 @@ def update_ui_states(event):
     toggle_logic_type(None)
     toggle_key_settings(None)
     max_starting_moves_count(None)
+    updateDoorOneNumAccess(None)
+    updateDoorOneCountText(None)
+    updateDoorTwoNumAccess(None)
+    updateDoorTwoCountText(None)
+    disable_tag_spawn(None)
+    disable_krool_phases(None)
+    disable_helm_phases(None)
+    enable_plandomizer(None)
+    disable_switchsanity_with_plandomizer(None)
+    toggle_medals_box(None)
+    toggle_extreme_prices_option(None)
+    toggle_vanilla_door_rando(None)
 
 
 @bind("click", "enable_plandomizer")
@@ -1453,32 +1465,7 @@ def shuffle_settings(evt):
     randomize_settings()
 
     # Run additional functions to ensure there are no conflicts.
-    updateDoorOneNumAccess(None)
-    updateDoorOneCountText(None)
-    updateDoorTwoNumAccess(None)
-    updateDoorTwoCountText(None)
-    toggle_b_locker_boxes(None)
-    toggle_counts_boxes(None)
-    update_boss_required(None)
-    disable_tag_spawn(None)
-    disable_krool_phases(None)
-    disable_helm_phases(None)
-    disable_move_shuffles(None)
-    disable_barrel_modal(None)
-    disable_enemy_modal(None)
-    disable_hard_mode_modal(None)
-    item_rando_list_changed(None)
-    enable_plandomizer(None)
-    disable_switchsanity_with_plandomizer(None)
-    toggle_medals_box(None)
-    toggle_extreme_prices_option(None)
-    toggle_logic_type(None)
-    toggle_bananaport_selector(None)
-    toggle_key_settings(None)
-    disable_helm_hurry(None)
-    disable_remove_barriers(None)
-    disable_faster_checks(None)
-    toggle_vanilla_door_rando(None)
+    update_ui_states()
 
 
 musicToggles = [category.replace(" ", "") for category in MusicSelectionPanel.keys()]


### PR DESCRIPTION
- Fixed an issue (again) where applying a preset didn't immediately cache the settings
- Fixed an issue where spoiler-hint-adjacent settings weren't being cached
- Fixed an issue where a few UI elements weren't correctly updating in some scenarios
- With the addition of the third slam you can now start with 41 moves, and the starting move selector has been adjusted to account for this
- Fixed issues with starting with a ton of moves and item hinting hints. You will now actually get filler hints (it won't be good filler, but you'll get filler alright) and not a bunch of errors.
- There is now a limit on funny joke hints in a seed. Wrinkly will get fed up with your nonsense after a few.
- Fixed an issue in LZR where you might have been expected to clear the Mechfish without diving
- Fixed an issue where Kongs outside of the item pool could have imprecise item hinting hints