### PR TITLE
CB fixes, Vanilla Camera fix, comp coin hint tree fix, UI tweak

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -472,11 +472,11 @@ def VerifyWorld(spoiler: Spoiler) -> bool:
                     if collectible.enabled and not collectible.added:
                         missingCBs.append(collectible)
             allCBsFound = False
-    spoiler.Reset()
     if not allLocationsReached:
         print(f"Unable to reach all locations: {unreachables}")
     if not allCBsFound:
         print(f"Unable to reach all CBs: {spoiler.LogicVariables.ColoredBananas}")
+    spoiler.Reset()
     return allLocationsReached and allCBsFound
 
 
@@ -1676,7 +1676,7 @@ def Fill(spoiler: Spoiler) -> None:
             bigListOfItemsToPlace.extend(ItemPool.ChunkyMoves)
             if spoiler.settings.training_barrels != TrainingBarrels.normal:
                 bigListOfItemsToPlace.extend(ItemPool.TrainingBarrelAbilities())
-            if spoiler.settings.shockwave_status != ShockwaveStatus.start_with:
+            if spoiler.settings.shockwave_status not in (ShockwaveStatus.start_with, ShockwaveStatus.vanilla):
                 bigListOfItemsToPlace.extend(ItemPool.ShockwaveTypeItems(spoiler.settings))
         if Types.Key in spoiler.settings.shuffled_location_types:
             bigListOfItemsToPlace.extend(ItemPool.KeysToPlace(spoiler.settings))

