### PR TITLE
improved multiselector tooltips, fixed a door issue

### DIFF
--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -60,6 +60,7 @@ class Spoiler:
         self.woth_paths = {}
         self.krool_paths = {}
         self.other_paths = {}
+        self.shuffled_door_data = {}
         self.shuffled_barrel_data = {}
         self.shuffled_exit_data = {}
         self.shuffled_exit_instructions = []

--- a/templates/macros.html.jinja2
+++ b/templates/macros.html.jinja2
@@ -1,4 +1,4 @@
-{% macro list_selector(list, name, title, tooltip, size) %}
+{% macro list_selector(list, name, title, tooltip, size, includeDisclaimer=False) %}
     <!-- Icon triggers modal -->
     <input class="customize"
            type="button"
@@ -27,7 +27,7 @@
             <div class="modal-body">
                 <div class="item-multiselect" style="margin-left: 105px;">
                     <div class="color-selector">
-                        <div class="input-group mb-3">
+                        <div class="input-group">
                             <div class="input-group-prepend">
                                 <div class="input-group-text search">
                                     <input type="text"
@@ -52,6 +52,12 @@
                         </div>
                     </div>
                 </div>
+                {% if includeDisclaimer %}
+                    <div class="fst-italic">
+                        <div>If nothing is selected, all options are treated as selected.</div>
+                        <div>Disable the setting slider to disable all options.</div>
+                    </div>
+                {% endif %}
                 {% if name == "minigames_list" %}
                     <div class="form-check form-switch" style="padding-left: 1.5em;">
                         <label data-toggle="tooltip"

--- a/templates/music.html.jinja2
+++ b/templates/music.html.jinja2
@@ -68,7 +68,7 @@
                                value="True"/>
                         Disabled Songs
                     </label>
