### PR TITLE
no more path to tns, unhinted score attempt

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -2272,17 +2272,17 @@ def compileHints(spoiler: Spoiler) -> bool:
                 # If this is the only child of this parent and the parent is directly hinted, this is the only location that can resolve that hint.
                 if len(parent_node.children) == 1 and (parent_node.path_hinted or parent_node.woth_hinted):
                     # Halve the unhinted contribution of this node per hinted solo-parent
-                    node.score_multiplier *= .5
+                    node.score_multiplier *= 0.5
                 # A woth-hinted location with multiple children means it could resolve in many ways, which could possibly leave this item effectively unhinted
-                # If the parents are path hinted, we need to analyze siblings' goals to determine if this location uniquely solves some portion of the parent's path 
+                # If the parents are path hinted, we need to analyze siblings' goals to determine if this location uniquely solves some portion of the parent's path
                 elif len(parent_node.children) > 1 and parent_node.path_hinted:
                     # Compile a list of all goals that the siblings are on the path to - this is always a subset of the parent's goals!
-                    sibling_nodes = [hint_tree[loc_id] for loc_id in parent_node.children if loc_id != node.node_location_id]
+                    sibling_nodes = [hint_tree[loc_id] for loc_id in parent_node.children if loc_id != node.node_location_id and loc_id in hint_tree.keys()]
                     sibling_goals = set([goal for node in sibling_nodes for goal in node.goals])
                     # If this node has *any* goals that are unique to this location, then this is the only location that can resolve that portion of the parent's path hint.
                     if any(set(node.goals).difference(sibling_goals)):
                         # Because of that, it makes this less unhinted
-                        node.score_multiplier *= .4
+                        node.score_multiplier *= 0.4
                     # Identify any particularly problematic siblings more directly
                     for child_loc_id in parent_node.children:
                         if child_loc_id != node.node_location_id:
@@ -2290,17 +2290,17 @@ def compileHints(spoiler: Spoiler) -> bool:
                             # If a parent is path hinted and this sibling could resolve this node's goals, one of the two would be effectively unhinted
                             if set(node.goals).issubset(set(child_node.goals)):
                                 # Split the difference - the current node being evaluated gets half the value
-                                node.unhinted_score += .5
+                                node.unhinted_score += 0.5
                                 # If the goals *exactly* match, then the current node could mask their sibling, even if the sibling is hinted!
                                 if node.goals == child_node.goals:
-                                    child_node.unhinted_score += .5
+                                    child_node.unhinted_score += 0.5
                                 # Note that if both are unhinted you'll double the score, which is appropriate for two unhinted items that could resolve the same path hint
         # Now that we've completed tree decoration, we can assess the damage - we have to do this at the end because sibling calculations can affect nodes that were previously calculated
         for node in hint_tree.values():
             total_score = node.unhinted_score * node.score_multiplier
             spoiler.unhinted_score += total_score
             # Arbitrary threshold of .5 unhinted to be a suspected ugly location
-            if total_score > .5:
+            if total_score > 0.5:
                 spoiler.poor_scoring_locations[spoiler.LocationList[node.node_location_id].name] = total_score
 
     UpdateSpoilerHintList(spoiler)

