### PR TITLE
Adding a default option to music selection

### DIFF
--- a/templates/music.html.jinja2
+++ b/templates/music.html.jinja2
@@ -181,7 +181,8 @@
                                     <select id="music_select_{{song["value"]}}"
                                             name="music_select_{{song["value"]}}"
                                             class="form-select {{subCategory["type"]}}-select">
-                                        <option value="" class="{{subCategory["type"]}}-default-option">-- Randomize --</option>
+                                        <option value="default_value">-- Default --</option>
+                                        <option value="">-- Randomize --</option>
                                         {% for select_song in select_songs[subCategory["type"]]|music_select_restrict(song["value"]) %}
                                             <option value="{{select_song["value"]}}"
                                                     class="original-song">

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -1266,60 +1266,68 @@ def hide_override_cosmetics(event):
     document.getElementById("override_cosmetics").checked = True
 
 
-@bind("click", "nav-music-tab")
 @bind("change", "music_bgm_randomized")
 def rename_default_bgm_options(evt):
-    """Rename the default options for BGM music selection."""
+    """Change between "Default" and "Randomize" for BGM music."""
     toggleElem = js.document.getElementById(f"music_bgm_randomized")
-    defaultOptions = js.document.getElementsByClassName(f"BGM-default-option")
+    selects = js.document.getElementsByClassName(f"BGM-select")
     if toggleElem.checked:
-        for opt in defaultOptions:
-            opt.innerHTML = "-- Randomize --"
+        for select in selects:
+            if select.value == "default_value":
+                select.value = ""
     else:
-        for opt in defaultOptions:
-            opt.innerHTML = "-- Default --"
+        for select in selects:
+            if select.value == "":
+                select.value = "default_value"
+    js.savemusicsettings()
 
 
-@bind("click", "nav-music-tab")
 @bind("change", "music_majoritems_randomized")
 def rename_default_majoritems_options(evt):
-    """Rename the default options for major item music selection."""
+    """Change between "Default" and "Randomize" for major item music."""
     toggleElem = js.document.getElementById(f"music_majoritems_randomized")
-    defaultOptions = js.document.getElementsByClassName(f"MajorItem-default-option")
+    selects = js.document.getElementsByClassName(f"MajorItem-select")
     if toggleElem.checked:
-        for opt in defaultOptions:
-            opt.innerHTML = "-- Randomize --"
+        for select in selects:
+            if select.value == "default_value":
+                select.value = ""
     else:
-        for opt in defaultOptions:
-            opt.innerHTML = "-- Default --"
+        for select in selects:
+            if select.value == "":
+                select.value = "default_value"
+    js.savemusicsettings()
 
 
-@bind("click", "nav-music-tab")
 @bind("change", "music_minoritems_randomized")
 def rename_default_minoritems_options(evt):
-    """Rename the default options for minor item music selection."""
+    """Change between "Default" and "Randomize" for minor item music."""
     toggleElem = js.document.getElementById(f"music_minoritems_randomized")
-    defaultOptions = js.document.getElementsByClassName(f"MinorItem-default-option")
+    selects = js.document.getElementsByClassName(f"MinorItem-select")
     if toggleElem.checked:
-        for opt in defaultOptions:
-            opt.innerHTML = "-- Randomize --"
+        for select in selects:
+            if select.value == "default_value":
+                select.value = ""
     else:
-        for opt in defaultOptions:
-            opt.innerHTML = "-- Default --"
+        for select in selects:
+            if select.value == "":
+                select.value = "default_value"
+    js.savemusicsettings()
 
 
-@bind("click", "nav-music-tab")
 @bind("change", "music_events_randomized")
 def rename_default_events_options(evt):
-    """Rename the default options for event music selection."""
+    """Change between "Default" and "Randomize" for event music."""
     toggleElem = js.document.getElementById(f"music_events_randomized")
-    defaultOptions = js.document.getElementsByClassName(f"Event-default-option")
+    selects = js.document.getElementsByClassName(f"Event-select")
     if toggleElem.checked:
-        for opt in defaultOptions:
-            opt.innerHTML = "-- Randomize --"
+        for select in selects:
+            if select.value == "default_value":
+                select.value = ""
     else:
-        for opt in defaultOptions:
-            opt.innerHTML = "-- Default --"
+        for select in selects:
+            if select.value == "":
+                select.value = "default_value"
+    js.savemusicsettings()
 
 
 @bind("click", "select_keys")


### PR DESCRIPTION
Each of the music selection dropdowns now has a "Default" option in addition to the "Randomize" option.

- If the checkbox to randomize a certain music category is checked, the default option for those songs will be "Randomize". Otherwise, it will be "Default". This will also apply when resetting song selections, or importing from a file.
- If the user exports their music selections to a file, the "Default" options will only be saved to file if that category of music is being randomized. (Otherwise, if the user randomizes none of the music and exports to file, all of the songs will be explicitly saved as their defaults, which was probably not the user's intention.)