### PR TITLE
Fill rework and kong paths

### DIFF
--- a/randomizer/Enums/HintType.py
+++ b/randomizer/Enums/HintType.py
@@ -29,3 +29,4 @@ class HintType(IntEnum):
     RegionItemCount = auto()
     ItemRegion = auto()
     Plando = auto()
+    RequiredSlamHint = auto()

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -776,6 +776,10 @@ def IdentifyMajorItems(spoiler: Spoiler) -> List[Locations]:
     """Identify the Major Items in this seed based on the item placement and the settings."""
     # Use the settings to determine non-progression Major Items
     majorItems = ItemPool.AllKongMoves()
+    majorItems.extend(ItemPool.CrankyItems())
+    majorItems.extend(ItemPool.FunkyItems())
+    majorItems.extend(ItemPool.CandyItems())
+    majorItems.extend(ItemPool.SnideItems())
     if spoiler.settings.training_barrels != TrainingBarrels.normal:
         majorItems.extend(ItemPool.TrainingBarrelAbilities())
     if spoiler.settings.shockwave_status != ShockwaveStatus.shuffled_decoupled:

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1452,26 +1452,7 @@ def PlaceItems(
 
 def FillShuffledKeys(spoiler: Spoiler, placed_types: List[Types], placed_items: List[Items]) -> None:
     """Fill Keys in shuffled locations based on the settings."""
-    keysToPlace = []
-    for keyEvent in spoiler.settings.krool_keys_required:
-        if keyEvent == Events.JapesKeyTurnedIn:
-            keysToPlace.append(Items.JungleJapesKey)
-        elif keyEvent == Events.AztecKeyTurnedIn:
-            keysToPlace.append(Items.AngryAztecKey)
-        elif keyEvent == Events.FactoryKeyTurnedIn:
-            keysToPlace.append(Items.FranticFactoryKey)
-        elif keyEvent == Events.GalleonKeyTurnedIn:
-            keysToPlace.append(Items.GloomyGalleonKey)
-        elif keyEvent == Events.ForestKeyTurnedIn:
-            keysToPlace.append(Items.FungiForestKey)
-        elif keyEvent == Events.CavesKeyTurnedIn:
-            keysToPlace.append(Items.CrystalCavesKey)
-        elif keyEvent == Events.CastleKeyTurnedIn:
-            keysToPlace.append(Items.CreepyCastleKey)
-        elif keyEvent == Events.HelmKeyTurnedIn:
-            keysToPlace.append(Items.HideoutHelmKey)
-    if spoiler.settings.key_8_helm and Items.HideoutHelmKey in keysToPlace:
-        keysToPlace.remove(Items.HideoutHelmKey)
+    keysToPlace = ItemPool.KeysToPlace(spoiler.settings)
     # Don't double-place keys
     for item in placed_items:
         if item in keysToPlace:
@@ -1624,43 +1605,64 @@ def Fill(spoiler: Spoiler) -> None:
     if spoiler.settings.extreme_debugging:
         DebugCheckAllReachable(spoiler, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types, placed_items=preplaced_items), "Rainbow Coins")
 