--- a/randomizer/Lists/PathHintTree.py
+++ b/randomizer/Lists/PathHintTree.py
@@ -1,0 +1,47 @@
+"""Path Hint Tree data for evaluating the strength of path hints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, List, Dict
+
+from randomizer.Enums.Locations import Locations
+
+
+
+class PathHintTreeNode:
+    """A node on the greater path hint tree."""
+
+    def __init__(self, loc: Locations) -> None:
+        self.node_location_id = loc
+        self.path_hinted = False
+        self.woth_hinted = False
+        self.goals = []
+        self.parents = []
+        self.children = []
+        self.unhinted_score = 0.0
+        self.score_multiplier = 1.0
+
+
+def BuildPathHintTree(woth_paths: Dict[Locations, List[Locations]]) -> Dict[Locations, PathHintTreeNode]:
+    """Assemble a list of multipath nodes that represent a tree from a list of Way of the Hoard paths."""
+    # TWO EXTREMELY IMPORTANT ASSUMPTIONS: 
+    # 1. The woth_paths keys are in order, meaning no earlier path has any elements that are a key for a future path.
+    # 2. The woth_paths values are ordered such that each path is a subset of the list of all keys without any reordering. (The order of each path matches the order of the dict's keys)
+    tree: Dict[Locations, PathHintTreeNode] = {}
+    # Traverse the list of paths in that careful order - this ensures we make the top-level parentless nodes first
+    for woth_loc_id, path in woth_paths.items():
+        node = PathHintTreeNode(woth_loc_id)
+        seen_nodes = set()
+        # For each item in the path in reverse order - this ensures we find the most-direct parents of this child first
+        for path_loc_id in reversed(path):
+            # If we've seen this location in our traversal, it's not a direct parent of this node - obviously you're also not your own parent.
+            if path_loc_id not in seen_nodes and path_loc_id != woth_loc_id:
+                # Any node we haven't seen must be a direct parent of this node
+                node.parents.append(path_loc_id)
+                # Which means this is a child of that node as well
+                tree[path_loc_id].children.append(woth_loc_id)
+                # All nodes on the path to the parent now count as seen - this is how we prevent inaccurate parentage
+                seen_nodes = seen_nodes.union(set(woth_paths[path_loc_id]))
+        # By adding this node here, all future loops will be able to add this as a parent and this node can have it's children added as well
+        tree[woth_loc_id] = node
+    return tree

--- a/randomizer/Lists/PathHintTree.py
+++ b/randomizer/Lists/PathHintTree.py
@@ -7,11 +7,11 @@ from typing import TYPE_CHECKING, Any, List, Dict
 from randomizer.Enums.Locations import Locations
 
 
-
 class PathHintTreeNode:
     """A node on the greater path hint tree."""
 
     def __init__(self, loc: Locations) -> None:
+        """Create a path hint tree node for the parameter location."""
         self.node_location_id = loc
         self.path_hinted = False
         self.woth_hinted = False
@@ -24,7 +24,7 @@ class PathHintTreeNode:
 
 def BuildPathHintTree(woth_paths: Dict[Locations, List[Locations]]) -> Dict[Locations, PathHintTreeNode]:
     """Assemble a list of multipath nodes that represent a tree from a list of Way of the Hoard paths."""
-    # TWO EXTREMELY IMPORTANT ASSUMPTIONS: 
+    # TWO EXTREMELY IMPORTANT ASSUMPTIONS:
     # 1. The woth_paths keys are in order, meaning no earlier path has any elements that are a key for a future path.
     # 2. The woth_paths values are ordered such that each path is a subset of the list of all keys without any reordering. (The order of each path matches the order of the dict's keys)
     tree: Dict[Locations, PathHintTreeNode] = {}

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -856,6 +856,8 @@ class Spoiler:
                 filtered_hint = filtered_hint.replace("\x0d", "")
                 human_hint_list[name] = filtered_hint
             humanspoiler["Wrinkly Hints"] = human_hint_list
+            humanspoiler["Unhinted Score"] = self.unhinted_score
+            humanspoiler["Potentially Awful Locations"] = self.poor_scoring_locations
 
         self.json = json.dumps(humanspoiler, indent=4)
 


### PR DESCRIPTION
- Path hints that point to T&S no longer exist, those hints are folded into "collecting CBs in {level}" hints
- Removed a joke hint that might be lying when shopkeepers are in the pool
- Shopkeepers count as Kongs for the purposes of vial hints
- Initial implementation for distilling the "unhintedness" of locations and whole seeds into a single score. This implementation is limited in scope, does not reflect all hint types, and generally is liable to come up wtih some false positives. It most needs manual feedback to improve however, so out into the wild it goes