### PR TITLE
Kasplat updates

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = 2.2.24
+current_version = 2.2.23
 
 [bumpversion:file:version.py]
 search = version = "{current_version}"

--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@
                 <br />
                 Randomizer by 2dos and Ballaam | Web Generator by Killklli
                 <br />
-                In-game characters, images and logos copyright © 1999-2021 Nintendo or Rareware respectively.
+                In-game characters, images and logos copyright © 1999-2024 Nintendo or Rareware respectively.
                 <br />
                 DK64Randomizer.com does not distribute copyright material.
             </div>

--- a/randomizer.html
+++ b/randomizer.html
@@ -547,7 +547,7 @@
                 <br />
                 Randomizer by 2dos and Ballaam | Web Generator by Killklli
                 <br />
-                In-game characters, images and logos copyright © 1999-2021 Nintendo or Rareware respectively.
+                In-game characters, images and logos copyright © 1999-2024 Nintendo or Rareware respectively.
                 <br />
                 DK64Randomizer.com does not distribute copyright material.
             </div>

--- a/randomizer/Lists/KasplatLocations.py
+++ b/randomizer/Lists/KasplatLocations.py
@@ -1119,7 +1119,7 @@ KasplatLocationList = {
             scale=1.3,
         ),
         KasplatLocation(
-            name="Caves Kasplat: Tied to the Bananaport Pillar",
+            name="Caves Kasplat: Tied to the Bananaport Spire",
             map_id=Maps.CrystalCaves,
             kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
             coords=[1169, 25, 1912],

--- a/randomizer/Lists/KasplatLocations.py
+++ b/randomizer/Lists/KasplatLocations.py
@@ -1116,7 +1116,7 @@ KasplatLocationList = {
             zmin=1920,
             zmax=2170,
             region=Regions.CrystalCavesMain,
-            scale = 1.3,
+            scale=1.3,
         ),
         KasplatLocation(
             name="Caves Kasplat: Tied to the Bananaport Pillar",

--- a/randomizer/Lists/KasplatLocations.py
+++ b/randomizer/Lists/KasplatLocations.py
@@ -11,7 +11,7 @@ from randomizer.Enums.Switches import Switches
 class KasplatLocation:
     """Class which stores name and logic for a kasplat location."""
 
-    def __init__(self, *, name="No Location", map_id=0, kong_lst=[], coords=[0, 0, 0], xmin=0, xmax=0, zmin=0, zmax=0, region, additional_logic=None, vanilla=False):
+    def __init__(self, *, name="No Location", map_id=0, kong_lst=[], coords=[0, 0, 0], xmin=0, xmax=0, zmin=0, zmax=0, region, additional_logic=None, vanilla=False, scale=1):
         """Initialize with given parameters."""
         self.name = name
         self.map = map_id
@@ -20,6 +20,7 @@ class KasplatLocation:
         self.bounds = [xmin, xmax, zmin, zmax]
         self.selected = False
         self.vanilla = vanilla
+        self.scale = scale
         self.region_id = region
         if additional_logic is None:
             self.additional_logic = lambda l: True
@@ -1114,6 +1115,18 @@ KasplatLocationList = {
             xmax=1490,
             zmin=1920,
             zmax=2170,
+            region=Regions.CrystalCavesMain,
+            scale = 1.3,
+        ),
+        KasplatLocation(
+            name="Caves Kasplat: Tied to the Bananaport Pillar",
+            map_id=Maps.CrystalCaves,
+            kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
+            coords=[1169, 25, 1912],
+            xmin=1168,
+            xmax=1170,
+            zmin=1911,
+            zmax=1913,
             region=Regions.CrystalCavesMain,
         ),
         KasplatLocation(

--- a/randomizer/Patching/KasplatLocationRando.py
+++ b/randomizer/Patching/KasplatLocationRando.py
@@ -123,6 +123,7 @@ def randomize_kasplat_locations(spoiler):
                             while fence_index in used_fence_ids:
                                 fence_index += 1
                             used_fence_ids.append(fence_index)
+                        scale = int(kasplat.scale * 0x32) & 0xFF
                         # Spawner
                         data_bytes = []
                         kong_idx = spoiler.shuffled_kasplat_map[kasplat.name]
@@ -140,7 +141,7 @@ def randomize_kasplat_locations(spoiler):
                         data_bytes.append(0x23)  # Idle Speed
                         data_bytes.append(0x3C)  # Aggro Speed
                         data_bytes.append(fence_index)  # Fence ID
-                        data_bytes.append(0x32)  # Scale
+                        data_bytes.append(scale)  # Scale
                         data_bytes.append(1)  # Init Control State
                         data_bytes.append(0)  # Extra Data Count
                         data_bytes.append(2)  # Init Spawn State

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 """Holds the version for DK64 Rando."""
-version = "2.2.24"
+version = "2.2.23"
 split_data = version.split(".")
 major = split_data[0]
 minor = split_data[1]

--- a/wiki-lists/CUSTOM_LOCATIONS.MD
+++ b/wiki-lists/CUSTOM_LOCATIONS.MD
@@ -194,7 +194,7 @@
 | Gloomy Galleon | In Enguarde Alcove | Events.LighthouseEnguarde in l.Events | 
 | Gloomy Galleon | In Front of Mermaid Palace | Events.LighthouseEnguarde in l.Events | 
 | Gloomy Galleon | On Rocketbarrel platform |  | 
-| Gloomy Galleon | Blueprint Alcove | Events.WaterLowered in l.Events, banned_types=[LocationTypes.MelonCrate]) | 
+| Gloomy Galleon | Blueprint Alcove | Events.WaterLowered in l.Events | 
 | Gloomy Galleon | Behind Snide's |  | 
 | Gloomy Galleon | Shipyard: On top of Tiny Submarine | Events.ShipyardEnguarde in l.Events | 
 | Gloomy Galleon | In the Shipwreck with Replenishables | Events.ShipyardEnguarde in l.Events | 

--- a/wiki-lists/KASPLATS.MD
+++ b/wiki-lists/KASPLATS.MD
@@ -149,6 +149,7 @@
 | Crystal Caves | Caves Kasplat: By the Far Warp 2 |  | 
 | Crystal Caves | Caves Kasplat: On 5-Door Igloo |  | 
 | Crystal Caves | Caves Kasplat: Water by Blast Pad |  | 
+| Crystal Caves | Caves Kasplat: Tied to the Bananaport Pillar |  | 
 | Crystal Caves | Caves Kasplat: Between Funky and Castle |  | 
 | Caves Lanky Race | Caves Kasplat: In the Beetle Race |  | 
 | Crystal Caves | Caves Kasplat: With the Giant Kosha |  | 

--- a/wiki-lists/KASPLATS.MD
+++ b/wiki-lists/KASPLATS.MD
@@ -149,7 +149,7 @@
 | Crystal Caves | Caves Kasplat: By the Far Warp 2 |  | 
 | Crystal Caves | Caves Kasplat: On 5-Door Igloo |  | 
 | Crystal Caves | Caves Kasplat: Water by Blast Pad |  | 
-| Crystal Caves | Caves Kasplat: Tied to the Bananaport Pillar |  | 
+| Crystal Caves | Caves Kasplat: Tied to the Bananaport Spire |  | 
 | Crystal Caves | Caves Kasplat: Between Funky and Castle |  | 
 | Caves Lanky Race | Caves Kasplat: In the Beetle Race |  | 
 | Crystal Caves | Caves Kasplat: With the Giant Kosha |  | 


### PR DESCRIPTION
- Enlarged the underwater kasplat in caves
- Added an additional underwater kasplat in caves

PR note: melon crates are still banned in the Galleon alcove. the linter just thought it shouldn't be mentioned in the .MD file