-    # Fill in Shop Owners
-    shop_owner_items = {
-        Types.Cranky: ItemPool.CrankyItems(),
-        Types.Funky: ItemPool.FunkyItems(),
-        Types.Candy: ItemPool.CandyItems(),
-        Types.Snide: ItemPool.SnideItems(),
-    }
-    shopowners_in_pool = False
-    for item_type in shop_owner_items:
-        if item_type in spoiler.settings.shuffled_location_types:
-            shopowners_in_pool = True
-            placed_types.append(item_type)
-            spoiler.Reset()
-            shopOwnerItemsToBePlaced = shop_owner_items[item_type]
-            for item in preplaced_items:
-                if item in shopOwnerItemsToBePlaced:
-                    shopOwnerItemsToBePlaced.remove(item)
-            unplacedShopOwners = PlaceItems(spoiler, FillAlgorithm.random, shopOwnerItemsToBePlaced, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types, placed_items=preplaced_items))
-            if unplacedShopOwners > 0:
-                raise Ex.ItemPlacementException(str(unplacedShopOwners) + " unplaced shop owners.")
-    if shopowners_in_pool:
-        for x in range(4):
-            if spoiler.LocationList[Locations.ShopOwner_Location00 + x].item is None:
-                spoiler.LocationList[Locations.ShopOwner_Location00 + x].PlaceItem(spoiler, Items.NoItem)
-
-    # Now we place all logically-relevant low-quantity items
-    # Then fill Kongs and Moves - this should be a very early fill type for hopefully obvious reasons
-    FillKongsAndMoves(spoiler, placed_types, preplaced_items)
-    if spoiler.settings.extreme_debugging:
-        DebugCheckAllReachable(spoiler, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types, placed_items=preplaced_items), "all moves")
-
-    # Then place Keys
-    if Types.Key in spoiler.settings.shuffled_location_types:
+    if spoiler.settings.shuffle_items and Types.Shop in spoiler.settings.shuffled_location_types:
+        if spoiler.settings.kong_rando:
+            FillKongs(spoiler, placed_types, preplaced_items)
+        preplaced_items.extend([Items.Donkey, Items.Diddy, Items.Lanky, Items.Tiny, Items.Chunky])
+        preplaced_items.extend(FillTrainingMoves(spoiler, preplaced_items))
+        placed_types.append(Types.Shop)
+        placed_types.append(Types.TrainingBarrel)
+        placed_types.append(Types.Shockwave)
         placed_types.append(Types.Key)
-        FillShuffledKeys(spoiler, placed_types, preplaced_items)
-    if spoiler.settings.extreme_debugging:
-        DebugCheckAllReachable(spoiler, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types, placed_items=preplaced_items), "Keys")
+        bigListOfItemsToPlace = []
+        if Types.Shop in spoiler.settings.shuffled_location_types:
+            bigListOfItemsToPlace.extend(ItemPool.ImportantSharedMoves.copy())
+            bigListOfItemsToPlace.extend(ItemPool.JunkSharedMoves.copy())
+            bigListOfItemsToPlace.extend(ItemPool.DonkeyMoves)
+            bigListOfItemsToPlace.extend(ItemPool.DiddyMoves)
+            bigListOfItemsToPlace.extend(ItemPool.LankyMoves)
+            bigListOfItemsToPlace.extend(ItemPool.TinyMoves)
+            bigListOfItemsToPlace.extend(ItemPool.ChunkyMoves)
+            if spoiler.settings.training_barrels != TrainingBarrels.normal:
+                bigListOfItemsToPlace.extend(ItemPool.TrainingBarrelAbilities())
+            if spoiler.settings.shockwave_status != ShockwaveStatus.start_with:
+                bigListOfItemsToPlace.extend(ItemPool.ShockwaveTypeItems(spoiler.settings))
+        if Types.Key in spoiler.settings.shuffled_location_types:
+            bigListOfItemsToPlace.extend(ItemPool.KeysToPlace(spoiler.settings))
+        if Types.Cranky in spoiler.settings.shuffled_location_types:
+            placed_types.append(Types.Cranky)
+            bigListOfItemsToPlace.extend(ItemPool.CrankyItems())
+        if Types.Funky in spoiler.settings.shuffled_location_types:
+            placed_types.append(Types.Funky)
+            bigListOfItemsToPlace.extend(ItemPool.FunkyItems())
+        if Types.Candy in spoiler.settings.shuffled_location_types:
+            placed_types.append(Types.Candy)
+            bigListOfItemsToPlace.extend(ItemPool.CandyItems())
+        if Types.Snide in spoiler.settings.shuffled_location_types:
+            placed_types.append(Types.Snide)
+            bigListOfItemsToPlace.extend(ItemPool.SnideItems())
+        for item in preplaced_items:
+            if item in bigListOfItemsToPlace:
+                bigListOfItemsToPlace.remove(item)
+        unplaced = PlaceItems(spoiler, FillAlgorithm.assumed, bigListOfItemsToPlace, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types, placed_items=preplaced_items))
+        if unplaced > 0:
+            raise Ex.ItemPlacementException(str(miscUnplaced) + " unplaced items from the fill.")
+        if spoiler.settings.extreme_debugging:
+            DebugCheckAllReachable(spoiler, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types, placed_items=preplaced_items), "The Fill")
+
+    else:
+        # Now we place all logically-relevant low-quantity items
+        # Then fill Kongs and Moves - this should be a very early fill type for hopefully obvious reasons
+        FillKongsAndMoves(spoiler, placed_types, preplaced_items)
+        if spoiler.settings.extreme_debugging:
+            DebugCheckAllReachable(spoiler, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types, placed_items=preplaced_items), "all moves")
+
+        # Then place Keys
+        if Types.Key in spoiler.settings.shuffled_location_types:
+            placed_types.append(Types.Key)
+            FillShuffledKeys(spoiler, placed_types, preplaced_items)
+        if spoiler.settings.extreme_debugging:
+            DebugCheckAllReachable(spoiler, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types, placed_items=preplaced_items), "Keys")
 
     # Then place misc progression items
     if Types.Bean in spoiler.settings.shuffled_location_types:
@@ -1843,6 +1845,11 @@ def Fill(spoiler: Spoiler) -> None:
     # This is the only location that cares about None vs NoItem - it needs to be None so it fills correctly but NoItem for logic to generate progression correctly
     if spoiler.LocationList[Locations.JapesDonkeyFreeDiddy].item is None:
         spoiler.LocationList[Locations.JapesDonkeyFreeDiddy].PlaceItem(spoiler, Items.NoItem)
+    # Shopkeepers have been either placed in the world or set to vanilla. In case of the former, empty out their vanilla "locations" as needed
+    for x in range(4):
+        if spoiler.LocationList[Locations.ShopOwner_Location00 + x].item is None:
+            spoiler.LocationList[Locations.ShopOwner_Location00 + x].PlaceItem(spoiler, Items.NoItem)
+
     # Finally, check if game is beatable
     spoiler.Reset()
     if not GetAccessibleLocations(spoiler, [], SearchMode.CheckAllReachable):
@@ -1850,6 +1857,70 @@ def Fill(spoiler: Spoiler) -> None:
         raise Ex.GameNotBeatableException("Game not able to complete 101% after placing all items.")
     # We have successfully filled the seed by this point. All that is left is to confirm there are no purchase order locks
     return
+
+
+def FillTrainingMoves(spoiler: Spoiler, placedMoves: List[Items]):
+    """Fill training barrels with your starting moves."""
+    # If we start with a slam as the training grounds reward, it counts as placed for fill purposes
+    if spoiler.settings.start_with_slam:
+        placedMoves.append(Items.ProgressiveSlam)
+    # First place our starting moves randomly
+    locationsNeedingMoves = []
+    # We can expect that all locations in this region are starting move locations or Training Barrels
+    for locationLogic in spoiler.RegionList[Regions.GameStart].locations:
+        location = spoiler.LocationList[locationLogic.id]
+        if location.item is None and not location.inaccessible:
+            locationsNeedingMoves.append(locationLogic.id)
+    # Fill the empty starting locations
+    newlyPlacedItems = []
+    if any(locationsNeedingMoves):
+        # Identify all possible items that can be starting moves if we need to randomly pick some
+        possibleStartingMoves = ItemPool.AllKongMoves().copy()
+        if len(locationsNeedingMoves) < 10:
+            # Generally only include one copy of the useless progressive moves to bias against picking them when you only have a few starting moves
+            possibleStartingMoves.append(Items.ProgressiveAmmoBelt)
+            possibleStartingMoves.append(Items.ProgressiveInstrumentUpgrade)
+        else:
+            # If we have lots of starting moves, we'll need to include all copies so we have enough stuff to fill all locations
+            possibleStartingMoves.extend(ItemPool.JunkSharedMoves)
+        if spoiler.settings.training_barrels == TrainingBarrels.shuffled:
+            possibleStartingMoves.extend(ItemPool.TrainingBarrelAbilities())
+        if spoiler.settings.shockwave_status in (ShockwaveStatus.shuffled, ShockwaveStatus.shuffled_decoupled):
+            possibleStartingMoves.extend(ItemPool.ShockwaveTypeItems(spoiler.settings))
+        # Any placed items placed before this method can't be random starting items
+        for item in placedMoves:
+            if item in possibleStartingMoves:
+                possibleStartingMoves.remove(item)
+        shuffle(possibleStartingMoves)
+        # Assemble the starting move pool
+        startingMovePool = [move for move in spoiler.settings.random_starting_move_list_selected]  # These are the user-chosen moves eligible to be random starting moves
+        shuffle(startingMovePool)
+        startingMovePool.extend(spoiler.settings.starting_move_list_selected)  # Append the guaranteed starting moves at the end so they're always picked first
+        # For each location needing a move, put in a random valid move
+        for locationId in locationsNeedingMoves:
+            # If there are moves in the starting move pool, always pick from there first
+            if len(startingMovePool) > 0:
+                startingMove = startingMovePool.pop()
+                if startingMove in possibleStartingMoves:  # Make sure to ward off issues of duplication
+                    possibleStartingMoves.remove(startingMove)
+            # Otherwise, pick from any random eligible move
+            else:
+                startingMove = possibleStartingMoves.pop()
+            newlyPlacedItems.append(startingMove)  # This line of code now assumes we place starting moves first!!
+            spoiler.LocationList[locationId].PlaceItem(spoiler, startingMove)
+            # Helpful debug code to keep track of where all major items are placed - do not rely on this variable anywhere
+            if locationId in spoiler.settings.debug_fill.keys():
+                del spoiler.settings.debug_fill[spoiler.LocationList[locationId].name]
+            spoiler.settings.debug_fill[spoiler.LocationList[locationId].name] = startingMove
+        # If we ever decide to place starting moves after other moves, we may find ourselves having placed moves twice.
+        # I don't foresee a reason to do this ever, just something to consider if things change.
+        # if any(toBeUnplaced):
+        #     for location in LocationList.values():
+        #         if location.item in (toBeUnplaced) and location.type not in (Types.TrainingBarrel, Types.PreGivenMove):
+        #             toBeUnplaced.remove(location.item)
+        #             location.UnplaceItem()
+    # Return all the moves we now know are placed
+    return newlyPlacedItems
 
 
 def ShuffleSharedMoves(spoiler: Spoiler, placedMoves: List[Items], placedTypes: List[Types]) -> None:
@@ -2193,66 +2264,28 @@ def FillKongsAndMoves(spoiler: Spoiler, placedTypes: List[Types], placedItems: L
         FillKongs(spoiler, placedTypes, placedItems)
     placedMoves = [Items.Donkey, Items.Diddy, Items.Lanky, Items.Tiny, Items.Chunky]  # Kongs are now placed, either in the above method or by default
     placedMoves.extend(placedItems)
-    # If we start with a slam as the training grounds reward, it counts as placed for fill purposes
-    if spoiler.settings.start_with_slam:
-        placedMoves.append(Items.ProgressiveSlam)
-    # First place our starting moves randomly
-    locationsNeedingMoves = []
-    # We can expect that all locations in this region are starting move locations or Training Barrels
-    for locationLogic in spoiler.RegionList[Regions.GameStart].locations:
-        location = spoiler.LocationList[locationLogic.id]
-        if location.item is None and not location.inaccessible:
-            locationsNeedingMoves.append(locationLogic.id)
-    # Fill the empty starting locations
-    if any(locationsNeedingMoves):
-        newlyPlacedItems = []
-        # Identify all possible items that can be starting moves if we need to randomly pick some
-        possibleStartingMoves = ItemPool.AllKongMoves().copy()
-        if len(locationsNeedingMoves) < 10:
-            # Generally only include one copy of the useless progressive moves to bias against picking them when you only have a few starting moves
-            possibleStartingMoves.append(Items.ProgressiveAmmoBelt)
-            possibleStartingMoves.append(Items.ProgressiveInstrumentUpgrade)
-        else:
-            # If we have lots of starting moves, we'll need to include all copies so we have enough stuff to fill all locations
-            possibleStartingMoves.extend(ItemPool.JunkSharedMoves)
-        if spoiler.settings.training_barrels == TrainingBarrels.shuffled:
-            possibleStartingMoves.extend(ItemPool.TrainingBarrelAbilities())
-        if spoiler.settings.shockwave_status in (ShockwaveStatus.shuffled, ShockwaveStatus.shuffled_decoupled):
-            possibleStartingMoves.extend(ItemPool.ShockwaveTypeItems(spoiler.settings))
-        # Any placed items placed before this method can't be random starting items
-        for item in placedMoves:
-            if item in possibleStartingMoves:
-                possibleStartingMoves.remove(item)
-        shuffle(possibleStartingMoves)
-        # Assemble the starting move pool
-        startingMovePool = [move for move in spoiler.settings.random_starting_move_list_selected]  # These are the user-chosen moves eligible to be random starting moves
-        shuffle(startingMovePool)
-        startingMovePool.extend(spoiler.settings.starting_move_list_selected)  # Append the guaranteed starting moves at the end so they're always picked first
-        # For each location needing a move, put in a random valid move
-        for locationId in locationsNeedingMoves:
-            # If there are moves in the starting move pool, always pick from there first
-            if len(startingMovePool) > 0:
-                startingMove = startingMovePool.pop()
-                if startingMove in possibleStartingMoves:  # Make sure to ward off issues of duplication
-                    possibleStartingMoves.remove(startingMove)
-            # Otherwise, pick from any random eligible move
-            else:
-                startingMove = possibleStartingMoves.pop()
-            newlyPlacedItems.append(startingMove)  # This line of code now assumes we place starting moves first!!
-            spoiler.LocationList[locationId].PlaceItem(spoiler, startingMove)
-            # Helpful debug code to keep track of where all major items are placed - do not rely on this variable anywhere
-            if locationId in spoiler.settings.debug_fill.keys():
-                del spoiler.settings.debug_fill[spoiler.LocationList[locationId].name]
-            spoiler.settings.debug_fill[spoiler.LocationList[locationId].name] = startingMove
-        # If we ever decide to place starting moves after other moves, we may find ourselves having placed moves twice.
-        # I don't foresee a reason to do this ever, just something to consider if things change.
-        # if any(toBeUnplaced):
-        #     for location in LocationList.values():
-        #         if location.item in (toBeUnplaced) and location.type not in (Types.TrainingBarrel, Types.PreGivenMove):
-        #             toBeUnplaced.remove(location.item)
-        #             location.UnplaceItem()
-        # Compile all the moves we now know are placed
-        placedMoves.extend(newlyPlacedItems)
+
+    # Place Training Moves
+    placedMoves.extend(FillTrainingMoves(spoiler, placedItems))
+
+    # Fill in Shop Owners
+    shop_owner_items = {
+        Types.Cranky: ItemPool.CrankyItems(),
+        Types.Funky: ItemPool.FunkyItems(),
+        Types.Candy: ItemPool.CandyItems(),
+        Types.Snide: ItemPool.SnideItems(),
+    }
+    for item_type in shop_owner_items:
+        if item_type in spoiler.settings.shuffled_location_types:
+            placedTypes.append(item_type)
+            spoiler.Reset()
+            shopOwnerItemsToBePlaced = shop_owner_items[item_type]
+            for item in placedMoves:
+                if item in shopOwnerItemsToBePlaced:
+                    shopOwnerItemsToBePlaced.remove(item)
+            unplacedShopOwners = PlaceItems(spoiler, FillAlgorithm.random, shopOwnerItemsToBePlaced, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placedTypes, placedItems))
+            if unplacedShopOwners > 0:
+                raise Ex.ItemPlacementException(str(unplacedShopOwners) + " unplaced shop owners.")
 
     # Handle shared moves before other moves in move rando
     if spoiler.settings.move_rando != MoveRando.off:
