### PR TITLE
Add "Keep vanilla song placements" option

### DIFF
--- a/randomizer/Patching/MusicRando.py
+++ b/randomizer/Patching/MusicRando.py
@@ -539,14 +539,13 @@ def randomize_music(settings: Settings):
                     else:
                         song_list[song.channel - 1].append(js.pointer_addresses[0]["entries"][song.mem_idx])
             for channel_index in range(12):
-                shuffled_music = song_list[channel_index].copy()
+                # Remove assigned locations.
+                open_locations = [x for x in song_list[channel_index] if x not in assigned_locations[channel_index]]
                 # If we're keeping vanilla songs in vanilla locations, do not
                 # shuffle this list.
                 if settings.music_bgm_randomized and not settings.music_vanilla_locations:
+                    shuffled_music = song_list[channel_index].copy()
                     random.shuffle(shuffled_music)
-                # Remove assigned locations.
-                open_locations = [x for x in song_list[channel_index] if x not in assigned_locations[channel_index]]
-                if settings.music_bgm_randomized:
                     # Move assigned songs to the back of the list, and shorten
                     # to match open_locations.
                     pre_assigned_songs = [x for x in shuffled_music if x in assigned_songs[channel_index]]
@@ -627,15 +626,14 @@ def randomize_music(settings: Settings):
                         shuffled_group_items.append(js.pointer_addresses[0]["entries"][song.mem_idx])
                     else:
                         group_items.append(js.pointer_addresses[0]["entries"][song.mem_idx])
-            # Shuffle the group list
-            shuffled_music = group_items.copy()
+            # Remove assigned locations.
+            open_locations = [x for x in group_items if x not in assigned_item_locations]
             # If we're keeping vanilla songs in vanilla locations, do not
             # shuffle this list.
             if type_data.setting and not settings.music_vanilla_locations:
+                # Shuffle the group list
+                shuffled_music = group_items.copy()
                 random.shuffle(shuffled_music)
-            # Remove assigned locations.
-            open_locations = [x for x in group_items if x not in assigned_item_locations]
-            if type_data.setting:
                 # Move assigned songs to the back of the list, and shorten
                 # to match open_locations.
                 pre_assigned_songs = [x for x in shuffled_music if x in assigned_items]

--- a/randomizer/Patching/MusicRando.py
+++ b/randomizer/Patching/MusicRando.py
@@ -540,7 +540,9 @@ def randomize_music(settings: Settings):
                         song_list[song.channel - 1].append(js.pointer_addresses[0]["entries"][song.mem_idx])
             for channel_index in range(12):
                 shuffled_music = song_list[channel_index].copy()
-                if settings.music_bgm_randomized:
+                # If we're keeping vanilla songs in vanilla locations, do not
+                # shuffle this list.
+                if settings.music_bgm_randomized and not settings.music_vanilla_locations:
                     random.shuffle(shuffled_music)
                 # Remove assigned locations.
                 open_locations = [x for x in song_list[channel_index] if x not in assigned_locations[channel_index]]
@@ -627,7 +629,9 @@ def randomize_music(settings: Settings):
                         group_items.append(js.pointer_addresses[0]["entries"][song.mem_idx])
             # Shuffle the group list
             shuffled_music = group_items.copy()
-            if type_data.setting:
+            # If we're keeping vanilla songs in vanilla locations, do not
+            # shuffle this list.
+            if type_data.setting and not settings.music_vanilla_locations:
                 random.shuffle(shuffled_music)
             # Remove assigned locations.
             open_locations = [x for x in group_items if x not in assigned_item_locations]

--- a/randomizer/SettingStrings.py
+++ b/randomizer/SettingStrings.py
@@ -199,6 +199,7 @@ def encrypt_settings_string_enum(dict_data: dict):
         "music_events_randomized",
         "music_majoritems_randomized",
         "music_minoritems_randomized",
+        "music_vanilla_locations",
         "tiny_hair_colors",
         "tiny_clothes_colors",
         "tiny_hair_custom_color",

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -452,6 +452,7 @@ class Settings:
         self.music_minoritems_randomized = False
         self.music_events_randomized = False
         self.random_music = False
+        self.music_vanilla_locations = False
         self.music_selection_dict = {
             "vanilla": {},
             "custom": {},

--- a/templates/music.html.jinja2
+++ b/templates/music.html.jinja2
@@ -65,6 +65,18 @@
                 </div>
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"
+                            title="If true, vanilla songs will never be placed anywhere but their original locations.">
+                        <input class="form-check-input"
+                            type="checkbox"
+                            name="music_vanilla_locations"
+                            id="music_vanilla_locations"
+                            display_name="Keep Vanilla Song Locations"
+                            value="True"/>
+                        Keep Vanilla Song Locations
+                    </label>
+                </div>
+                <div class="form-check form-switch item-switch">
+                    <label data-toggle="tooltip"
                            title="This option disables various songs.">
                         <input class="form-check-input"
                                type="checkbox"

--- a/templates/music.html.jinja2
+++ b/templates/music.html.jinja2
@@ -70,9 +70,9 @@
                             type="checkbox"
                             name="music_vanilla_locations"
                             id="music_vanilla_locations"
-                            display_name="Keep Vanilla Song Locations"
+                            display_name="Keep Vanilla Song Placement"
                             value="True"/>
-                        Keep Vanilla Song Locations
+                        Keep Vanilla Song Placement
                     </label>
                 </div>
                 <div class="form-check form-switch item-switch">

--- a/templates/music.html.jinja2
+++ b/templates/music.html.jinja2
@@ -65,7 +65,7 @@
                 </div>
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"
-                            title="If true, vanilla songs will never be placed anywhere but their original locations.">
+                            title="If true, vanilla songs will not be shuffled anywhere but their original locations.">
                         <input class="form-check-input"
                             type="checkbox"
                             name="music_vanilla_locations"


### PR DESCRIPTION
This option will ensure that vanilla songs are not shuffled into any locations other than their original locations. This will not affect user-assigned songs, or the proportions or locations of custom songs.