### PR TITLE
training blast hint fix, correct cb positioning

### DIFF
--- a/randomizer/CollectibleLogicFiles/FranticFactory.py
+++ b/randomizer/CollectibleLogicFiles/FranticFactory.py
@@ -57,9 +57,7 @@ LogicRegions = {
 
     ],
     Regions.ChunkyRoomPlatform: [
-        Collectible(Collectibles.bunch, Kongs.chunky, lambda l: l.punch, None, 3),
 
-        # Collectible(Collectibles.coin, Kongs.any, lambda l: l.shockwave, None, 1),
     ],
     Regions.PowerHut: [
         Collectible(Collectibles.bunch, Kongs.donkey, lambda l: True, None, 3),
@@ -79,6 +77,7 @@ LogicRegions = {
         Collectible(Collectibles.bunch, Kongs.tiny, lambda l: True, None, 2),  # Halfway down the hatch
         Collectible(Collectibles.banana, Kongs.chunky, lambda l: True, None, 10),  # On pole down the hatch
         Collectible(Collectibles.bunch, Kongs.chunky, lambda l: True, None, 1),  # W1
+        Collectible(Collectibles.bunch, Kongs.chunky, lambda l: l.punch, None, 3),  # Dark Room
 
         Collectible(Collectibles.coin, Kongs.donkey, lambda l: True, None, 3),  # Bottom of pole
         Collectible(Collectibles.coin, Kongs.diddy, lambda l: l.spring or l.phasewalk, None, 3),  # High ledge in Chunky's room

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -479,6 +479,10 @@ def compileHints(spoiler: Spoiler) -> bool:
         ]
         useless_locations[Items.HideoutHelmKey].append(Locations.HelmKey)  # Also don't count the known location of the key itself
     # Your training in moves which you know are always needed beat K. Rool are pointless to hint
+    if Kongs.donkey in spoiler.settings.krool_order and Kongs.donky in spoiler.krool_paths.keys() and spoiler.settings.balanced_krool_phases:
+        useless_locations[Kongs.donkey] = [
+            loc for loc in spoiler.krool_paths[Kongs.donkey] if (loc in TrainingBarrelLocations or loc in PreGivenLocations) and spoiler.LocationList[loc].item == Items.BaboonBlast
+        ]
     if Kongs.diddy in spoiler.settings.krool_order and Kongs.diddy in spoiler.krool_paths.keys():
         useless_locations[Kongs.diddy] = [
             loc


### PR DESCRIPTION
- Blast should not be hintable if you start with it and it's only on the path to Donkey Phase
- Fixed a position of the dark room Chunky CBs. This would only be noticeable in some rare worlds where you didn't start with a slam.