@@ -2832,11 +2865,11 @@ def Generate_Spoiler(spoiler: Spoiler) -> Tuple[bytes, Spoiler]:
             raise Ex.VanillaItemsGameNotBeatableException("Game unbeatable.")
     CorrectBossKongLocations(spoiler)
     GeneratePlaythrough(spoiler)
+    compileMicrohints(spoiler)
     if spoiler.settings.wrinkly_hints != WrinklyHints.off:
         compileHints(spoiler)
     if spoiler.settings.spoiler_hints != SpoilerHints.off:
         compileSpoilerHints(spoiler)
-    compileMicrohints(spoiler)
     spoiler.Reset()
     ShuffleExits.Reset(spoiler)
     spoiler.createJson()

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -3,6 +3,7 @@
 import itertools
 import random
 
+from randomizer.Enums.Events import Events
 import randomizer.Enums.Kongs as KongObject
 from randomizer.Enums.Items import Items
 from randomizer.Enums.Locations import Locations
@@ -120,6 +121,10 @@ def AllItemsUnrestricted(settings):
     else:
         allItems.append(Items.CameraAndShockwave)
     allItems.extend(Kongs(settings))
+    allItems.extend(CrankyItems())
+    allItems.extend(FunkyItems())
+    allItems.extend(CandyItems())
+    allItems.extend(SnideItems())
     return allItems
 
 
