### PR TITLE
cb logic cleanup, switchsanity fail fix, shockwave spoiler value

### DIFF
--- a/randomizer/CollectibleLogicFiles/CreepyCastle.py
+++ b/randomizer/CollectibleLogicFiles/CreepyCastle.py
@@ -79,7 +79,7 @@ LogicRegions = {
         Collectible(Collectibles.coin, Kongs.chunky, lambda l: True, None, 4),
     ],
     Regions.Museum: [
-        Collectible(Collectibles.bunch, Kongs.chunky, lambda l: (l.punch and l.barrels) or l.phasewalk, None, 1),  # Inside boulder (Chunky)
+        Collectible(Collectibles.bunch, Kongs.chunky, lambda l: l.punch and l.barrels, None, 1),  # Inside boulder (Chunky)
         Collectible(Collectibles.balloon, Kongs.chunky, lambda l: l.pineapple, None, 1),
 
         Collectible(Collectibles.coin, Kongs.chunky, lambda l: True, None, 3),

--- a/randomizer/CollectibleLogicFiles/CrystalCaves.py
+++ b/randomizer/CollectibleLogicFiles/CrystalCaves.py
@@ -72,7 +72,7 @@ LogicRegions = {
         Collectible(Collectibles.balloon, Kongs.donkey, lambda l: l.coconut, None, 1),
 
         Collectible(Collectibles.banana, Kongs.chunky, lambda l: Events.CavesSmallBoulderButton in l.Events or l.phasewalk, None, 6),
-        Collectible(Collectibles.bunch, Kongs.chunky, lambda l: (Events.CavesSmallBoulderButton in l.Events and l.hunkyChunky and l.barrels) or l.phasewalk, None, 1),
+        Collectible(Collectibles.bunch, Kongs.chunky, lambda l: Events.CavesSmallBoulderButton in l.Events and l.hunkyChunky and l.barrels, None, 1),
 
         Collectible(Collectibles.coin, Kongs.donkey, lambda l: True, None, 3),
     ],

--- a/randomizer/CollectibleLogicFiles/FungiForest.py
+++ b/randomizer/CollectibleLogicFiles/FungiForest.py
@@ -124,9 +124,9 @@ LogicRegions = {
         Collectible(Collectibles.coin, Kongs.chunky, lambda l: True, None, 3),  # On mushroom near Chunky minecart exit
     ],
     Regions.MillChunkyTinyArea: [
-        Collectible(Collectibles.bunch, Kongs.chunky, lambda l: l.punch or l.phasewalk, None, 1),
+        Collectible(Collectibles.bunch, Kongs.chunky, lambda l: l.punch, None, 1),
         Collectible(Collectibles.bunch, Kongs.tiny, lambda l: True, None, 2),  # Near Spider
-        Collectible(Collectibles.bunch, Kongs.tiny, lambda l: Events.MillBoxBroken in l.Events or l.phasewalk, None, 1),  # Inside Box
+        Collectible(Collectibles.bunch, Kongs.tiny, lambda l: Events.MillBoxBroken in l.Events, None, 1),  # Inside Box
 
         Collectible(Collectibles.coin, Kongs.chunky, lambda l: True, None, 3),
     ],
@@ -134,7 +134,7 @@ LogicRegions = {
         Collectible(Collectibles.bunch, Kongs.tiny, lambda l: True, None, 1),
     ],
     Regions.GrinderRoom: [
-        Collectible(Collectibles.bunch, Kongs.donkey, lambda l: l.Slam or l.phasewalk, None, 1),  # In slam box
+        Collectible(Collectibles.bunch, Kongs.donkey, lambda l: l.Slam, None, 1),  # In slam box
         Collectible(Collectibles.balloon, Kongs.donkey, lambda l: (l.CanSlamSwitch(Levels.FungiForest, 2) or l.generalclips or l.phasewalk) and l.coconut, None, 1),  # Behind gate
 
         Collectible(Collectibles.coin, Kongs.lanky, lambda l: True, None, 3),
@@ -161,7 +161,7 @@ LogicRegions = {
         Collectible(Collectibles.coin, Kongs.donkey, lambda l: l.strongKong, None, 3),  # On thorn vines
     ],
     Regions.ThornvineBarn: [
-        Collectible(Collectibles.bunch, Kongs.donkey, lambda l: (l.Slam or l.phasewalk) and l.isdonkey, None, 1),  # In slam box
+        Collectible(Collectibles.bunch, Kongs.donkey, lambda l: l.Slam and l.isdonkey, None, 1),  # In slam box
         Collectible(Collectibles.coin, Kongs.donkey, lambda l: True, None, 3),  # In trough
     ],
     Regions.WormArea: [

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -2220,7 +2220,7 @@ def compileSpoilerHints(spoiler):
             + str(spoiler.settings.points_list_pad_moves)
             + " | Barrel Moves: "
             + str(spoiler.settings.points_list_barrel_moves)
-            + " | Training Moves: "
+            + " | Training and Fairy Moves: "
             + str(spoiler.settings.points_list_training_moves)
             + " | Shared Moves: "
             + str(spoiler.settings.points_list_important_shared)

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -2273,6 +2273,8 @@ def PointValueOfItem(settings, item_id):
         return settings.points_list_important_shared
     elif item_id == Items.Bean:
         return settings.points_list_bean
+    elif item_id in ItemPool.ShockwaveTypeItems(settings):
+        return settings.points_list_training_moves  # This will be changed to an independent option later
     return 0
 
 

--- a/randomizer/Lists/CBLocations/AngryAztecCBLocations.py
+++ b/randomizer/Lists/CBLocations/AngryAztecCBLocations.py
@@ -743,7 +743,7 @@ ColoredBananaGroupList = [
         name="Inside giant boulder",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.AngryAztecMain,
-        logic=lambda l: (l.chunky and l.hunkyChunky and l.barrels) or l.phasewalk,
+        logic=lambda l: l.chunky and l.hunkyChunky and l.barrels,
         locations=[[5, 1.0, 3585, 118, 2406]],
     ),
     ColoredBananaGroup(

--- a/randomizer/Lists/CBLocations/CreepyCastleCBLocations.py
+++ b/randomizer/Lists/CBLocations/CreepyCastleCBLocations.py
@@ -1027,7 +1027,7 @@ ColoredBananaGroupList = [
         ],
     ),
     ColoredBananaGroup(
-        group=87, map_id=Maps.CastleShed, name="On Gorilla Gone pad", konglist=[Kongs.chunky], region=Regions.Shed, logic=lambda l: l.punch or l.phasewalk, locations=[[5, 1.0, 304, 12, 354]]
+        group=87, map_id=Maps.CastleShed, name="On Gorilla Gone pad", konglist=[Kongs.chunky], region=Regions.Shed, logic=lambda l: l.punch, locations=[[5, 1.0, 304, 12, 354]]
     ),
     ColoredBananaGroup(
         group=88,

--- a/randomizer/Lists/CBLocations/CreepyCastleCBLocations.py
+++ b/randomizer/Lists/CBLocations/CreepyCastleCBLocations.py
@@ -1513,7 +1513,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.chunky],
         region=Regions.Museum,
         vanilla=True,
-        logic=lambda l: (l.punch and l.barrels) or l.phasewalk,
+        logic=lambda l: l.punch and l.barrels,
         locations=[[5, 1.0, 773.6740112304688, 159.0, 298.97247314453125]],
     ),
     ColoredBananaGroup(

--- a/randomizer/Lists/CBLocations/CreepyCastleCBLocations.py
+++ b/randomizer/Lists/CBLocations/CreepyCastleCBLocations.py
@@ -1026,9 +1026,7 @@ ColoredBananaGroupList = [
             [1, 1.0, 402, 0, 495],
         ],
     ),
-    ColoredBananaGroup(
-        group=87, map_id=Maps.CastleShed, name="On Gorilla Gone pad", konglist=[Kongs.chunky], region=Regions.Shed, logic=lambda l: l.punch, locations=[[5, 1.0, 304, 12, 354]]
-    ),
+    ColoredBananaGroup(group=87, map_id=Maps.CastleShed, name="On Gorilla Gone pad", konglist=[Kongs.chunky], region=Regions.Shed, logic=lambda l: l.punch, locations=[[5, 1.0, 304, 12, 354]]),
     ColoredBananaGroup(
         group=88,
         map_id=Maps.CastleLowerCave,

--- a/randomizer/Lists/CBLocations/CrystalCavesCBLocations.py
+++ b/randomizer/Lists/CBLocations/CrystalCavesCBLocations.py
@@ -1267,7 +1267,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.BoulderCave,
         vanilla=True,
-        logic=lambda l: (Events.CavesSmallBoulderButton in l.Events and l.hunkyChunky and l.barrels) or l.phasewalk,
+        logic=lambda l: Events.CavesSmallBoulderButton in l.Events and l.hunkyChunky and l.barrels,
         locations=[[5, 1.0, 1922.93359375, 290.3333435058594, 2504.288330078125]],
     ),
     ColoredBananaGroup(

--- a/randomizer/Lists/CBLocations/FungiForestCBLocations.py
+++ b/randomizer/Lists/CBLocations/FungiForestCBLocations.py
@@ -1510,7 +1510,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.donkey],
         region=Regions.ThornvineBarn,
         vanilla=True,
-        logic=lambda l: (l.Slam or l.phasewalk) and l.isdonkey,
+        logic=lambda l: l.Slam and l.isdonkey,
         locations=[[5, 1.0, 114.7787094116211, 17.76678466796875, 188.0786590576172]],
     ),
     ColoredBananaGroup(
@@ -1528,7 +1528,7 @@ ColoredBananaGroupList = [
         name="On DK switch (Donkey)",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.GrinderRoom,
-        logic=lambda l: l.Slam or l.phasewalk,
+        logic=lambda l: l.Slam,
         vanilla=True,
         locations=[[5, 1.0, 48.73106002807617, 61.166255950927734, 188.2012481689453]],
     ),
@@ -1557,7 +1557,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.tiny, Kongs.chunky],
         region=Regions.MillChunkyTinyArea,
         vanilla=True,
-        logic=lambda l: Events.MillBoxBroken in l.Events or l.phasewalk,
+        logic=lambda l: Events.MillBoxBroken in l.Events,
         locations=[[5, 1.0, 390.7475891113281, 0, 114.15646362304688]],
     ),
     ColoredBananaGroup(
@@ -1567,7 +1567,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.tiny, Kongs.chunky],
         region=Regions.MillChunkyTinyArea,
         vanilla=True,