-                    {{ list_selector(excluded_songs, "excluded_songs", "Disabled Songs", "This will open a popup that will let you customize what songs are disabled.&#10;This defaults to All options.", 4) }}
+                    {{ list_selector(excluded_songs, "excluded_songs", "Disabled Songs", "This will open a popup that will let you customize what songs are disabled.", 4) }}
                     {# Remove end </div> as it's included in the macro for formatting #}
                 <div class="spacer"></div>
             </div>

--- a/templates/overworld.html.jinja2
+++ b/templates/overworld.html.jinja2
@@ -35,7 +35,7 @@
                                 value="True"/>
                             Remove Barriers
                         </label>
-                        {{ list_selector(remove_barriers, "remove_barriers", "REMOVE BARRIERS", "This will open a popup that will let you customize what barriers are removed.&#10;This defaults to All options.", 12) }}
+                        {{ list_selector(remove_barriers, "remove_barriers", "REMOVE BARRIERS", "This will open a popup that will let you customize what barriers are removed.&#10;This defaults to All options.", 12, True) }}
                         {# Remove end </div> as it's included in the macro for formatting #}
                     <div class="form-check form-switch item-switch">
                         <label data-toggle="tooltip"
@@ -57,7 +57,7 @@
                                 value="True"/>
                             Faster Checks
                         </label>
-                        {{ list_selector(faster_checks, "faster_checks", "FASTER CHECKS", "This will open a popup that will let you customize what checks are sped up.&#10;This defaults to All options.", 12) }}
+                        {{ list_selector(faster_checks, "faster_checks", "FASTER CHECKS", "This will open a popup that will let you customize what checks are sped up.&#10;This defaults to All options.", 12, True) }}
                         {# Remove end </div> as it's included in the macro for formatting #}
                     <div class="form-check form-switch item-switch">
                         <label data-toggle="tooltip"
@@ -105,7 +105,7 @@
                                 </option>
                             </select>
                             <div style="padding: 5px;">
-                                {{ list_selector(glitches, "glitches", "GLITCHES", "This will open a popup that will let you customize what tricks are considered by logic with glitch logic.&#10;This defaults to All options.", 16) }}
+                                {{ list_selector(glitches, "glitches", "GLITCHES", "This will open a popup that will let you customize what tricks are considered by logic with glitch logic.&#10;This defaults to All options.", 16, True) }}
                                 {# Remove end </div> as it's included in the macro for formatting #}
                             </div>
                         </div>
@@ -281,7 +281,7 @@
                                value="True"/>
                         Hard Mode
                     </label>
-                    {{ list_selector(hard_mode, "hard_mode", "HARD MODE", "This will open a popup that will let you customize what hard mode Options are active.&#10;This defaults to All options.", 5) }}
+                    {{ list_selector(hard_mode, "hard_mode", "HARD MODE", "This will open a popup that will let you customize what hard mode Options are active.", 5) }}
                     {# Remove end </div> as it's included in the macro for formatting #}
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"

--- a/templates/qualityoflife.html.jinja2
+++ b/templates/qualityoflife.html.jinja2
@@ -20,7 +20,7 @@
                                checked/>
                         Misc Changes
                     </label>
-                    {{ list_selector(misc_changes, "misc_changes", "MISC CHANGES", "This will open a popup that will let you customize what Quality of Life Options are active.&#10;This defaults to All options.", 18) }}
+                    {{ list_selector(misc_changes, "misc_changes", "MISC CHANGES", "This will open a popup that will let you customize what Quality of Life Options are active.&#10;This defaults to All options.", 18, True) }}
                     {# Remove end </div> as it's included in the macro for formatting #}
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -19,7 +19,7 @@
                                 <path d="M14.876,2.672a3.309,3.309,0,0,0-5.752,0L.414,18.19a3.178,3.178,0,0,0,.029,3.189A3.264,3.264,0,0,0,3.29,23H20.71a3.264,3.264,0,0,0,2.847-1.621,3.178,3.178,0,0,0,.029-3.189ZM12,19a1,1,0,1,1,1-1A1,1,0,0,1,12,19Zm1-5a1,1,0,0,1-2,0V8a1,1,0,0,1,2,0Z"/>
                             </svg>
                         </span>
-                        {{ list_selector(itemRando, "item_rando_list", "ITEM RANDO SELECTOR", "This will open a popup that will let you customize what items are shuffled in the pool.&#10;This defaults to All options.", 15) }}
+                        {{ list_selector(itemRando, "item_rando_list", "ITEM RANDO SELECTOR", "This will open a popup that will let you customize what items are shuffled in the pool.&#10;This defaults to All options.", 15, True) }}
                     {# Remove end </div> as it's included in the macro for formatting #}
                     <div class="form-check form-switch item-switch" style="max-height: 24px;">
                         <label data-toggle="tooltip" title="Sparkling enemies can drop major items. Highly chaotic, adding lots of checks all over the world.">
@@ -227,7 +227,7 @@
                                 value="True"/>
                         Shuffle Enemies
                     </label>
-                    {{ list_selector(enemies, "enemies", "ENEMIES", "This will open a popup that will let you customize what enemies appear in the game.&#10;This defaults to All options.", 16) }}
+                    {{ list_selector(enemies, "enemies", "ENEMIES", "This will open a popup that will let you customize what enemies appear in the game.&#10;This defaults to All options.", 16, True) }}
                 {# Remove end </div> as it's included in the macro for formatting #}
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"
@@ -239,7 +239,7 @@
                                value="True"/>
                         Shuffle Bonus Barrels
                     </label>
-                    {{ list_selector(minigames, "minigames_list", "MINIGAME SELECTOR", "This will open a popup that will let you customize what Bonus Games are in the pool.&#10;This defaults to All minigames.", 18) }}
+                    {{ list_selector(minigames, "minigames_list", "MINIGAME SELECTOR", "This will open a popup that will let you customize what Bonus Games are in the pool.&#10;This defaults to All minigames.", 18, True) }}
                 {# Remove end </div> as it's included in the macro for formatting #}
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip" title="Enemy speeds are randomized.">
@@ -446,7 +446,7 @@
                         </option>
                     </select>
                     <div style="padding: 5px;">
-                        {{ list_selector(vanilla_warps, "warp_level_list", "LEVEL SELECTOR", "This will open a popup that will let you customize what levels' warps are in the pool. Any level not selected will have its vanilla warp locations.&#10;This defaults to All levels.", 10) }}
+                        {{ list_selector(vanilla_warps, "warp_level_list", "LEVEL SELECTOR", "This will open a popup that will let you customize what levels' warps are in the pool. Any level not selected will have its vanilla warp locations.&#10;This defaults to All levels.", 10, True) }}
                     {# Remove end </div> as it's included in the macro for formatting #}
                 </div>
             </div>


### PR DESCRIPTION
- Fixed an issue where progressive hints + not removing wrinkly puzzles would error during patching
- The multiselectors on the site were observed to have inconsistent behavior. Numerous tooltips have been adjusted and text has been added to clarify the behavior of the multiselector modals. No functionality has changed, this is purely a visual update.