### PR TITLE
rebalance helm doors, enguarde no dive

### DIFF
--- a/randomizer/Lists/Minigame.py
+++ b/randomizer/Lists/Minigame.py
@@ -240,7 +240,7 @@ MinigameRequirements = {
         group="Arenas",
         map_id=Maps.EnguardeArena,
         can_repeat=True,
-        logic=lambda l: l.swim,
+        logic=lambda l: True,
     ),
     Minigames.BarrelBarrel: Minigame(
         name="Barrel Training",

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -790,9 +790,9 @@ class Settings:
             HelmDoorItem.req_gb: HelmDoorInfo(201),
             HelmDoorItem.req_bp: HelmDoorInfo(
                 40,
-                HelmDoorRandomInfo(10, 30, 0.18),
-                HelmDoorRandomInfo(7, 25, 0.2),
-                HelmDoorRandomInfo(5, 15, 0.2),
+                HelmDoorRandomInfo(20, 30, 0.1),
+                HelmDoorRandomInfo(10, 20, 0.2),
+                HelmDoorRandomInfo(4, 10, 0.25),
             ),
             HelmDoorItem.req_companycoins: HelmDoorInfo(
                 2,
@@ -801,27 +801,27 @@ class Settings:
             HelmDoorItem.req_key: HelmDoorInfo(8),
             HelmDoorItem.req_medal: HelmDoorInfo(
                 40,
-                HelmDoorRandomInfo(10, 20, 0.18),
-                HelmDoorRandomInfo(7, 15, 0.2),
-                HelmDoorRandomInfo(5, 10, 0.2),
+                HelmDoorRandomInfo(20, 30, 0.2),
+                HelmDoorRandomInfo(10, 20, 0.21),
+                HelmDoorRandomInfo(4, 10, 0.25),
             ),
             HelmDoorItem.req_crown: HelmDoorInfo(
                 10,
-                HelmDoorRandomInfo(3, 6, 0.1),
-                HelmDoorRandomInfo(2, 4, 0.1),
-                HelmDoorRandomInfo(1, 3, 0.06),
+                HelmDoorRandomInfo(5, 7, 0.14),
+                HelmDoorRandomInfo(3, 5, 0.14),
+                HelmDoorRandomInfo(1, 3, 0.1),
             ),
             HelmDoorItem.req_fairy: HelmDoorInfo(
                 18,
-                HelmDoorRandomInfo(5, 10, 0.15),
-                HelmDoorRandomInfo(3, 7, 0.14),
-                HelmDoorRandomInfo(1, 5, 0.18),
+                HelmDoorRandomInfo(9, 14, 0.18),
+                HelmDoorRandomInfo(5, 9, 0.18),
+                HelmDoorRandomInfo(2, 5, 0.18),
             ),  # Remove two fairies since you can't get the final two fairies glitchless if on the crown door
             HelmDoorItem.req_rainbowcoin: HelmDoorInfo(
                 16,
-                HelmDoorRandomInfo(6, 10, 0.14),
-                HelmDoorRandomInfo(4, 8, 0.15),
-                HelmDoorRandomInfo(3, 5, 0.18),
+                HelmDoorRandomInfo(8, 12, 0.18),
+                HelmDoorRandomInfo(4, 8, 0.18),
+                HelmDoorRandomInfo(2, 4, 0.18),
             ),
             HelmDoorItem.req_bean: HelmDoorInfo(
                 1,
@@ -830,9 +830,9 @@ class Settings:
             ),
             HelmDoorItem.req_pearl: HelmDoorInfo(
                 5,
-                HelmDoorRandomInfo(3, 4, 0.15),
-                HelmDoorRandomInfo(2, 4, 0.2),
-                HelmDoorRandomInfo(2, 3, 0.18),
+                HelmDoorRandomInfo(2, 4, 0.1),
+                HelmDoorRandomInfo(1, 2, 0.08),
+                HelmDoorRandomInfo(1, 1, 0.04),
             ),
         }
         random_helm_door_settings = (HelmDoorItem.easy_random, HelmDoorItem.medium_random, HelmDoorItem.hard_random)


### PR DESCRIPTION
Rebalanced Helm doors with the following generic criteria:
- Easy doors: 10-25% of an item
- Medium doors: 25-50% of an item
- Hard doors: 50-75% of an item

Also removed diving requirement for Enguarde arena because you don't need it