### PR TITLE
Last Call for S3 Fixes

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -799,6 +799,9 @@ def compileHints(spoiler: Spoiler) -> bool:
                 hint_distribution[HintType.Multipath] = len(multipath_dict_hints.keys())
                 maxed_hint_types.append(HintType.Multipath)
             valid_types.append(HintType.Multipath)
+            # Multipath hints are designed to passively hint your K. Rool order - you don't need it hinted directly in full
+            if HintType.KRoolOrder in valid_types:
+                valid_types.remove(HintType.KRoolOrder)
         # If somehow you threaded the needle with no valid hint types, you'll get joke hints whether you like it or not
         if len(valid_types) == 0:
             valid_types = [HintType.Joke]
@@ -1180,6 +1183,11 @@ def compileHints(spoiler: Spoiler) -> bool:
                         # Otherwise pick a random location on this path - this guarantees the camera has at least one hint in its direction
                         location_to_hint = random.choice(location_options)
                         hinted_path_locations.append(location_to_hint)
+        # If we attempt to hint more locations than the distribution allows for, we'll error
+        # This should only happen if we're plandoing a ton of hints
+        if len(hinted_path_locations) > hint_distribution[HintType.Multipath]:
+            # We have to randomly choose from what we want to hint - if this culls some endpoints out of being hinted, so be it
+            hinted_path_locations = random.sample(hinted_path_locations, hint_distribution[HintType.Multipath])
         # pick randomly from remaining locations in the keys to the multipath dict
         while len(hinted_path_locations) < hint_distribution[HintType.Multipath]:
             location_to_hint = random.choice([loc for loc in multipath_dict_hints.keys() if loc not in hinted_path_locations])
@@ -1633,7 +1641,8 @@ def compileHints(spoiler: Spoiler) -> bool:
                 )
                 if region.level == Levels.Shops and region.hint_name != "Jetpac Game":  # Jetpac isn't a "real" shop, it's in the Shops level for convenience
                     shops_in_region += 1
-            if "Medal Rewards" in foolish_name:  # "Medal Rewards" regions are cb foolish hints, which are just generally more valuable to hint foolish
+            # "Medal Rewards" regions are cb foolish hints, which are just generally more valuable to hint foolish (so long as medals are relevant)
+            if "Medal Rewards" in foolish_name and Types.Medal in spoiler.settings.shuffled_location_types:
                 foolish_location_score += 3
             elif shops_in_region > 0:  # Shops are generally overvalued (4/6 locations per shop) with this method due to having mutually exclusive locations
                 foolish_location_score -= 1 * shops_in_region  # With smaller shops, this reduces the location count to 3 locations per shop

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -230,7 +230,7 @@ class Settings:
             self.troff_6 = round(min(cbs[6] * self.troff_weight_6, 500))
         if self.randomize_blocker_required_amounts:
             if self.blocker_max > 0:
-                randomlist = random.sample(range(1, self.blocker_max), 7)
+                randomlist = random.choices(range(1, self.blocker_max), k=7)
                 b_lockers = randomlist
                 if self.shuffle_loading_zones == ShuffleLoadingZones.all or self.hard_level_progression:
                     b_lockers.append(random.randint(1, self.blocker_max))
@@ -1436,11 +1436,11 @@ class Settings:
                     allKongMoveLocations.update(TrainingBarrelLocations.copy())
                 if self.shockwave_status in (ShockwaveStatus.vanilla, ShockwaveStatus.start_with) and Types.Shockwave not in self.shuffled_location_types:
                     allKongMoveLocations.remove(Locations.CameraAndShockwave)
-                self.valid_locations[Types.Shop][Kongs.donkey] = allKongMoveLocations
-                self.valid_locations[Types.Shop][Kongs.diddy] = allKongMoveLocations
-                self.valid_locations[Types.Shop][Kongs.lanky] = allKongMoveLocations
-                self.valid_locations[Types.Shop][Kongs.tiny] = allKongMoveLocations
-                self.valid_locations[Types.Shop][Kongs.chunky] = allKongMoveLocations
+                self.valid_locations[Types.Shop][Kongs.donkey] = allKongMoveLocations.copy()
+                self.valid_locations[Types.Shop][Kongs.diddy] = allKongMoveLocations.copy()
+                self.valid_locations[Types.Shop][Kongs.lanky] = allKongMoveLocations.copy()
+                self.valid_locations[Types.Shop][Kongs.tiny] = allKongMoveLocations.copy()
+                self.valid_locations[Types.Shop][Kongs.chunky] = allKongMoveLocations.copy()
             self.valid_locations[Types.Shop][Kongs.any] = SharedShopLocations.copy()
             if self.shockwave_status not in (ShockwaveStatus.vanilla, ShockwaveStatus.start_with) and Types.Shockwave not in self.shuffled_location_types:
                 self.valid_locations[Types.Shop][Kongs.any].add(Locations.CameraAndShockwave)
