### PR TITLE
fix reshuffling random starting location, non item rando starting moves

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -2299,7 +2299,7 @@ def FillWorld(spoiler: Spoiler) -> None:
             if retries % 3 == 0:
                 js.postMessage("Retrying fill really hard. Tries: " + str(retries))
                 if spoiler.settings.random_starting_region:
-                    spoiler.settings.RandomizeStartingLocation()
+                    spoiler.settings.RandomizeStartingLocation(spoiler)
                 if spoiler.settings.shuffle_loading_zones == ShuffleLoadingZones.levels:  # TODO: Reshuffling LZR doesn't work yet, but it might be nice? Not sure how necessary it is
                     ShuffleExits.ShuffleExits(spoiler)
                     spoiler.UpdateExits()

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -20,7 +20,7 @@ def PlaceConstants(spoiler):
     # Settings-dependent locations
     settings = spoiler.settings
     # Determine what types of locations are being shuffled
-    typesOfItemsShuffled = []
+    typesOfItemsShuffled = [Types.PreGivenMove]  # Your starting moves are always eligible to be shuffled if needed
     if settings.kong_rando:
         typesOfItemsShuffled.append(Types.Kong)
     if settings.move_rando != MoveRando.off:

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -1021,10 +1021,6 @@ class Settings:
         self.helm_order = orderedRooms
         self.kong_helm_order = rooms
 
-        # Start Region
-        if self.random_starting_region:
-            self.RandomizeStartingLocation()
-
         # Initial Switch Level Placement - Will be corrected if level order rando is on during the fill process. Disable it for vanilla
         if self.level_randomization == LevelRandomization.vanilla:
             self.alter_switch_allocation = False
@@ -1313,6 +1309,9 @@ class Settings:
 
     def finalize_world_settings(self, spoiler):
         """Finalize the world state after settings initialization."""
+        # Starting Region Randomization
+        if self.random_starting_region:
+            self.RandomizeStartingLocation(spoiler)
         self.shuffle_prices(spoiler)
         # Starting Move Location handling
         # Undo any damage that might leak between seeds
@@ -1640,7 +1639,7 @@ class Settings:
             kongCageLocations.append(random.choice([Locations.DiddyKong, Locations.TinyKong, Locations.ChunkyKong]))
         return kongCageLocations
 
-    def RandomizeStartingLocation(self):
+    def RandomizeStartingLocation(self, spoiler):
         """Randomize the starting point of this seed."""
         region_data = [
             randomizer.LogicFiles.DKIsles.LogicRegions,
@@ -1690,7 +1689,7 @@ class Settings:
                         )
         self.starting_region = random.choice(valid_starting_regions)
         for x in range(2):
-            randomizer.LogicFiles.DKIsles.LogicRegions[Regions.GameStart].exits[x + 1].dest = self.starting_region["region"]
+            spoiler.RegionList[Regions.GameStart].exits[x + 1].dest = self.starting_region["region"]
 
     def ApplyPlandomizerSettings(self):
         """Apply settings specified by the plandomizer."""

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -33,7 +33,7 @@ with open("static/presets/preset_files.json", "r") as file:
 # Add a custom preset for testing
 # If we're not running on github actions, add the custom preset
 if not os.environ.get("GITHUB_ACTIONS"):
-    valid_presets.append(("Custom", "bKEFiRorPN5ysoQNEB6OkWMAhuIMtYhBevn8A2ePhhNHO7qV7KzM4ps6ti+FOB9UDQiGRCVLY1z4D8Ro9dpcviFOWJtOCFAUekB0Vpq+ApBbqevwJIBk0UJokZBdZLLBQF0AIMBOoCBwN2AYQCO4ECQV4AoUDPIGCwd6A4YEKENPHtkKR6ioZypTLm0W8DODo9Rbgp+ioiwCJiKAK9a45G7Vf77IoHMWIoBzZ5EkWABMYABMaAA8cAA8eAAsgAAsiAAckAAcmAAcoAAanLlDkuFTphCSCL6BOSDDCVU5mNpjBxaFpXLArQ5bDQnFgqMBMGBGJCmOKaTyKTIjUoAqgEuAhk4AA"))
+    valid_presets.append(("Custom", "VjCAIgnDEGkBCgKQHRWmr5P34EgAiaKE0SMguAoC6DwGBXU8A4e7MgIHnd9BJk8SwKQXmvBag9ZAMZFCGnj2yFI9Rls9Eql1SYRbgZ+ioCwIJgKAS9HLVfZFA5iRDACbPIkiwAJjAAJjQAHjgAHjwAFkAAFkQADkgADkwADlAADUxckuFNidMISQRfQJyQYYSoeB4fCJHLpLF4QMxtMYOLSjAQgFpuK5YFaHLYaE4sFRkMpgJgwIxoJCmOJrDZ/TSeRSZEZDUoAqgEuRBASFBYYG0pEWCYoKkhaLjAySlw2ODpMXj5AQk5QUlRgYmQ"))
 
 
 @parameterized_class(('name', 'settings_string'), valid_presets)


### PR DESCRIPTION
- Fixed a comically complicated error that could occur when random starting locations were enabled that might cause your seed to be logically unbeatable.
- Fixed an issue where you couldn't start with moves when the item randomizer is disabled or shops are not in the item rando pool