@@ -315,6 +320,31 @@ def Blueprints():
 def Keys():
     """Return all key items."""
     return [Items.JungleJapesKey, Items.AngryAztecKey, Items.FranticFactoryKey, Items.GloomyGalleonKey, Items.FungiForestKey, Items.CrystalCavesKey, Items.CreepyCastleKey, Items.HideoutHelmKey]
+
+
+def KeysToPlace(settings):
+    """Return all keys that are non-starting keys."""
+    keysToPlace = []
+    for keyEvent in settings.krool_keys_required:
+        if keyEvent == Events.JapesKeyTurnedIn:
+            keysToPlace.append(Items.JungleJapesKey)
+        elif keyEvent == Events.AztecKeyTurnedIn:
+            keysToPlace.append(Items.AngryAztecKey)
+        elif keyEvent == Events.FactoryKeyTurnedIn:
+            keysToPlace.append(Items.FranticFactoryKey)
+        elif keyEvent == Events.GalleonKeyTurnedIn:
+            keysToPlace.append(Items.GloomyGalleonKey)
+        elif keyEvent == Events.ForestKeyTurnedIn:
+            keysToPlace.append(Items.FungiForestKey)
+        elif keyEvent == Events.CavesKeyTurnedIn:
+            keysToPlace.append(Items.CrystalCavesKey)
+        elif keyEvent == Events.CastleKeyTurnedIn:
+            keysToPlace.append(Items.CreepyCastleKey)
+        elif keyEvent == Events.HelmKeyTurnedIn:
+            keysToPlace.append(Items.HideoutHelmKey)
+    if settings.key_8_helm and Items.HideoutHelmKey in keysToPlace:
+        keysToPlace.remove(Items.HideoutHelmKey)
+    return keysToPlace
 
 
 def Kongs(settings):

--- a/randomizer/Patching/ApplyRandomizer.py
+++ b/randomizer/Patching/ApplyRandomizer.py
@@ -587,7 +587,7 @@ def patching_response(spoiler):
         applyHelmDoorCosmetics(spoiler.settings)
         applyKongModelSwaps(spoiler.settings)
 
-    patchAssembly(ROM_COPY, spoiler)
+        patchAssembly(ROM_COPY, spoiler)
 
     # Apply Hash
     order = 0