@@ -1475,17 +1475,17 @@ class Settings:
                 # Shockwave and Training Barrels can only be shuffled if shops are shuffled and their valid locations are non-Kong-specific shops
                 if Types.Shockwave in self.shuffled_location_types:
                     locations_excluding_kong_shops.append(Locations.CameraAndShockwave)
-                    self.valid_locations[Types.Shockwave] = locations_excluding_kong_shops
+                    self.valid_locations[Types.Shockwave] = locations_excluding_kong_shops.copy()
                 if Types.TrainingBarrel in self.shuffled_location_types:
-                    self.valid_locations[Types.TrainingBarrel] = locations_excluding_kong_shops
-                self.valid_locations[Types.Shop][Kongs.any] = locations_excluding_kong_shops
+                    self.valid_locations[Types.TrainingBarrel] = locations_excluding_kong_shops.copy()
+                self.valid_locations[Types.Shop][Kongs.any] = locations_excluding_kong_shops.copy()
                 # Kong-specific moves can go in any non-shared shop location
                 locations_excluding_shared_shops = [location for location in shuffledLocations if location not in SharedShopLocations]
-                self.valid_locations[Types.Shop][Kongs.donkey] = locations_excluding_shared_shops
-                self.valid_locations[Types.Shop][Kongs.diddy] = locations_excluding_shared_shops
-                self.valid_locations[Types.Shop][Kongs.lanky] = locations_excluding_shared_shops
-                self.valid_locations[Types.Shop][Kongs.tiny] = locations_excluding_shared_shops
-                self.valid_locations[Types.Shop][Kongs.chunky] = locations_excluding_shared_shops
+                self.valid_locations[Types.Shop][Kongs.donkey] = locations_excluding_shared_shops.copy()
+                self.valid_locations[Types.Shop][Kongs.diddy] = locations_excluding_shared_shops.copy()
+                self.valid_locations[Types.Shop][Kongs.lanky] = locations_excluding_shared_shops.copy()
+                self.valid_locations[Types.Shop][Kongs.tiny] = locations_excluding_shared_shops.copy()
+                self.valid_locations[Types.Shop][Kongs.chunky] = locations_excluding_shared_shops.copy()
             if Types.Blueprint in self.shuffled_location_types:
                 # Blueprints are banned from Key, Crown, Fairy and Rainbow Coin Locations
                 blueprintValidTypes = [typ for typ in self.shuffled_location_types if typ not in (Types.Crown, Types.Key, Types.Fairy, Types.RainbowCoin)]
@@ -1519,17 +1519,17 @@ class Settings:
                 )
                 self.valid_locations[Types.Crown] = [location for location in shuffledNonMoveLocations if location not in banned_crown_locations]
             if Types.Key in self.shuffled_location_types:
-                self.valid_locations[Types.Key] = shuffledNonMoveLocations
+                self.valid_locations[Types.Key] = shuffledNonMoveLocations.copy()
             if Types.Medal in self.shuffled_location_types:
-                self.valid_locations[Types.Medal] = fairyBannedLocations
+                self.valid_locations[Types.Medal] = fairyBannedLocations.copy()
             if Types.Coin in self.shuffled_location_types:
-                self.valid_locations[Types.Coin] = fairyBannedLocations
+                self.valid_locations[Types.Coin] = fairyBannedLocations.copy()
             if Types.Pearl in self.shuffled_location_types:
-                self.valid_locations[Types.Pearl] = fairyBannedLocations
+                self.valid_locations[Types.Pearl] = fairyBannedLocations.copy()
             if Types.Bean in self.shuffled_location_types:
-                self.valid_locations[Types.Bean] = fairyBannedLocations
+                self.valid_locations[Types.Bean] = fairyBannedLocations.copy()
             if Types.Fairy in self.shuffled_location_types:
-                self.valid_locations[Types.Fairy] = shuffledNonMoveLocations
+                self.valid_locations[Types.Fairy] = shuffledNonMoveLocations.copy()
             if Types.RainbowCoin in self.shuffled_location_types:
                 self.valid_locations[Types.RainbowCoin] = [
                     x for x in fairyBannedLocations if spoiler.LocationList[x].type not in (Types.Shop, Types.TrainingBarrel, Types.Shockwave, Types.PreGivenMove)

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -200,7 +200,7 @@ class TestSpoiler(unittest.TestCase):
     def test_settings_string(self):
         """Confirm that settings strings decryption is working and generate a spoiler log with it."""
         # The settings string is defined from the preset_files.json file
-        self.settings_string = "bKEGiRqzxNXnerKEDRAejpFjAIbiDLWIQXr5/ANnj4YTRzu6leyszOKbOrYvhTgfVA8IhkMhKlsa58Ij8Ro9dpcviFOWJtOCFA0ekCRNGeKvgKQW6nr8CSAZNFDKKGQXWSywUBdACDATqAgcDdgGEAjuBAkFeAKFAzyBgsHegOGBChDTx7ZCkQoqGciUy5JLNFvAjg6RaRcFP0VEWARMRQBXrXHI3ar/fZFA5ixFAGazZlUYkiwAJjAAJjQAHjgAHjwAFkAAFkQADkgADkwADlAADU5coclwqdMISQRfQJyQYYSqnMxtMYOLQtK5YFaHLYaE4sFRgJgwIymOKeRSZEalAFUAlwEMnCEICQoLDaUiKw8QESMsExQVJC0XGBklLhscHSYvHyAhJyg"
+        # self.settings_string = "bKEGiRqzxNXnerKEDRAejpFjAIbiDLWIQXr5/ANnj4YTRzu6leyszOKbOrYvhTgfVA8IhkMhKlsa58Ij8Ro9dpcviFOWJtOCFA0ekCRNGeKvgKQW6nr8CSAZNFDKKGQXWSywUBdACDATqAgcDdgGEAjuBAkFeAKFAzyBgsHegOGBChDTx7ZCkQoqGciUy5JLNFvAjg6RaRcFP0VEWARMRQBXrXHI3ar/fZFA5ixFAGazZlUYkiwAJjAAJjQAHjgAHjwAFkAAFkQADkgADkwADlAADU5coclwqdMISQRfQJyQYYSqnMxtMYOLQtK5YFaHLYaE4sFRgJgwIymOKeRSZEalAFUAlwEMnCEICQoLDaUiKw8QESMsExQVJC0XGBklLhscHSYvHyAhJyg"
         settings_dict = decrypt_settings_string_enum(self.settings_string)
         settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
 

--- a/ui/generate_buttons.py
+++ b/ui/generate_buttons.py
@@ -36,6 +36,7 @@ def import_settings_string(event):
     Args:
         event (event): Javascript Event object.
     """
+    js.settings_string.value = js.settings_string.value.strip()
     settings_string = js.settings_string.value
     settings = decrypt_settings_string_enum(settings_string)
     # Clear all select boxes on the page so as long as its not in the nav-cosmetics div

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -63,8 +63,8 @@ def max_randomized_blocker(event):
     blocker_text = js.document.getElementById("blocker_text")
     if not blocker_text.value:
         blocker_text.value = 50
-    elif 0 <= int(blocker_text.value) < 8:
-        blocker_text.value = 8
+    elif int(blocker_text.value) < 0:
+        blocker_text.value = 0
     elif int(blocker_text.value) > 200:
         blocker_text.value = 200
 


### PR DESCRIPTION
Last few fixes in this PR, I expect this to go to master and then we move to 4.0
- Prevent foolish hints for medal regions when medals aren't in the pool
- Remove K. Rool Order hints when multipath hints will appear, as these hints will indirectly hint K. Rool phases already
- Fix a corner case where it would try to hint more multipath hints than the distribution would expect
- Settings strings are now trimmed on import in case you copy a leading or trailing space
- Fix max random B. Lockers being floored at 8