### PR TITLE
Hint Rebalance and other fixes

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -775,7 +775,7 @@ def compileHints(spoiler: Spoiler) -> bool:
             if HintType.RequiredKeyHint in valid_types:
                 valid_types.remove(HintType.RequiredKeyHint)
             # The number of multipath hints is a percentage of all eligible locations while still guaranteeing every goal gets at least one hint
-            hint_distribution[HintType.Multipath] = max(len(multipath_dict_hints.keys()) * .65, min_value)
+            hint_distribution[HintType.Multipath] = max(len(multipath_dict_hints.keys()) * 0.65, min_value)
             # That percentage likely turns out a decimal - that decimal becomes a % chance to get an extra hint
             rng = random.random()
             if hint_distribution[HintType.Multipath] % 1 < rng:

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -558,7 +558,11 @@ def compileHints(spoiler: Spoiler) -> bool:
         valid_types = [HintType.ItemRegion, HintType.Joke]
         # Build the list of valid hint types
         # If K. Rool is live it is guaranteed a hint in this distribution if it is not hinted otherwise via spoiler hints
-        if (spoiler.settings.krool_phase_count < 5 or spoiler.settings.krool_random) and spoiler.settings.win_condition == WinCondition.beat_krool and spoiler.settings.spoiler_hints == SpoilerHints.off:
+        if (
+            (spoiler.settings.krool_phase_count < 5 or spoiler.settings.krool_random)
+            and spoiler.settings.win_condition == WinCondition.beat_krool
+            and spoiler.settings.spoiler_hints == SpoilerHints.off
+        ):
             valid_types.append(HintType.KRoolOrder)
             hint_distribution[HintType.KRoolOrder] = 1
             hint_distribution[HintType.ItemRegion] -= 1
@@ -694,7 +698,11 @@ def compileHints(spoiler: Spoiler) -> bool:
             hint_distribution[HintType.TroffNScoff] = temp
             valid_types.append(HintType.Entrance)
         # If K. Rool is live it can get one hint if it is not hinted otherwise via spoiler hints
-        if (spoiler.settings.krool_phase_count < 5 or spoiler.settings.krool_random) and spoiler.settings.win_condition == WinCondition.beat_krool and spoiler.settings.spoiler_hints == SpoilerHints.off:
+        if (
+            (spoiler.settings.krool_phase_count < 5 or spoiler.settings.krool_random)
+            and spoiler.settings.win_condition == WinCondition.beat_krool
+            and spoiler.settings.spoiler_hints == SpoilerHints.off
+        ):
             valid_types.append(HintType.KRoolOrder)
             maxed_hint_types.append(HintType.KRoolOrder)
             # If the seed doesn't funnel you into helm, guarantee one K. Rool order hint

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -557,8 +557,8 @@ def compileHints(spoiler: Spoiler) -> bool:
             hint_distribution[HintType.ItemRegion] -= plando_hints_placed
         valid_types = [HintType.ItemRegion, HintType.Joke]
         # Build the list of valid hint types
-        # If K. Rool is live it is guaranteed a hint in this distribution
-        if (spoiler.settings.krool_phase_count < 5 or spoiler.settings.krool_random) and spoiler.settings.win_condition == WinCondition.beat_krool:
+        # If K. Rool is live it is guaranteed a hint in this distribution if it is not hinted otherwise via spoiler hints
+        if (spoiler.settings.krool_phase_count < 5 or spoiler.settings.krool_random) and spoiler.settings.win_condition == WinCondition.beat_krool and spoiler.settings.spoiler_hints == SpoilerHints.off:
             valid_types.append(HintType.KRoolOrder)
             hint_distribution[HintType.KRoolOrder] = 1
             hint_distribution[HintType.ItemRegion] -= 1
@@ -693,7 +693,8 @@ def compileHints(spoiler: Spoiler) -> bool:
                 hint_distribution[HintType.BLocker] = max(1, hint_distribution[HintType.TroffNScoff])  # Always want a helm hint in there
             hint_distribution[HintType.TroffNScoff] = temp
             valid_types.append(HintType.Entrance)
-        if (spoiler.settings.krool_phase_count < 5 or spoiler.settings.krool_random) and spoiler.settings.win_condition == WinCondition.beat_krool:
+        # If K. Rool is live it can get one hint if it is not hinted otherwise via spoiler hints
+        if (spoiler.settings.krool_phase_count < 5 or spoiler.settings.krool_random) and spoiler.settings.win_condition == WinCondition.beat_krool and spoiler.settings.spoiler_hints == SpoilerHints.off:
             valid_types.append(HintType.KRoolOrder)
             maxed_hint_types.append(HintType.KRoolOrder)
             # If the seed doesn't funnel you into helm, guarantee one K. Rool order hint

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from math import ceil, floor
 import random
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 from randomizer.Enums.MoveTypes import MoveTypes
@@ -429,8 +430,8 @@ item_hint_distribution = {
     HintType.Plando: 0,
 }
 
