### PR TITLE
fix forest enemies, short training hints

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -1252,6 +1252,7 @@ def compileHints(spoiler: Spoiler) -> bool:
                 # Starting moves could be a lot of things - instead of being super vague we'll hint the specific item directly.
                 hinted_item_name = ItemList[spoiler.LocationList[loc].item].name
                 message = f"Your \x0btraining with {hinted_item_name}\x0b is on the path to {multipath_dict_hints[loc]}."
+                hinted_location_text = f"\x0b{hinted_item_name}\x0b"
             else:
                 message = f"Something in the {hinted_location_text} is on the path to {multipath_dict_hints[loc]}."
             hint_location.related_location = loc

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -27,7 +27,7 @@ LogicRegions = {
         LocationLogic(Locations.ForestMainEnemy_NearAppleDropoff, lambda l: True),
         LocationLogic(Locations.ForestMainEnemy_NearDKPortal, lambda l: True),
         LocationLogic(Locations.ForestMainEnemy_NearWellTag, lambda l: True),
-        LocationLogic(Locations.ForestMainEnemy_GreenTunnel, lambda l: l.pineapple and l.chunky),
+        LocationLogic(Locations.ForestMainEnemy_GreenTunnel, lambda l: l.checkBarrier(RemovedBarriersSelected.forest_green_tunnel) or (l.hasMoveSwitchsanity(Switches.FungiGreenFeather, False))),
     ], [
         Event(Events.ForestEntered, lambda l: True),
         Event(Events.Night, lambda l: l.HasGun(Kongs.any) or l.settings.fungi_time_internal in (FungiTimeSetting.night, FungiTimeSetting.dusk, FungiTimeSetting.progressive)),
@@ -94,6 +94,7 @@ LogicRegions = {
 
     Regions.MushroomLowerExterior: Region("Mushroom Lower Exterior", "Giant Mushroom Exterior", Levels.FungiForest, True, None, [
         LocationLogic(Locations.ForestKasplatLowerMushroomExterior, lambda l: not l.settings.kasplat_rando),
+        LocationLogic(Locations.ForestMainEnemy_NearBBlast, lambda l: True),
     ], [], [
         TransitionFront(Regions.FungiForestMedals, lambda l: True),
         TransitionFront(Regions.GiantMushroomArea, lambda l: True),
@@ -104,7 +105,6 @@ LogicRegions = {
 
     Regions.ForestBaboonBlast: Region("Forest Baboon Blast", "Giant Mushroom Exterior", Levels.FungiForest, False, None, [
         LocationLogic(Locations.ForestDonkeyBaboonBlast, lambda l: l.isdonkey, MinigameType.BonusBarrel),
-        LocationLogic(Locations.ForestMainEnemy_NearBBlast, lambda l: True),
     ], [], [
         TransitionFront(Regions.FungiForestMedals, lambda l: True),
         TransitionFront(Regions.MushroomLowerExterior, lambda l: True)


### PR DESCRIPTION
- Fixed an enemy incorrectly being in the Forest blast course
- Fixed an enemy with incorrect logic in the tunnel to Forest Funky
- Fixed a rare care where a shortened hint might be worse than the original