### PR TITLE
double slam start, no jetpac scouring

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -2318,7 +2318,13 @@ def GenerateMultipathDict(
     """
     multipath_dict_hints = {}
     multipath_dict_goals = {}
+    training_slam_hinted = False
     for location in spoiler.woth_locations:
+        # In worlds where you start with multiple slams and it could be hinted, you'll get identical-looking hints for each slam location. We only want to create that hint once.
+        if location in TrainingBarrelLocations or location in PreGivenLocations and spoiler.LocationList[location].item == Items.ProgressiveSlam:
+            if training_slam_hinted:
+                continue
+            training_slam_hinted = True
         path_to_keys = []
         path_to_krool_phases = []
         path_to_camera = []

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -983,7 +983,7 @@ def CalculateFoolish(spoiler: Spoiler, WothLocations: List[Union[Locations, int]
             if bossLocation.item in MajorItems:
                 nonHintableNames.add(region.hint_name)
         # Ban shops from region count hinting. These are significantly worse regions to hint than any others.
-        if "Shops" not in region.hint_name:
+        if "Shops" not in region.hint_name and region.hint_name not in nonHintableNames:
             # Count the number of region count hintable items in the region (again, ignore training moves)
             regionItemCount = sum(1 for loc in locations if loc.type not in (Types.TrainingBarrel, Types.PreGivenMove) and loc.item in regionCountHintableItems)
             if regionItemCount > 0:


### PR DESCRIPTION
- If you start with two slams, you are now limited to one "your training with progressive slam..." hint
- Prevented Jetpac scouring hints