--- a/randomizer/Lists/CBLocations/AngryAztecCBLocations.py
+++ b/randomizer/Lists/CBLocations/AngryAztecCBLocations.py
@@ -1313,7 +1313,7 @@ ColoredBananaGroupList = [
         name="Llama Temple Water Corners",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.LlamaTemple,
-        logic=lambda l: l.CanLlamaSpit() and l.swim,
+        logic=lambda l: Events.AztecLlamaSpit in l.Events and l.swim,
         locations=[
             [5, 1.0, 2038, 211, 2689],
             [5, 1.0, 2410, 211, 2113],

--- a/randomizer/Lists/CBLocations/JungleJapesCBLocations.py
+++ b/randomizer/Lists/CBLocations/JungleJapesCBLocations.py
@@ -991,7 +991,7 @@ ColoredBananaGroupList = [
         name="Inside Free Diddy cage",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
         region=Regions.JungleJapesMain,
-        logic=lambda l: l.CanFreeDiddy(),
+        logic=lambda l: Events.JapesFreeKongOpenGates in l.Events,
         locations=[[5, 1.0, 1065, 858, 2608]],
     ),
     ColoredBananaGroup(

--- a/randomizer/Lists/PathHintTree.py
+++ b/randomizer/Lists/PathHintTree.py
@@ -35,7 +35,7 @@ def BuildPathHintTree(woth_paths: Dict[Locations, List[Locations]]) -> Dict[Loca
         # For each item in the path in reverse order - this ensures we find the most-direct parents of this child first
         for path_loc_id in reversed(path):
             # If we've seen this location in our traversal, it's not a direct parent of this node - obviously you're also not your own parent.
-            if path_loc_id not in seen_nodes and path_loc_id != woth_loc_id:
+            if path_loc_id not in seen_nodes and path_loc_id != woth_loc_id and path_loc_id in woth_paths.keys():
                 # Any node we haven't seen must be a direct parent of this node
                 node.parents.append(path_loc_id)
                 # Which means this is a child of that node as well

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -7,7 +7,7 @@ from randomizer.Enums.Levels import Levels
 from randomizer.Enums.Locations import Locations
 from randomizer.Enums.MinigameType import MinigameType
 from randomizer.Enums.Regions import Regions
-from randomizer.Enums.Settings import MinigameBarrels, CBRando
+from randomizer.Enums.Settings import FungiTimeSetting, MinigameBarrels, CBRando
 from randomizer.Enums.Transitions import Transitions
 from randomizer.Enums.Switches import Switches
 from randomizer.LogicClasses import (Event, LocationLogic, Region,
@@ -74,6 +74,8 @@ LogicRegions = {
         Event(Events.CavesKeyTurnedIn, lambda l: l.settings.auto_keys and l.CavesKey and l.HasFillRequirementsForLevel(Levels.HideoutHelm)),
         Event(Events.CastleKeyTurnedIn, lambda l: l.settings.auto_keys and l.CastleKey and l.HasFillRequirementsForLevel(Levels.HideoutHelm)),
         Event(Events.HelmKeyTurnedIn, lambda l: l.settings.auto_keys and l.HelmKey),
+        Event(Events.Night, lambda l: l.settings.fungi_time_internal in (FungiTimeSetting.night, FungiTimeSetting.dusk, FungiTimeSetting.progressive)),
+        Event(Events.Day, lambda l: l.settings.fungi_time_internal in (FungiTimeSetting.day, FungiTimeSetting.dusk, FungiTimeSetting.progressive)),
     ], [
         TransitionFront(Regions.Credits, lambda l: True),
         # Replace these with the actual starting region if we choose to randomize it

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -880,17 +880,22 @@ def toggle_item_rando(evt):
     enemy_drop_rando = document.getElementById("enemy_drop_rando")
     non_item_rando_warning = document.getElementById("non_item_rando_warning")
     shared_shop_warning = document.getElementById("shared_shop_warning")
+    kong_rando = document.getElementById("kong_rando")
     shops_in_pool = False
+    kongs_in_pool = False
     nothing_selected = True
     for option in item_rando_pool:
         if option.value == "shop":
             if option.selected:
                 shops_in_pool = True
-                break
+        if option.value == "kong":
+            if option.selected:
+                kongs_in_pool = True
         if option.selected:
             nothing_selected = False
     if nothing_selected:
         shops_in_pool = True
+        kongs_in_pool = True
     if js.document.getElementById("shuffle_items").checked:
         disabled = False
     try:
@@ -906,6 +911,7 @@ def toggle_item_rando(evt):
             enemy_drop_rando.checked = False
             non_item_rando_warning.removeAttribute("hidden")
             shared_shop_warning.removeAttribute("hidden")
+            kong_rando.removeAttribute("disabled")
         else:
             # Enable item rando modal, prevent shockwave/camera coupling, enable dropsanity, and enable smaller shops if it's in the pool
             selector.removeAttribute("disabled")
@@ -922,10 +928,14 @@ def toggle_item_rando(evt):
                 move_rando.setAttribute("disabled", "disabled")
                 smaller_shops.removeAttribute("disabled")
                 # Prevent UI breaking if Vanilla/Unlock All moves was selected before selection Shops in Item Rando
-                js.document.getElementById("training_barrels").removeAttribute("disabled")
                 js.document.getElementById("shockwave_status").removeAttribute("disabled")
                 js.document.getElementById("random_prices").removeAttribute("disabled")
-    except AttributeError:
+            if kongs_in_pool:
+                kong_rando.setAttribute("disabled", "disabled")
+                kong_rando.checked = True
+            else:
+                kong_rando.removeAttribute("disabled")
+    except AttributeError as e:
         pass
 
 
@@ -941,17 +951,22 @@ def item_rando_list_changed(evt):
     move_vanilla = document.getElementById("move_off")
     move_rando = document.getElementById("move_on")
     shared_shop_warning = document.getElementById("shared_shop_warning")
+    kong_rando = document.getElementById("kong_rando")
     shops_in_pool = False
+    kongs_in_pool = False
     nothing_selected = True
     for option in item_rando_pool:
         if option.value == "shop":
             if option.selected:
                 shops_in_pool = True
-                break
+        if option.value == "kong":
+            if option.selected:
+                kongs_in_pool = True
         if option.selected:
             nothing_selected = False
     if nothing_selected:
         shops_in_pool = True
+        kongs_in_pool = True
     if js.document.getElementById("shuffle_items").checked:
         item_rando_disabled = False
     if shops_in_pool and not item_rando_disabled:
@@ -976,6 +991,11 @@ def item_rando_list_changed(evt):
         move_rando.removeAttribute("disabled")
         smaller_shops.setAttribute("disabled", "disabled")
         smaller_shops.checked = False
+    if kongs_in_pool and not item_rando_disabled:
+        kong_rando.setAttribute("disabled", "disabled")
+        kong_rando.checked = True
+    else:
+        kong_rando.removeAttribute("disabled")
     plando_disable_arena_custom_locations(None)
     plando_disable_crate_custom_locations(None)
     plando_disable_fairy_custom_locations(None)

--- a/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
@@ -63,7 +63,7 @@
 | Behind stump in beehive area | 10 | `` | 
 | Above Melon Crate behind mountain | 5 | `` | 
 | Above melon crate behind boulder | 5 | `` | 
-| Inside Free Diddy cage | 5 | `l.CanFreeDiddy()` | 
+| Inside Free Diddy cage | 5 | `Events.JapesFreeKongOpenGates in l.Events` | 
 | Between starting vines (Donkey) | 5 | `l.vines or (l.advanced_platforming and l.isdonkey and (not l.isKrushaAdjacent(Kongs.donkey)))` | 
 | On top of slippery slope in BP cave (Lanky) | 5 | `l.handstand` | 
 | W3 bunches (Donkey) | 10 | `` | 
@@ -331,7 +331,7 @@
 | W1 (1 custom, 1 Lanky bunch) | 10 | `` | 
 | Behind and above llama | 10 | `` | 
 | All around Llama Temple (Donkey) | 15 | `` | 
-| Llama Temple Water Corners | 20 | `l.CanLlamaSpit() and l.swim` | 
+| Llama Temple Water Corners | 20 | `Events.AztecLlamaSpit in l.Events and l.swim` | 
 | To lava room (Tiny) | 3 | `` | 
 | To lava room (Tiny) | 2 | `` | 
 | On Tiny switches in lava room (Tiny) | 10 | `(l.CanSlamSwitch(Levels.AngryAztec, 1) or (l.twirl and l.advanced_platforming)) and l.istiny` | 


### PR DESCRIPTION
- Fixed some bad logic on a few CB groups
- Fixed an issue where a vanilla camera/shockwave would never succeed in the fill
- Fixed an issue where vanilla company coins might break the fill when calculating unhinted score
- Tweaked the UI to prevent Shuffle Kongs from being unselected while Kongs are in the item pool