-hint_reroll_cap = 1  # How many times are you willing to reroll a hinted location?
-hint_reroll_chance = 1.0  # What % of the time do you reroll in conditions that could trigger a reroll?
+hint_reroll_cap = 2  # How many times are you willing to reroll a hinted location?
+hint_reroll_chance = 1.0  # What % of the time (from 0-1) do you reroll in conditions that could trigger a reroll?
 globally_hinted_location_ids = []
 
 
@@ -467,7 +468,7 @@ def compileHints(spoiler: Spoiler) -> bool:
             key_location_ids[location.item] = location_id
 
     # Some locations are particularly useless to hint
-    useless_locations = {Items.HideoutHelmKey: [], Kongs.diddy: [], Kongs.lanky: [], Kongs.tiny: [], Kongs.chunky: []}
+    useless_locations = {Items.HideoutHelmKey: [], Kongs.donkey: [], Kongs.diddy: [], Kongs.lanky: [], Kongs.tiny: [], Kongs.chunky: []}
     # Your training in Gorilla Gone, Monkeyport, and Vines are always pointless hints if Key 8 is in Helm, so let's not
     if spoiler.settings.key_8_helm and Locations.HelmKey in spoiler.woth_paths.keys():
         useless_moves = [Items.Vines]
@@ -560,11 +561,12 @@ def compileHints(spoiler: Spoiler) -> bool:
             valid_types.append(HintType.KRoolOrder)
             hint_distribution[HintType.KRoolOrder] = 1
             hint_distribution[HintType.ItemRegion] -= 1
+        # Helm order hint has been moved to Snide
         # If Helm is live it is guaranteed a hint in this distribution
-        if spoiler.settings.helm_setting != HelmSetting.skip_all and (spoiler.settings.helm_phase_count < 5 or spoiler.settings.helm_random):
-            valid_types.append(HintType.HelmOrder)
-            hint_distribution[HintType.HelmOrder] = 1
-            hint_distribution[HintType.ItemRegion] -= 1
+        # if spoiler.settings.helm_setting != HelmSetting.skip_all and (spoiler.settings.helm_phase_count < 5 or spoiler.settings.helm_random):
+        #     valid_types.append(HintType.HelmOrder)
+        #     hint_distribution[HintType.HelmOrder] = 1
+        #     hint_distribution[HintType.ItemRegion] -= 1
         # Each random Helm door is also guaranteed a hint
         if spoiler.settings.crown_door_random or spoiler.settings.coin_door_random:
             valid_types.append(HintType.RequiredHelmDoorHint)
@@ -696,9 +698,10 @@ def compileHints(spoiler: Spoiler) -> bool:
             # If the seed doesn't funnel you into helm, guarantee one K. Rool order hint
             if Events.HelmKeyTurnedIn not in spoiler.settings.krool_keys_required or not spoiler.settings.key_8_helm:
                 minned_hint_types.append(HintType.KRoolOrder)
-        if spoiler.settings.helm_setting != HelmSetting.skip_all and (spoiler.settings.helm_phase_count < 5 or spoiler.settings.helm_random):
-            valid_types.append(HintType.HelmOrder)
-            locked_hint_types.append(HintType.HelmOrder)
+        # Helm order hint has been moved to Snide
+        # if spoiler.settings.helm_setting != HelmSetting.skip_all and (spoiler.settings.helm_phase_count < 5 or spoiler.settings.helm_random):
+        #     valid_types.append(HintType.HelmOrder)
+        #     locked_hint_types.append(HintType.HelmOrder)
         if spoiler.settings.move_rando not in (MoveRando.off, MoveRando.item_shuffle) and Types.Shop not in spoiler.settings.shuffled_location_types:
             valid_types.append(HintType.FullShopWithItems)
             valid_types.append(HintType.MoveLocation)
@@ -734,37 +737,8 @@ def compileHints(spoiler: Spoiler) -> bool:
                 # K. Rool seeds could use some help finding the last pesky moves
                 if spoiler.settings.win_condition == WinCondition.beat_krool:
                     valid_types.append(HintType.RequiredWinConditionHint)