--- a/randomizer/Patching/MusicRando.py
+++ b/randomizer/Patching/MusicRando.py
@@ -214,6 +214,7 @@ def isSongWithInLengthRange(vanilla_length: int, proposed_length: int) -> bool:
         return True
     return False
 
+
 def writeSongMemory(ROM_COPY: ROM, index: int, value: int):
     """Write song memory to ROM."""
     offset_dict = populateOverlayOffsets(ROM_COPY)
@@ -226,6 +227,7 @@ def writeSongMemory(ROM_COPY: ROM, index: int, value: int):
     channel = (value & 0x78) >> 3
     original_value = original_value | ((write_slot & 3) << 1) | ((channel & 0xF) << 3)
     writeValue(ROM_COPY, 0x80745658 + (index * 2), Overlay.Static, original_value, offset_dict)
+
 
 def writeSongVolume(ROM_COPY: ROM, index: int, song_type: SongType):
     """Write song volume to ROM."""
@@ -243,6 +245,7 @@ def writeSongVolume(ROM_COPY: ROM, index: int, song_type: SongType):
         ROM_COPY.write(255)
     if song_type in volumes:
         writeValue(ROM_COPY, 0x807454F0 + (index * 2), Overlay.Static, volumes.get(song_type, 23000), offset_dict)
+
 
 def getAssignedCustomSongData(file_data_array: list, song_name: str, length_filter: bool, location_filter: bool, song_type: SongType) -> UploadInfo:
     """Request a specific custom song from the list."""

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -1484,11 +1484,14 @@ class Settings:
                         spoiler.LocationList[location_id].inaccessible = False
                         spoiler.LocationList[location_id].smallerShopsInaccessible = False
 
-        # shop_types = (Types.Cranky, Types.Funky, Types.Candy, Types.Snide)
-        # shopkeepers_in_pool = len([x for x in shop_types if x in self.shuffled_location_types]) > 0
-        # if shopkeepers_in_pool:
-        #     for x in range(4):
-        #         spoiler.LocationList[Locations.ShopOwner_Location00 + x].inaccessible = True
+        if Types.Cranky in self.shuffled_location_types:
+            spoiler.LocationList[Locations.ShopOwner_Location00].inaccessible = True
+        if Types.Funky in self.shuffled_location_types:
+            spoiler.LocationList[Locations.ShopOwner_Location01].inaccessible = True
+        if Types.Candy in self.shuffled_location_types:
+            spoiler.LocationList[Locations.ShopOwner_Location02].inaccessible = True
+        if Types.Snide in self.shuffled_location_types:
+            spoiler.LocationList[Locations.ShopOwner_Location03].inaccessible = True
 
         # Designate the Rock GB as a location for the starting kong
         spoiler.LocationList[Locations.IslesDonkeyJapesRock].kong = self.starting_kong
@@ -1552,9 +1555,8 @@ class Settings:
             ]
             shuffledLocationsShopOwner = [
                 location
-                for location in spoiler.LocationList
-                if spoiler.LocationList[location].type in self.shuffled_location_types
-                and spoiler.LocationList[location].type not in (Types.Kong, Types.Shop, Types.Shockwave, Types.PreGivenMove, Types.TrainingBarrel, Types.NintendoCoin, Types.RarewareCoin)
+                for location in shuffledLocations  # Placing a shop owner in a shop owner location is boring and we don't want to do it ever
+                if spoiler.LocationList[location].type not in (Types.Shop, Types.Shockwave, Types.PreGivenMove, Types.TrainingBarrel, Types.NintendoCoin, Types.RarewareCoin)
             ]
             shuffledNonMoveLocations = [location for location in shuffledLocations if spoiler.LocationList[location].type != Types.PreGivenMove]
             fairyBannedLocations = [location for location in shuffledNonMoveLocations if spoiler.LocationList[location].type != Types.Fairy]
@@ -1799,6 +1801,36 @@ class Settings:
                     self.minoritems_songs_selected = True
                 elif song.type == SongType.Event:
                     self.events_songs_selected = True
