### PR TITLE
disable fungi cb group 79

### DIFF
--- a/randomizer/Lists/CBLocations/FungiForestCBLocations.py
+++ b/randomizer/Lists/CBLocations/FungiForestCBLocations.py
@@ -881,14 +881,16 @@ ColoredBananaGroupList = [
         ],
     ),
     ColoredBananaGroup(group=78, map_id=Maps.ForestAnthill, name="On outside islands", konglist=[Kongs.tiny], region=Regions.Anthill, locations=[[5, 2.0, 770, 220, 418], [5, 2.0, 425, 220, 408]]),
-    ColoredBananaGroup(
-        group=79,
-        map_id=Maps.ForestBaboonBlast,
-        name="Between some barrels",
-        konglist=[Kongs.donkey],
-        region=Regions.ForestBaboonBlast,
-        locations=[[5, 1.0, 2550, 885, 2186], [5, 1.0, 2636, 762, 1200]],
-    ),
+    # Reason for disabling: Krusha's collision with one of the automatically shooting barrels is off,
+    # making one of those bunches unobtainable as Krusha.
+    # ColoredBananaGroup(
+    #     group=79,
+    #     map_id=Maps.ForestBaboonBlast,
+    #     name="Between some barrels",
+    #     konglist=[Kongs.donkey],
+    #     region=Regions.ForestBaboonBlast,
+    #     locations=[[5, 1.0, 2550, 885, 2186], [5, 1.0, 2636, 762, 1200]],
+    # ),
     ColoredBananaGroup(
         group=80,
         map_id=Maps.ForestWinchRoom,

--- a/randomizer/Lists/CBLocations/JungleJapesCBLocations.py
+++ b/randomizer/Lists/CBLocations/JungleJapesCBLocations.py
@@ -877,7 +877,7 @@ ColoredBananaGroupList = [
         name="Next to Snide",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.JungleJapesMain,
-        locations=[[5, 1.0, 2071, 690, 2565], [5, 1.0, 2260, 690, 2523]],
+        locations=[[5, 1.0, 2054, 690, 2566], [5, 1.0, 2274, 690, 2513]],
     ),
     ColoredBananaGroup(
         group=63,

--- a/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
@@ -895,11 +895,6 @@
 | Name | Amount | Logic |
 | ---- | ------ | ----- |
 | On outside islands | 10 | `` | 
-## Forest Baboon Blast
-| Name | Amount | Logic |
-| ---- | ------ | ----- |
-| Between some barrels | 10 | `` | 
-| In baboon blast course (Donkey) | 10 | `` | 
 ## Forest Winch Room
 | Name | Amount | Logic |
 | ---- | ------ | ----- |
@@ -992,6 +987,10 @@
 | ---- | ------ | ----- |
 | On Chunky switch (Chunky) | 5 | `` | 
 | Chunky's face puzzle room (Chunky) | Balloon | `` | 
+## Forest Baboon Blast
+| Name | Amount | Logic |
+| ---- | ------ | ----- |
+| In baboon blast course (Donkey) | 10 | `` | 
 
 # Crystal Caves
 ## Crystal Caves


### PR DESCRIPTION
- Temporarily removed a potential colored banana location in Fungi Baboon Blast (there's sitll the vanilla location there) due to Krusha's unfortunate bone structure.
- Moved the Japes CB's next to Snide a bit more away from Snide's HQ, so that they don't clip into Funky's Armory as much.