-                    path_length = len(spoiler.woth_paths[Locations.BananaHoard]) - 1  # Don't include the Banana Hoard itself in the path length
-                    if Kongs.diddy in spoiler.settings.krool_order:
-                        hint_distribution[HintType.RequiredWinConditionHint] += 1
-                    if Kongs.lanky in spoiler.settings.krool_order:
-                        hint_distribution[HintType.RequiredWinConditionHint] += 1
-                    if Kongs.tiny in spoiler.settings.krool_order:
-                        hint_distribution[HintType.RequiredWinConditionHint] += 1
-                    if Kongs.chunky in spoiler.settings.krool_order:
-                        hint_distribution[HintType.RequiredWinConditionHint] += 2
-                    path_length -= len(useless_locations[Kongs.diddy]) + len(useless_locations[Kongs.lanky]) + len(useless_locations[Kongs.tiny]) + len(useless_locations[Kongs.chunky])
-                    if hint_distribution[HintType.RequiredWinConditionHint] != 0:
-                        # Guarantee you have a decent number of hints, even if you have very few, very buried moves required
-                        if path_length == 0:
-                            hint_distribution[HintType.RequiredWinConditionHint] = 0
-                        elif path_length <= 1:  # 2 (should never be 1 here)
-                            hint_distribution[HintType.RequiredWinConditionHint] = max(hint_distribution[HintType.RequiredWinConditionHint], 1)
-                        elif path_length <= 3:  # 3-4
-                            hint_distribution[HintType.RequiredWinConditionHint] = max(hint_distribution[HintType.RequiredWinConditionHint], 2)
-                        elif path_length <= 6:  # 5-7
-                            hint_distribution[HintType.RequiredWinConditionHint] = max(hint_distribution[HintType.RequiredWinConditionHint], 3)
-                        elif path_length <= 9:  # 8-10
-                            hint_distribution[HintType.RequiredWinConditionHint] = max(hint_distribution[HintType.RequiredWinConditionHint], 4)
-                        else:  # 11+
-                            hint_distribution[HintType.RequiredWinConditionHint] = max(hint_distribution[HintType.RequiredWinConditionHint], 5)
-                    # Old system pointing to specific moves
-                    # if Kongs.diddy in spoiler.settings.krool_order:
-                    #     hint_distribution[HintType.RequiredWinConditionHint] += 1  # Dedicated Rocketbarrel hint
-                    # if Kongs.tiny in spoiler.settings.krool_order:
-                    #     hint_distribution[HintType.RequiredWinConditionHint] += 1  # Dedicated Mini Monkey hint
-                    # if Kongs.chunky in spoiler.settings.krool_order:
-                    #     hint_distribution[HintType.RequiredWinConditionHint] += 1  # Dedicated Hunky Chunky hint
+                    # Count the number of non-trivial phases
+                    hint_distribution[HintType.RequiredWinConditionHint] = len([kong for kong in spoiler.settings.krool_order if len(spoiler.krool_paths[kong]) - len(useless_locations[kong]) > 0])
                 # Some win conditions need help finding the camera (if you don't start with it) - variable amount of unique hints for it
                 if spoiler.settings.win_condition in (WinCondition.all_fairies, WinCondition.poke_snap) and spoiler.settings.shockwave_status != ShockwaveStatus.start_with:
                     camera_location_id = None
@@ -775,18 +749,7 @@ def compileHints(spoiler: Spoiler) -> bool:
                     # Don't make a Camera path hint if Camera isn't woth
                     if camera_location_id in spoiler.woth_paths.keys():
                         valid_types.append(HintType.RequiredWinConditionHint)
-                        # Same rules as key path amounts
-                        path_length = len(spoiler.woth_paths[camera_location_id]) - 1  # Don't include the camera itself in the path length
-                        if path_length < 0:  # 0 (I'm not sure this is possible but I don't want to error)
-                            hint_distribution[HintType.RequiredWinConditionHint] = 0
-                        elif path_length <= 1:  # 1-2
-                            hint_distribution[HintType.RequiredWinConditionHint] = 1
-                        elif path_length <= 5:  # 3-6
-                            hint_distribution[HintType.RequiredWinConditionHint] = 2
-                        elif path_length <= 9:  # 7-10
-                            hint_distribution[HintType.RequiredWinConditionHint] = 3
-                        else:  # 11+
-                            hint_distribution[HintType.RequiredWinConditionHint] = 4
+                        hint_distribution[HintType.RequiredWinConditionHint] = 1
         if spoiler.settings.crown_door_random or spoiler.settings.coin_door_random:
             valid_types.append(HintType.RequiredHelmDoorHint)
             if spoiler.settings.crown_door_random:
@@ -801,42 +764,27 @@ def compileHints(spoiler: Spoiler) -> bool:
             # Dynamically calculate the number of key hints that need to be placed per key. Any WotH keys should have paths that we should hint.
             if spoiler.settings.shuffle_items and len(woth_key_ids) > 0:
                 valid_types.append(HintType.RequiredKeyHint)
-                # Only hint keys that are in the Way of the Hoard
-                for key_id in woth_key_ids:
-                    # Keys you are expected to find early only get one direct hint, treat all keys as early keys because there are no paths
-                    if False and key_id in (Items.JungleJapesKey, Items.AngryAztecKey) and level_order_matters and not spoiler.settings.hard_level_progression:
-                        # This is no longer true with multipath hints - all keys get hints based on path length
-                        key_hint_dict[key_id] = 1
-                    # Late or complex keys get a number of hints based on the length of the path to them
-                    else:
-                        path_length = len(spoiler.woth_paths[key_location_ids[key_id]])
-                        # If key 8 is in Helm, your training in several moves is utterly useless to hint
-                        if key_id == Items.HideoutHelmKey and spoiler.settings.key_8_helm:
-                            path_length -= len(useless_locations[Items.HideoutHelmKey])
-                        if path_length <= 0:  # 0
-                            key_hint_dict[key_id] = 0
-                        elif path_length <= 2:  # 1-2
-                            key_hint_dict[key_id] = 1
-                        elif path_length <= 5:  # 3-5
-                            key_hint_dict[key_id] = 2
-                        elif path_length <= 9:  # 6-9
-                            key_hint_dict[key_id] = 3
-                        elif path_length <= 13:  # 10-13
-                            key_hint_dict[key_id] = 4
-                        else:  # 14+
-                            key_hint_dict[key_id] = 5
-                hint_distribution[HintType.RequiredKeyHint] = sum(key_hint_dict.values())
-            # Convert all path hints into multipath hints, utilizing the prior calculations as a rough estimate of path length/difficulty
-            estimated_path_difficulty = max(0, (hint_distribution[HintType.RequiredKeyHint] * 1) + (hint_distribution[HintType.RequiredWinConditionHint] * 0.8))
+                # Only guarantee hints for keys that are in the Way of the Hoard
+                hint_distribution[HintType.RequiredKeyHint] = len(woth_key_ids)
+            # Convert all path hints into multipath hints
+            min_value = hint_distribution[HintType.RequiredWinConditionHint] + hint_distribution[HintType.RequiredKeyHint]
             hint_distribution[HintType.RequiredWinConditionHint] = 0
             hint_distribution[HintType.RequiredKeyHint] = 0
             if HintType.RequiredWinConditionHint in valid_types:
                 valid_types.remove(HintType.RequiredWinConditionHint)
             if HintType.RequiredKeyHint in valid_types:
                 valid_types.remove(HintType.RequiredKeyHint)
-            # Multipath hints are generally more powerful than your average hint, so we need fewer of them (but not more hints than are possible!)
-            hint_distribution[HintType.Multipath] = min(len(multipath_dict_hints.keys()), round(estimated_path_difficulty))
+            # The number of multipath hints is a percentage of all eligible locations while still guaranteeing every goal gets at least one hint
+            hint_distribution[HintType.Multipath] = max(len(multipath_dict_hints.keys()) * .65, min_value)
+            # That percentage likely turns out a decimal - that decimal becomes a % chance to get an extra hint
+            rng = random.random()
+            if hint_distribution[HintType.Multipath] % 1 < rng:
+                hint_distribution[HintType.Multipath] = ceil(hint_distribution[HintType.Multipath])
+            else:
+                hint_distribution[HintType.Multipath] = floor(hint_distribution[HintType.Multipath])
+            # If we somehow have more multipath hints than there are locations, cap it (this should be impossible now?)
             if hint_distribution[HintType.Multipath] >= len(multipath_dict_hints.keys()):
+                hint_distribution[HintType.Multipath] = len(multipath_dict_hints.keys())
                 maxed_hint_types.append(HintType.Multipath)
             valid_types.append(HintType.Multipath)
 
@@ -2005,10 +1953,7 @@ def compileHints(spoiler: Spoiler) -> bool:
             else:
                 bean_region = GetRegionOfLocation(spoiler, bean_location_id)
                 hinted_location_text = bean_region.hint_name
-                be_verb = "is"
-                if hinted_location_text[-1] == "s":
-                    be_verb = "are"
-                message = f"The {hinted_location_text} {be_verb} on the Way of the Bean."
+                message = f"The Way of the Bean concludes in the {hinted_location_text}."
                 hint_location.related_location = bean_location_id
         hint_location.hint_type = HintType.Joke
         UpdateHint(hint_location, message)

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -509,6 +509,7 @@ def compileHints(spoiler: Spoiler) -> bool:
         HintType.RequiredHelmDoorHint,
         HintType.Multipath,
         HintType.ItemRegion,