-        logic=lambda l: Events.MillBoxBroken in l.Events or l.phasewalk,
+        logic=lambda l: Events.MillBoxBroken in l.Events,
         locations=[[5, 1.0, 622.750732421875, 18.0, 167.2416534423828]],
     ),
     ColoredBananaGroup(

--- a/randomizer/Lists/CBLocations/FungiForestCBLocations.py
+++ b/randomizer/Lists/CBLocations/FungiForestCBLocations.py
@@ -259,9 +259,9 @@ ColoredBananaGroupList = [
         group=27,
         map_id=Maps.FungiForest,
         name="Top of Minecart exit",
-        konglist=[Kongs.donkey, Kongs.tiny],
+        konglist=[Kongs.tiny],
         region=Regions.MillArea,
-        logic=lambda l: (l.isdonkey and l.settings.krusha_kong != Kongs.donkey) or (l.istiny and l.twirl),
+        logic=lambda l: l.istiny and l.twirl,
         locations=[[5, 1.0, 5354, 395, 3644], [5, 1.0, 5331, 392, 3712]],
     ),
     ColoredBananaGroup(

--- a/randomizer/Lists/CBLocations/GloomyGalleonCBLocations.py
+++ b/randomizer/Lists/CBLocations/GloomyGalleonCBLocations.py
@@ -116,7 +116,7 @@ ColoredBananaGroupList = [
         name="Inside middle chest with headphones",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.GloomyGalleonStart,
-        logic=lambda l: l.punch or l.phasewalk,
+        logic=lambda l: l.punch,
         locations=[[5, 1.0, 3668, 1675, 3808]],
     ),
     ColoredBananaGroup(
@@ -125,7 +125,7 @@ ColoredBananaGroupList = [
         name="Inside left chest with Fairy",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.GloomyGalleonStart,
-        logic=lambda l: l.punch or l.phasewalk,
+        logic=lambda l: l.punch,
         locations=[[5, 1.0, 3548, 1675, 3695]],
     ),
     ColoredBananaGroup(

--- a/randomizer/Lists/CBLocations/JungleJapesCBLocations.py
+++ b/randomizer/Lists/CBLocations/JungleJapesCBLocations.py
@@ -1114,7 +1114,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.JapesBeyondCoconutGate2,
         vanilla=True,
-        logic=lambda l: Events.Rambi in l.Events or l.phasewalk,
+        logic=lambda l: Events.Rambi in l.Events,
         locations=[[5, 1.0, 2007.12548828125, 315.0, 4295.62548828125]],
     ),
     ColoredBananaGroup(
@@ -1124,7 +1124,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.JapesBeyondCoconutGate2,
         vanilla=True,
-        logic=lambda l: Events.Rambi in l.Events or l.phasewalk,
+        logic=lambda l: Events.Rambi in l.Events,
         locations=[[5, 1.0, 1372.8516845703125, 315.0, 4290.01708984375]],
     ),
     ColoredBananaGroup(
@@ -1134,7 +1134,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.JapesBeyondCoconutGate2,
         vanilla=True,
-        logic=lambda l: Events.Rambi in l.Events or l.phasewalk,
+        logic=lambda l: Events.Rambi in l.Events,
         locations=[[5, 1.0, 1213.37646484375, 315.0, 3887.611083984375]],
     ),
     ColoredBananaGroup(
@@ -1144,7 +1144,7 @@ ColoredBananaGroupList = [
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.JapesBeyondCoconutGate2,
         vanilla=True,
-        logic=lambda l: Events.Rambi in l.Events or l.phasewalk,
+        logic=lambda l: Events.Rambi in l.Events,
         locations=[[5, 1.0, 2173.53125, 315.0, 3889.4189453125]],
     ),
     ColoredBananaGroup(

--- a/randomizer/Lists/WrinklyHints.py
+++ b/randomizer/Lists/WrinklyHints.py
@@ -88,7 +88,7 @@ PointSpreadBase = [
     ("Keys", 9),
     ("Guns", 7),
     ("Instruments", 7),
-    ("Training and Fairy Moves", 5),
+    ("Training/Fairy Moves", 5),
     ("Important Shared", 5),
     ("Pad Moves", 3),
     ("Barrel Moves", 3),
@@ -96,4 +96,4 @@ PointSpreadBase = [
     ("Bean", 3),
 ]
 for item in PointSpreadBase:
-    PointSpreadSelector.append({"name": item[0], "value": item[0].lower().replace(" ", "_"), "tooltip": "", "default": item[1]})
+    PointSpreadSelector.append({"name": item[0], "value": item[0].replace("Training/Fairy", "training").lower().replace(" ", "_"), "tooltip": "", "default": item[1]})

--- a/randomizer/Lists/WrinklyHints.py
+++ b/randomizer/Lists/WrinklyHints.py
@@ -88,7 +88,7 @@ PointSpreadBase = [
     ("Keys", 9),
     ("Guns", 7),
     ("Instruments", 7),
-    ("Training Moves", 5),
+    ("Training and Fairy Moves", 5),
     ("Important Shared", 5),
     ("Pad Moves", 3),
     ("Barrel Moves", 3),

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -376,7 +376,7 @@ LogicRegions = {
     ]),
 
     Regions.HideoutHelmLobby: Region("Hideout Helm Lobby", "Caves-Helm Lobbies", Levels.DKIsles, True, None, [
-        LocationLogic(Locations.IslesChunkyHelmLobby, lambda l: (l.hasMoveSwitchsanity(Switches.IslesHelmLobbyGone, False) and l.chunky and l.vines) or (l.settings.bonus_barrels == MinigameBarrels.skip and l.advanced_platforming and l.istiny and l.twirl and l.settings.free_trade_items), MinigameType.BonusBarrel),
+        LocationLogic(Locations.IslesChunkyHelmLobby, lambda l: (l.hasMoveSwitchsanity(Switches.IslesHelmLobbyGone, False) and l.ischunky and l.vines) or (l.settings.bonus_barrels == MinigameBarrels.skip and l.advanced_platforming and l.istiny and l.twirl and l.settings.free_trade_items), MinigameType.BonusBarrel),
         LocationLogic(Locations.IslesKasplatHelmLobby, lambda l: not l.settings.kasplat_rando and ((l.scope and l.coconut) or (l.twirl and l.tiny and l.advanced_platforming))),
     ], [
         Event(Events.HelmLobbyAccessed, lambda l: True),

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -376,7 +376,7 @@ LogicRegions = {
     ]),
 
     Regions.HideoutHelmLobby: Region("Hideout Helm Lobby", "Caves-Helm Lobbies", Levels.DKIsles, True, None, [
-        LocationLogic(Locations.IslesChunkyHelmLobby, lambda l: (l.hasMoveSwitchsanity(Switches.IslesHelmLobbyGone) and l.chunky and l.vines) or (l.settings.bonus_barrels == MinigameBarrels.skip and l.advanced_platforming and l.istiny and l.twirl and l.settings.free_trade_items), MinigameType.BonusBarrel),
+        LocationLogic(Locations.IslesChunkyHelmLobby, lambda l: (l.hasMoveSwitchsanity(Switches.IslesHelmLobbyGone, False) and l.chunky and l.vines) or (l.settings.bonus_barrels == MinigameBarrels.skip and l.advanced_platforming and l.istiny and l.twirl and l.settings.free_trade_items), MinigameType.BonusBarrel),
         LocationLogic(Locations.IslesKasplatHelmLobby, lambda l: not l.settings.kasplat_rando and ((l.scope and l.coconut) or (l.twirl and l.tiny and l.advanced_platforming))),
     ], [
         Event(Events.HelmLobbyAccessed, lambda l: True),

--- a/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
@@ -237,7 +237,7 @@
 | Bunches on 4 corners of Chunky BB cage | 20 | `` | 
 | Bunches on top of Chunky BB cage | 10 | `` | 
 | Along the walls around Chunky BB cage | 15 | `` | 
-| Inside giant boulder | 5 | `(l.chunky and l.hunkyChunky and l.barrels) or l.phasewalk` | 
+| Inside giant boulder | 5 | `l.chunky and l.hunkyChunky and l.barrels` | 
 | Bunches on each side of Funky's | 10 | `` | 
 | Singles up the stairs between Funky and Llama temple | 10 | `` | 
 | Singles up the stairs between Llama Temple and W2 | 10 | `` | 
@@ -550,8 +550,8 @@
 | To Cranky area (3 custom, 2 Chunky) | 5 | `` | 
 | Tunnel to Chests room (5 custom, 5 Chunky) | 10 | `` | 
 | Around Chunky chest room | 10 | `` | 
-| Inside middle chest with headphones | 5 | `l.punch or l.phasewalk` | 
-| Inside left chest with Fairy | 5 | `l.punch or l.phasewalk` | 
+| Inside middle chest with headphones | 5 | `l.punch` | 
+| Inside left chest with Fairy | 5 | `l.punch` | 
 | In alcove to chest room by Chunky coins | 10 | `` | 
 | On left side of ship to chests room | 5 | `` | 
 | On each side of Cranky's Lab ship at the bottom | 10 | `` | 
@@ -921,13 +921,13 @@
 | Near melon crate in thornvine area | 5 | `` | 
 | On boxes on upper level | 10 | `` | 
 | On ladder | 5 | `` | 
-| On switch (Donkey) | 5 | `(l.Slam or l.phasewalk) and l.isdonkey` | 
+| On switch (Donkey) | 5 | `l.Slam and l.isdonkey` | 
 ## Forest Mill Front
 | Name | Amount | Logic |
 | ---- | ------ | ----- |
 | On flour bag by Mini Monkey | 5 | `` | 
 | On conveyor belt | 5 | `` | 
-| On DK switch (Donkey) | 5 | `l.Slam or l.phasewalk` | 
+| On DK switch (Donkey) | 5 | `l.Slam` | 
 | Middle of the room | Balloon | `` | 
 | In DK's lever room (Donkey) | Balloon | `(l.CanSlamSwitch(Levels.FungiForest, 2) or l.generalclips or l.phasewalk)` | 
 ## Forest Giant Mushroom
@@ -975,8 +975,8 @@
 | On boxes by Mini Monkey barrels | 10 | `` | 
 | On boxes by spider room (Tiny) | 5 | `` | 
 | By Mini Monkey entrance to front mill (Tiny) | 5 | `` | 
-| Inside punchable box (Tiny) | 5 | `Events.MillBoxBroken in l.Events or l.phasewalk` | 
-| On triangle pad (Chunky) | 5 | `Events.MillBoxBroken in l.Events or l.phasewalk` | 
+| Inside punchable box (Tiny) | 5 | `Events.MillBoxBroken in l.Events` | 
+| On triangle pad (Chunky) | 5 | `Events.MillBoxBroken in l.Events` | 
 | Middle of room | Balloon | `` | 
 ## Forest Spider
 | Name | Amount | Logic |
@@ -1097,7 +1097,7 @@
 | Chunky igloo (Chunky) | 5 | `Events.CavesLargeBoulderButton in l.Events or l.generalclips or l.CanPhaseswim()` | 
 | On Gorilla Gone pad (Chunky) | 5 | `(l.punch and l.chunky) or l.phasewalk or l.CanPhaseswim()` | 
 | On small boulder switch (Chunky) | 5 | `` | 
-| Inside giant boulder (Chunky) | 5 | `(Events.CavesSmallBoulderButton in l.Events and l.hunkyChunky and l.barrels) or l.phasewalk` | 
+| Inside giant boulder (Chunky) | 5 | `Events.CavesSmallBoulderButton in l.Events and l.hunkyChunky and l.barrels` | 
 | W3 (Tiny) | 5 | `` | 
 | W3 (Tiny) | 5 | `` | 
 | On riverbed to waterfall (Lanky) | 10 | `` | 
@@ -1365,7 +1365,7 @@
 | Name | Amount | Logic |
 | ---- | ------ | ----- |
 | Shed - Around room | 15 | `` | 
-| On Gorilla Gone pad | 5 | `l.punch, locations=[[5, 1.0, 304, 12, 354]]` | 
+| On Gorilla Gone pad | 5 | `l.punch, locations=[[5, 1.0, 304, 12, 354]])` | 
 | In shed (Chunky) | Balloon | `` | 
 ## Castle Lower Cave
 | Name | Amount | Logic |

--- a/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
@@ -70,10 +70,10 @@
 | Starting area (Diddy) | 5 | `` | 
 | On Funky's shop (Chunky) | 10 | `` | 
 | Under Lanky's bonus barrel in first cave (Lanky) | 5 | `l.grape or l.phasewalk or l.generalclips` | 
-| In Rambi hut (Lanky) | 5 | `Events.Rambi in l.Events or l.phasewalk` | 
-| In Rambi hut (Donkey) | 5 | `Events.Rambi in l.Events or l.phasewalk` | 
-| In Rambi hut (Diddy) | 5 | `Events.Rambi in l.Events or l.phasewalk` | 
-| In Rambi hut (Tiny) | 5 | `Events.Rambi in l.Events or l.phasewalk` | 
+| In Rambi hut (Lanky) | 5 | `Events.Rambi in l.Events` | 
+| In Rambi hut (Donkey) | 5 | `Events.Rambi in l.Events` | 
+| In Rambi hut (Diddy) | 5 | `Events.Rambi in l.Events` | 
+| In Rambi hut (Tiny) | 5 | `Events.Rambi in l.Events` | 
 | On treetops (Tag barrel side) (Diddy) | 10 | `` | 
 | Inside cage with Rambi Box (Donkey) | 5 | `l.hasMoveSwitchsanity(Switches.JapesRambi, False) or l.phasewalk` | 
 | On 4 trees in Beehive area (Chunky) | 20 | `l.hunkyChunky` | 
@@ -781,7 +781,7 @@
 | Mushroom by Diddy's barn | 5 | `` | 
 | Mushroom by back tag barrel | 5 | `` | 
 | Mushroom by Minecart exit | 5 | `` | 
-| Top of Minecart exit | 10 | `(l.isdonkey and l.settings.krusha_kong != Kongs.donkey) or (l.istiny and l.twirl)` | 
+| Top of Minecart exit | 10 | `l.istiny and l.twirl` | 
 | Top of Mill (8 custom, 7 Lanky) | 15 | `` | 
 | Outside of conveyor belt (behind night gate) | 5 | `Events.Night in l.Events or l.phasewalk or l.CanPhaseswim() or l.ledgeclip` | 
 | W1 (1 custom, 1 Lanky bunch) | 5 | `` | 
@@ -1365,7 +1365,7 @@
 | Name | Amount | Logic |
 | ---- | ------ | ----- |
 | Shed - Around room | 15 | `` | 
-| On Gorilla Gone pad | 5 | `l.punch or l.phasewalk, locations=[[5, 1.0, 304, 12, 354]]` | 
+| On Gorilla Gone pad | 5 | `l.punch, locations=[[5, 1.0, 304, 12, 354]]` | 
 | In shed (Chunky) | Balloon | `` | 
 ## Castle Lower Cave
 | Name | Amount | Logic |

--- a/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
@@ -1448,7 +1448,7 @@
 | On chimneys of car race building | 10 | `` | 
 | On monkeyport pads on car race side (Tiny) | 10 | `` | 
 | On monkeyport pad on monument side (Tiny) | 5 | `l.monkeyport or l.phasewalk` | 
-| Inside boulder (Chunky) | 5 | `(l.punch and l.barrels) or l.phasewalk` | 
+| Inside boulder (Chunky) | 5 | `l.punch and l.barrels` | 
 | In hallway to main room | Balloon | `` | 
 | Around car race | Balloon | `` | 
 | In monument room (Tiny) | Balloon | `l.feather and (l.monkeyport or l.phasewalk)` | 


### PR DESCRIPTION
- Fixed one more cb custom location that had issues with Krusha
- Cleaned up some cb logic that would make you do degenerate things with phasewalking
- Added camera/shockwave to points hints. They are tied to the training move point value. In a future major version they will get their own point box.
- Fixed an issue where a few (rare) specific combinations of Switchsanity and Bonus Barrel rando could cause the Helm lobby barrel to be logically impossible.