+
+    def is_valid_item_pool(self):
+        """Confirm that the item pool is a valid combination of items. Must be run after valid locations are calculated without any restrictions."""
+        junk_space_available = 0
+        if self.shuffle_items:
+            if Types.Enemies in self.shuffled_location_types:
+                junk_space_available += 100  # Rough estimate, not to be used as factual
+            if Types.Shop in self.shuffled_location_types:
+                junk_space_available += 30  # Rough estimate, not to be used as factual
+            if Types.Kong in self.shuffled_location_types:
+                junk_space_available -= 5 - len(self.starting_kong_list)  # Not always this, Kongs in cages are so rare it may as well be
+            # Shopkeepers don't get placed in their vanilla locations (essentially a start with)
+            if Types.Cranky in self.shuffled_location_types:
+                junk_space_available -= 1
+                if len(self.valid_locations[Types.Cranky]) <= 0:
+                    return False
+            if Types.Funky in self.shuffled_location_types:
+                junk_space_available -= 1
+                if len(self.valid_locations[Types.Funky]) <= 0:
+                    return False
+            if Types.Candy in self.shuffled_location_types:
+                junk_space_available -= 1
+                if len(self.valid_locations[Types.Candy]) <= 0:
+                    return False
+            if Types.Snide in self.shuffled_location_types:
+                junk_space_available -= 1
+                if len(self.valid_locations[Types.Snide]) <= 0:
+                    return False
+            return junk_space_available >= 0
+        return True
 
     def __repr__(self):
         """Return printable version of the object as json.

--- a/randomizer/ShuffleItems.py
+++ b/randomizer/ShuffleItems.py
@@ -98,7 +98,7 @@ def ShuffleItems(spoiler):
                     item_location.type == Types.TrainingBarrel and not item_location.constant
                 )  # Depending on starting moves, training barrels can be empty (only when constant). This quick check prevents weirdness later in this method.
             )
-            and not item_location.inaccessible
+            and (not item_location.inaccessible or item_location.type in (Types.Cranky, Types.Funky, Types.Candy, Types.Snide))  # Shopkeepers' locations are either inaccessible or vanilla
             and item_location.type in spoiler.settings.shuffled_location_types
         ):
             # Create placement info for the patcher to use

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -6,6 +6,7 @@ import json
 from copy import deepcopy
 from typing import TYPE_CHECKING, Dict, List, Optional, OrderedDict, Union
 
+import randomizer.Lists.Exceptions as Ex
 from randomizer.Enums.Events import Events
 from randomizer.Enums.Items import Items
 from randomizer.Enums.Kongs import Kongs
@@ -129,6 +130,8 @@ class Spoiler:
         self.tied_hint_flags = {}
         self.settings.finalize_world_settings(self)
         self.settings.update_valid_locations(self)
+        if not self.settings.is_valid_item_pool():
+            raise Ex.SettingsIncompatibleException("Item pool is not a valid combination of items and cannot successfully fill the world.")
 
     def FlushAllExcessSpoilerData(self):
         """Flush all spoiler data that is not needed for the final result."""


### PR DESCRIPTION
Hints:
- Freeing Kongs is now a path endpoint. Anything that will help you free kongs is eligible to be hinted this way. Items can be hinted to exclusively freeing kongs just like any other path endpoint. This has the effect of slightly increasing the amount of path hints seen, but probably not to a significant extent. This is intended to assist with kong casinos, particularly in settings without SLO's guide rails.
- A random wrinkly door and the last progressive hint are now guaranteed to be the equivalent to the slam microhint. This guarantee is contingent on it actually being relevant: if you start with less than Super Simian Slam, you will receive this hint.

Fill & Friends:
- Reworked the fill to reduce the inherent biases observed over the lifespan of 2.0 and beyond. By lumping everything into a single list and placing them in a random order, you no longer have a bias towards early-placed items and a bias against later-placed items. This should manifest as reducing the effects of the SLO "first 3 levels" bias and the CLO "early keys" bias.
- Moved around the shopkeeper shuffle to better gel with the fill rework.
- Fixed an issue where shopkeepers weren't considered important items.