+        HintType.Plando,
     ]  # Some hint types cannot have their value changed
     maxed_hint_types = []  # Some hint types cannot have additional hints placed
     minned_hint_types = []  # Some hint types cannot have all their hints removed
@@ -817,11 +818,11 @@ def compileHints(spoiler: Spoiler) -> bool:
             locked_hint_count = sum([hint_distribution[typ] for typ in locked_hint_types]) + sum([hint_distribution[typ] for typ in minned_hint_types])
             # If this is the case (again, INSANELY rare) then you lose a random key hint
             if locked_hint_count > HINT_CAP:
-                key_to_lose_a_hint = random.choice([key for key in key_hint_dict.keys() if key_hint_dict[key] > 0])
-                key_hint_dict[key_to_lose_a_hint] -= 1
                 if HintType.Multipath in valid_types:
                     hint_distribution[HintType.Multipath] -= 1
                 else:
+                    key_to_lose_a_hint = random.choice([key for key in key_hint_dict.keys() if key_hint_dict[key] > 0])
+                    key_hint_dict[key_to_lose_a_hint] -= 1
                     hint_distribution[HintType.RequiredKeyHint] -= 1
                 hint_count -= 1
                 continue

--- a/randomizer/Enums/Types.py
+++ b/randomizer/Enums/Types.py
@@ -37,7 +37,7 @@ class Types(IntEnum):
 # If you make change to this selector, make sure to change the corresponding
 # ItemRandoListSelected enum in randomizer.Enums.Settings.
 ItemRandoSelector = [
-    {"name": "Shops", "value": "shop", "tooltip": "Cranky, Funky, and Candy Moves are in the Pool and become possible locations for items.&#10;By selecting this, Cross-Kong purchases is forced on."},
+    {"name": "Shops & Moves", "value": "shop", "tooltip": "Cranky, Funky, and Candy Moves are in the Pool and become possible locations for items.&#10;By selecting this, Cross-Kong purchases is forced on."},
     {"name": "Golden Bananas", "value": "banana", "tooltip": ""},
     {
         "name": "Tough Golden Bananas",

--- a/randomizer/Enums/Types.py
+++ b/randomizer/Enums/Types.py
@@ -37,7 +37,11 @@ class Types(IntEnum):
 # If you make change to this selector, make sure to change the corresponding
 # ItemRandoListSelected enum in randomizer.Enums.Settings.
 ItemRandoSelector = [
-    {"name": "Shops & Moves", "value": "shop", "tooltip": "Cranky, Funky, and Candy Moves are in the Pool and become possible locations for items.&#10;By selecting this, Cross-Kong purchases is forced on."},
+    {
+        "name": "Shops & Moves",
+        "value": "shop",
+        "tooltip": "Cranky, Funky, and Candy Moves are in the Pool and become possible locations for items.&#10;By selecting this, Cross-Kong purchases is forced on.",
+    },
     {"name": "Golden Bananas", "value": "banana", "tooltip": ""},
     {
         "name": "Tough Golden Bananas",

--- a/randomizer/Lists/EnemyTypes.py
+++ b/randomizer/Lists/EnemyTypes.py
@@ -812,12 +812,12 @@ enemy_location_list = {
     Locations.Caves1DCEnemy_Near: EnemyLoc(Maps.CavesLankyCabin, Enemies.Kosha, 2, [], True),
     Locations.Caves1DCEnemy_Far: EnemyLoc(Maps.CavesLankyCabin, Enemies.Kosha, 1, [], True),
     # DK 5DC
-    Locations.Caves5DCDKEnemy_Gauntlet0: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 1, enemies_nokill_gun, True),
-    Locations.Caves5DCDKEnemy_Gauntlet1: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 2, enemies_nokill_gun, True),
-    Locations.Caves5DCDKEnemy_Gauntlet2: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 3, enemies_nokill_gun, True),
-    Locations.Caves5DCDKEnemy_Gauntlet3: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 4, enemies_nokill_gun, True),
-    Locations.Caves5DCDKEnemy_Gauntlet4: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 5, enemies_nokill_gun, True),
-    Locations.Caves5DCDKEnemy_Gauntlet5: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 6, enemies_nokill_gun, True),
+    Locations.Caves5DCDKEnemy_Gauntlet0: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 1, enemies_nokill_gun + [Enemies.Bat], True),
+    Locations.Caves5DCDKEnemy_Gauntlet1: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 2, enemies_nokill_gun + [Enemies.Bat], True),
+    Locations.Caves5DCDKEnemy_Gauntlet2: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 3, enemies_nokill_gun + [Enemies.Bat], True),
+    Locations.Caves5DCDKEnemy_Gauntlet3: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 4, enemies_nokill_gun + [Enemies.Bat], True),
+    Locations.Caves5DCDKEnemy_Gauntlet4: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 5, enemies_nokill_gun + [Enemies.Bat], True),
+    Locations.Caves5DCDKEnemy_Gauntlet5: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 6, enemies_nokill_gun + [Enemies.Bat], True),
     # Diddy Enemies 5DC
     Locations.Caves5DCDiddyLowEnemy_CloseRight: EnemyLoc(Maps.CavesDiddyLowerCabin, Enemies.Klump, 1, enemy_5dc_ban, True, False),
     Locations.Caves5DCDiddyLowEnemy_FarRight: EnemyLoc(Maps.CavesDiddyLowerCabin, Enemies.Kremling, 2, enemy_5dc_ban, True, False),

