### PR TITLE
better buffers, no jetpac foolish

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -967,10 +967,9 @@ def CalculateFoolish(spoiler: Spoiler, WothLocations: List[Union[Locations, int]
         regionCountHintableItems.append(Items.Shockwave)
         regionCountHintableItems.append(Items.Camera)
 
-    nonHintableNames = {"Game Start", "K. Rool Arena", "Snide", "Candy Generic", "Funky Generic", "Credits"}  # These regions never have anything useful so shouldn't be hinted
+    # These regions never have anything useful or are otherwise accounted for in the hints and shouldn't be hinted
+    nonHintableNames = {"Game Start", "K. Rool Arena", "Snide", "Candy Generic", "Funky Generic", "Credits", "Jetpac Game"}
     spoiler.region_hintable_count = {}
-    if Types.Coin not in spoiler.settings.shuffled_location_types:
-        nonHintableNames.add("Jetpac Game")  # If this is vanilla, it's never useful to hint
     bossLocations = [location for id, location in spoiler.LocationList.items() if location.type == Types.Key]
     # In order for a region to be foolish, it can contain none of these Major Items
     for id, region in spoiler.RegionList.items():

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -1143,9 +1143,9 @@ class Settings:
             # Range roughly from 4 to 15, average around 10
             self.medal_requirement = round(random.normalvariate(10, 1.5))
         self.original_medal_requirement = self.medal_requirement
-        self.logical_medal_requirement = min(math.floor(self.medal_requirement * 1.2), 40)
+        self.logical_medal_requirement = min(40, max(self.medal_requirement + 1, math.floor(self.medal_requirement * 1.2)))
         self.original_fairy_requirement = self.rareware_gb_fairies
-        self.logical_fairy_requirement = min(math.floor(self.rareware_gb_fairies * 1.2), 20)
+        self.logical_fairy_requirement = min(20, max(self.rareware_gb_fairies + 1, int(self.rareware_gb_fairies * 1.2)))
 
         # Boss Rando
         self.boss_maps = ShuffleBosses(self.boss_location_rando)


### PR DESCRIPTION
- Guarantee a buffer of at least 1 no matter the number of medals or fairies required for Jetpac and BFI
- Jetpac can no longer be hinted foolish because Cranky always tells you this info anyway