--- a/randomizer/Lists/Location.py
+++ b/randomizer/Lists/Location.py
@@ -811,7 +811,7 @@ LocationListOriginal = {
     Locations.AztecDK5DTEnemy_EndTrap2: Location(Levels.AngryAztec, "Aztec Donkey5DTemple Enemy: End Trap (2)", Items.EnemyItem, Types.Enemies, Kongs.any, [MapIDCombo(Maps.AztecDonkey5DTemple, -1, 0x409)]),
     Locations.AztecDK5DTEnemy_EndPath0: Location(Levels.AngryAztec, "Aztec Donkey5DTemple Enemy: End Path (0)", Items.EnemyItem, Types.Enemies, Kongs.any, [MapIDCombo(Maps.AztecDonkey5DTemple, -1, 0x40a)]),
     Locations.AztecDK5DTEnemy_EndPath1: Location(Levels.AngryAztec, "Aztec Donkey5DTemple Enemy: End Path (1)", Items.EnemyItem, Types.Enemies, Kongs.any, [MapIDCombo(Maps.AztecDonkey5DTemple, -1, 0x40b)]),
-    Locations.AztecDK5DTEnemy_StartPath: Location(Levels.AngryAztec, "Aztec Donkey5DTemple Enemy: Start Pat (h)", Items.EnemyItem, Types.Enemies, Kongs.any, [MapIDCombo(Maps.AztecDonkey5DTemple, -1, 0x40c)]),
+    Locations.AztecDK5DTEnemy_StartPath: Location(Levels.AngryAztec, "Aztec Donkey5DTemple Enemy: Start Path", Items.EnemyItem, Types.Enemies, Kongs.any, [MapIDCombo(Maps.AztecDonkey5DTemple, -1, 0x40c)]),
     Locations.AztecDiddy5DTEnemy_EndTrap0: Location(Levels.AngryAztec, "Aztec Diddy5DTemple Enemy: End Trap (0)", Items.EnemyItem, Types.Enemies, Kongs.any, [MapIDCombo(Maps.AztecDiddy5DTemple, -1, 0x40d)]),
     Locations.AztecDiddy5DTEnemy_EndTrap1: Location(Levels.AngryAztec, "Aztec Diddy5DTemple Enemy: End Trap (1)", Items.EnemyItem, Types.Enemies, Kongs.any, [MapIDCombo(Maps.AztecDiddy5DTemple, -1, 0x40e)]),
     Locations.AztecDiddy5DTEnemy_EndTrap2: Location(Levels.AngryAztec, "Aztec Diddy5DTemple Enemy: End Trap (2)", Items.EnemyItem, Types.Enemies, Kongs.any, [MapIDCombo(Maps.AztecDiddy5DTemple, -1, 0x40f)]),

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -36,6 +36,7 @@ from randomizer.Lists.Logic import GlitchLogicItems
 from randomizer.Enums.Maps import Maps
 from randomizer.Lists.MapsAndExits import GetExitId, GetMapId
 from randomizer.Lists.Minigame import BarrelMetaData, HelmMinigameLocations, MinigameRequirements
+from randomizer.Lists.Multiselectors import FasterCheckSelector, RemovedBarrierSelector
 from randomizer.Logic import CollectibleRegionsOriginal, LogicVarHolder, RegionsOriginal
 from randomizer.Prices import ProgressiveMoves
 from randomizer.Settings import Settings
@@ -267,8 +268,14 @@ class Spoiler:
         settings["Quality of Life"] = self.settings.quality_of_life
         settings["Tag Anywhere"] = self.settings.enable_tag_anywhere
         settings["Kongless Hint Doors"] = self.settings.wrinkly_available
-        settings["Fast GBs"] = self.settings.faster_checks_enabled
-        settings["Barriers Removed"] = self.settings.remove_barriers_enabled
+        if self.settings.faster_checks_enabled and any(self.settings.faster_checks_selected):
+            settings["Fast GBs"] = [FasterCheckSelector[barrier_enum - 1]["name"] for barrier_enum in self.settings.faster_checks_selected]
+        else:
+            settings["Fast GBs"] = self.settings.faster_checks_enabled
+        if self.settings.remove_barriers_enabled and any(self.settings.remove_barriers_selected):
+            settings["Barriers Removed"] = [RemovedBarrierSelector[barrier_enum - 1]["name"] for barrier_enum in self.settings.remove_barriers_selected]
+        else:
+            settings["Barriers Removed"] = self.settings.remove_barriers_enabled
         settings["Win Condition"] = self.settings.win_condition.name
         settings["Fungi Time of Day"] = self.settings.fungi_time.name
         settings["Galleon Water Level"] = self.settings.galleon_water.name

--- a/static/presets/preset_files.json
+++ b/static/presets/preset_files.json
@@ -41,7 +41,7 @@
   {
     "name": "Hell Mode",
     "description": "Pain (May have a hard time generating)",
-    "settings_string": "bM7VlCAMMSwVfwNywcYytEh6H1QGEMpkJH4jR67S5fELNbbHTtijTAjQVIDorTV8BU9fmSACJoobRavWJXh41J5ZGcX2SywUAdACDADqAgcAdgGEADuBAkAeAKFADyBgsAegOGAChDZZ7yCk8o0GeiVS6pMJFwM/RUhYBEyFAFetccjdqvsigcxIigFNnkSRYAExgAExoADxwADx4ACyAACyIAByQAByYABygABqcuUOS4VTg4tKMQC03FsVGAmDAjGgiqY4n9NJ5FJkRkIAHQB8AKUAhgBVAJcA"
+    "settings_string": "bM7VlCAMMSwVfwNywcYytEh6H1QGEMpkJH4jR67S5fELNbbHTtijTAjQVIDorTV8BU9fmSACJoobRaxK8PGpPLIzi+yWWCgDoAQYAdQEDgDsAwgAdwIEgDwBQoAeQMFgD0BwwAUIbLPeQUnlGgz0SqXVJhIuBn6KkLAImQoAr1rjkbtV9kUDmJEUAps8iSLAAmMAAmNAAeOAAePAAWQAAWRAAOSAAOTAAOUAANTlyhyXCqcHFpRiAWm4rlsVGAmDAjGgiqY4n9NJ5FJkRkIAHQB8AKUAhgBvAFUAlwA"
   },
   {
     "name": "Vanilla Game But Better",

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -229,8 +229,8 @@ class TestSpoiler(unittest.TestCase):
             values += (str(value) + ", ")
         print(types)
         print(values)
-    
+
     def printDesiredOutput(self, spoiler: Spoiler):
         """Print any desired output from the spoiler. Customize to your heart's desire."""
-        print("# of path hints: " + str(spoiler.hint_distribution[HintType.Multipath]) +  " | woth length: " + str(len(spoiler.woth_locations) - 2))
+        print("# of path hints: " + str(spoiler.hint_distribution[HintType.Multipath]) + " | woth length: " + str(len(spoiler.woth_locations) - 2))
         print()

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -7,6 +7,7 @@ import unittest
 from parameterized import parameterized_class
 
 # from randomizer.Enums.Items import Items
+from randomizer.Enums.HintType import HintType
 import randomizer.Lists.Exceptions as Ex
 from randomizer.Enums.Settings import (ActivateAllBananaports, BananaportRando,
                                        CrownEnemyRando, DamageAmount,
@@ -33,7 +34,7 @@ with open("static/presets/preset_files.json", "r") as file:
 # Add a custom preset for testing
 # If we're not running on github actions, add the custom preset
 if not os.environ.get("GITHUB_ACTIONS"):
-    valid_presets.append(("Custom", "VjCAIgnDEGkBCgKQHRWmr5P34EgAiaKE0SMguAoC6DwGBXU8A4e7MgIHnd9BJk8SwKQXmvBag9ZAMZFCGnj2yFI9Rls9Eql1SYRbgZ+ioCwIJgKAS9HLVfZFA5iRDACbPIkiwAJjAAJjQAHjgAHjwAFkAAFkQADkgADkwADlAADUxckuFNidMISQRfQJyQYYSoeB4fCJHLpLF4QMxtMYOLSjAQgFpuK5YFaHLYaE4sFRkMpgJgwIxoJCmOJrDZ/TSeRSZEZDUoAqgEuRBASFBYYG0pEWCYoKkhaLjAySlw2ODpMXj5AQk5QUlRgYmQ"))
+    valid_presets.append(("Custom", "bKEFiRorPN5ysoQNEB6OkWMAhuIMtYhBevn8A2ePhhNHO7qV7KzM4ps6ti+FOB9UDQiGRCVLY1z4D8Ro9dpcviFOWJtOCFAUekB0Vpq+ApBbqevwJIBk0UJokZBdZLLBQF0AIMBOoCBwN2AYQCO4ECQV4AoUDPIGCwd6A4YEKENPHtkKR6ioZypTLmkq0W8DODo9RaRcFP0VEWARMRQBXrXHI3ar/fZFA5ixFAObPIkiwAJjAAJjQAHjgAHjwAFkAAFkQADkgADkwADlAADU5coclwqdMISQRfQJyQYYSqnMxtMYOLQtK5YFaHLYaE4sFRgJgwIymOKaTyKTIjUoAqgEuAhk4AA"))
 
 
 @parameterized_class(('name', 'settings_string'), valid_presets)
@@ -199,6 +200,7 @@ class TestSpoiler(unittest.TestCase):
     def test_settings_string(self):
         """Confirm that settings strings decryption is working and generate a spoiler log with it."""
         # The settings string is defined from the preset_files.json file
+        # self.settings_string = "bKEHCRorPE1ed6soQOCokPR0ixgENxBlrEIL18/gGzx8MJo53dSvZWZnFNnVsXwpwPqgeEQyGQlS2Nc+ER+I0eu0uXxC205Yk04IUDR6QJE0Z4q+ApBbqev2JIBk0UJooZBdZLLBQF0AIMBOoCBwN2AYQCO4ECQV4AoUDPIGCwd6A4YEKENPHtkKRCioZyJTLmku0W8BOEWkXBT9FRFgETEUAV61xyN2q/32RQOYsRQBms2URJFgATGAATGgAPHAAPHgALIAALIgAHJAAHJgAHKAAGpy5Q5LhU6YQkX0CckGGEqpzMYwcWhaVywK0OWw0JxYKjATBgRlMcU8ikyI1KAKoBLgIZOEIQEhQWG0pEVh4gIkZYJigqSFouMDJKXDY4OkxePkBCTlA"
         settings_dict = decrypt_settings_string_enum(self.settings_string)
         settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
 
@@ -213,6 +215,7 @@ class TestSpoiler(unittest.TestCase):
         print(spoiler)
         print(spoiler.json)
         # self.printHintDistribution(spoiler)
+        self.printDesiredOutput(spoiler)
         with open(f"test-result-{self.name}.json", "w") as outfile:
             outfile.write(spoiler.json)
         print(f"test {self.name} done")
@@ -226,3 +229,8 @@ class TestSpoiler(unittest.TestCase):
             values += (str(value) + ", ")
         print(types)
         print(values)
+    
+    def printDesiredOutput(self, spoiler: Spoiler):
+        """Print any desired output from the spoiler. Customize to your heart's desire."""
+        print("# of path hints: " + str(spoiler.hint_distribution[HintType.Multipath]) +  " | woth length: " + str(len(spoiler.woth_locations) - 2))
+        print()


### PR DESCRIPTION
Hint Changes:
- The number of path hints you get is no longer based on the length of paths. That number is now 65% (randomly rounded) of the total number of multipath-eligible locations. This is intended to be a slight buff to the average seed and a more noticeable buff to the worst seeds.
- Buffed the duplication prevention mechanism
- Removed Wrinkly Helm Order hints, as it is now always available at Snide's
- Removed Wrinkly K. Rool Order hints if you have spoiler hints enabled because it's redundant
- Fixed an issue where overhinted seeds might error out
- Fixed an issue where you might try to receive more multipath hints than there are multipath-eligible locations
- Altered the phrasing on a certain special joke hint to not be misleading with the context of the cumulative hint changes over the last few months. As a reminder, your hints will never lie to you.

Other Fixes:
- Fixed a typo on an enemy's name in DK's 5 Door Temple
- Split up Removed Barriers and Faster Checks in the spoiler log to show which specific options were selected. If you have none selected but have the option enabled, it will just say True.
- Banned bats from spawning in DK's 5 Door Cabin
- Removed No Heals from Hell preset to make it slightly less impossible with lava water