### PR TITLE
no &

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -1012,6 +1012,10 @@ def compileHints(spoiler: Spoiler) -> bool:
         # If we're using progressive hints, put it on the last hint
         if spoiler.settings.enable_progressive_hints:
             hint_location = [hint for hint in hints if hint.level == Levels.CreepyCastle and hint.kong == Kongs.chunky][0]
+            if hint_location.hint_type == HintType.Plando:
+                hint_location = getRandomHintLocation()
+                if hint_location is None:
+                    raise Exception("Hint Plandomizer leaves no room for RequiredSlamHint")
         # Loop through locations looking for the slams - from prior calculations we can guarantee there are at least two in non-starting move locations
         slam_levels = []
         for id, location in spoiler.LocationList.items():

--- a/randomizer/Enums/HintRegion.py
+++ b/randomizer/Enums/HintRegion.py
@@ -140,7 +140,7 @@ HINT_REGION_PAIRING = {
     HintRegion.ForestCenterAndBeanstalk: "Forest Center and Beanstalk",
     HintRegion.MushroomExterior: "Giant Mushroom Exterior",
     HintRegion.MushroomInterior: "Giant Mushroom Insides",
-    HintRegion.OwlTree: "Owl Area",
+    HintRegion.OwlTree: "Owl Tree Area",
     HintRegion.Mills: "Forest Mills",
     # Caves
     HintRegion.MainCaves: "Main Caves Area",

--- a/randomizer/Lists/DoorLocations.py
+++ b/randomizer/Lists/DoorLocations.py
@@ -1,4 +1,4 @@
-"""Stores the data for each potential T&S and Wrinkly door location."""
+"""Stores the data for each potential TnS and Wrinkly door location."""
 
 from randomizer.Enums.DoorType import DoorType
 from randomizer.Enums.Events import Events
@@ -75,7 +75,7 @@ class DoorData:
                 # Disable non-main maps for now because of instance script/exit memes
                 self.door_type = [x for x in self.door_type if x != DoorType.dk_portal]
         if self.default_placed == DoorType.dk_portal:
-            # Disable T&S spawning here because of it being slightly bugged when exiting as DK/Chunky
+            # Disable TnS spawning here because of it being slightly bugged when exiting as DK/Chunky
             # Instantly re-activates the portal for some reason?
             # TODO: Figure out how to prevent this so we can remove this condition
             self.door_type = [x for x in self.door_type if x != DoorType.boss]
@@ -91,7 +91,7 @@ class DoorData:
         self.assigned_kong = kong
 
     def assignPortal(self, spoiler):
-        """Assign T&S Portal to slot."""
+        """Assign TnS Portal to slot."""
         self.placed = DoorType.boss
         portal_region = spoiler.RegionList[self.logicregion]
         boss_region_id = GetBossLobbyRegionIdForRegion(self.logicregion, portal_region)
@@ -195,7 +195,7 @@ door_locations = {
             group=2,
             moveless=False,
             placed=DoorType.boss,
-        ),  # T&S Door in Diddy Cave
+        ),  # TnS Door in Diddy Cave
         DoorData(
             name="Jungle Japes: Near Painting Room",
             map=Maps.JungleJapes,
@@ -204,7 +204,7 @@ door_locations = {
             group=3,
             placed=DoorType.boss,
             door_type=[DoorType.wrinkly, DoorType.dk_portal],
-        ),  # T&S Door in Near Painting Room. Ironically cannot be a T&S because the indicator is weird
+        ),  # TnS Door in Near Painting Room. Ironically cannot be a TnS because the indicator is weird
         DoorData(
             name="Jungle Japes: Fairy Cave",
             map=Maps.JungleJapes,
@@ -213,7 +213,7 @@ door_locations = {
             group=4,
             moveless=False,
             placed=DoorType.boss,
-        ),  # T&S Door in Fairy Cave
+        ),  # TnS Door in Fairy Cave
         DoorData(
             name="Jungle Japes: Next to Diddy Cage - right",
             map=Maps.JungleJapes,
@@ -363,14 +363,14 @@ door_locations = {
         DoorData(
             name="Jungle Japes: Outside Diddy Cave Switch - left",
             map=Maps.JungleJapes,
-            logicregion=Regions.JungleJapesMain,
+            logicregion=Regions.JungleJapesStart,
             location=[2133.0, 280.0, 421.0, 1.0],
             group=2,
         ),
         DoorData(
             name="Jungle Japes: Outside Diddy Cave Switch - right",
             map=Maps.JungleJapes,
-            logicregion=Regions.JungleJapesMain,
+            logicregion=Regions.JungleJapesStart,
             location=[2119.0, 280.0, 599.0, 180.0],
             group=2,
         ),
@@ -616,7 +616,7 @@ door_locations = {
             group=2,
             moveless=False,
             placed=DoorType.boss,
-        ),  # T&S Portal by Funky
+        ),  # TnS Portal by Funky
         DoorData(
             name="Angry Aztec: Near Cranky's",
             map=Maps.AngryAztec,
@@ -625,7 +625,7 @@ door_locations = {
             group=3,
             moveless=False,
             placed=DoorType.boss,
-        ),  # T&S Portal by Cranky
+        ),  # TnS Portal by Cranky
         DoorData(
             name="Angry Aztec: Near Candy's",
             map=Maps.AngryAztec,
@@ -633,7 +633,7 @@ door_locations = {
             location=[2268.343, 120.0, 448.669, 59.0],
             group=4,
             placed=DoorType.boss,
-        ),  # T&S Portal by Candy
+        ),  # TnS Portal by Candy
         DoorData(
             name="Angry Aztec: Near Snide's",
             map=Maps.AngryAztec,
@@ -642,7 +642,7 @@ door_locations = {
             group=2,
             moveless=False,
             placed=DoorType.boss,
-        ),  # T&S Portal by Snide
+        ),  # TnS Portal by Snide
         DoorData(
             name="Angry Aztec: Behind 5DT",
             map=Maps.AngryAztec,
@@ -651,7 +651,7 @@ door_locations = {
             group=5,
             moveless=False,
             placed=DoorType.boss,
-        ),  # T&S Portal behind 5DT
+        ),  # TnS Portal behind 5DT
         DoorData(
             name="Angry Aztec: Next to Candy - right",
             map=Maps.AngryAztec,
@@ -727,7 +727,7 @@ door_locations = {
         DoorData(
             name="Angry Aztec: Cranky Tunnel - Near Chunky Barrel - left",
             map=Maps.AngryAztec,
-            logicregion=Regions.AngryAztecMain,
+            logicregion=Regions.AngryAztecConnectorTunnel,
             location=[3182.5, 120.0, 1440.0, 41.0],
             group=7,
             moveless=False,
@@ -735,7 +735,7 @@ door_locations = {
         DoorData(
             name="Angry Aztec: Cranky Tunnel - Near Chunky Barrel - right",
             map=Maps.AngryAztec,
-            logicregion=Regions.AngryAztecMain,
+            logicregion=Regions.AngryAztecConnectorTunnel,
             location=[3358.0, 120.0, 1445.5, 318.5],
             group=7,
             moveless=False,
@@ -743,7 +743,7 @@ door_locations = {
         DoorData(
             name="Angry Aztec: Cranky Tunnel - Near Road to Cranky - left",
             map=Maps.AngryAztec,
-            logicregion=Regions.AngryAztecMain,
+            logicregion=Regions.AngryAztecConnectorTunnel,
             location=[3366.8, 120.0, 2032.0, 241.43],
             group=7,
             moveless=False,
@@ -751,7 +751,7 @@ door_locations = {
         DoorData(
             name="Angry Aztec: Cranky Tunnel - Near Road to Cranky - right",
             map=Maps.AngryAztec,
-            logicregion=Regions.AngryAztecMain,
+            logicregion=Regions.AngryAztecConnectorTunnel,
             location=[3166.25, 120.0, 2028.0, 118.5],
             group=7,
             moveless=False,
@@ -775,14 +775,14 @@ door_locations = {
         DoorData(
             name="Angry Aztec: Entrance Tunnel - next to Coconut Switch",
             map=Maps.AngryAztec,
-            logicregion=Regions.AngryAztecOasis,
+            logicregion=Regions.AztecTunnelBeforeOasis,
             location=[1514.0, 120.0, 1107.8, 4.8],
             group=8,
         ),
         DoorData(
             name="Angry Aztec: Entrance Tunnel - left (near the oasis end)",
             map=Maps.AngryAztec,
-            logicregion=Regions.AngryAztecOasis,
+            logicregion=Regions.AztecTunnelBeforeOasis,
             location=[1820.0, 120.0, 816.5, 19.0],
             group=8,
         ),
@@ -1048,7 +1048,7 @@ door_locations = {
             location=[1778.702, 1106.667, 1220.515, 357.0],
             group=2,
             placed=DoorType.boss,
-        ),  # T&S Portal in Arcade Room
+        ),  # TnS Portal in Arcade Room
         DoorData(
             name="Frantic Factory: Production Room",
             map=Maps.FranticFactory,
@@ -1056,16 +1056,16 @@ door_locations = {
             location=[381.573, 605.0, 1032.929, 45.0],
             group=3,
             placed=DoorType.boss,
-        ),  # T&S Portal in Production Room
+        ),  # TnS Portal in Production Room
         DoorData(
-            name="Frantic Factory: R&D",
+            name="Frantic Factory: R and D",
             map=Maps.FranticFactory,
             logicregion=Regions.RandD,
             location=[3827.127, 1264.0, 847.458, 222.0],
             group=4,
             moveless=False,
             placed=DoorType.boss,
-        ),  # T&S Portal in R&D
+        ),  # TnS Portal in R and D
         DoorData(
             name="Frantic Factory: Block Tower",
             map=Maps.FranticFactory,
@@ -1074,7 +1074,7 @@ door_locations = {
             group=5,
             moveless=False,
             placed=DoorType.boss,
-        ),  # T&S Portal in Block Tower Room
+        ),  # TnS Portal in Block Tower Room
         DoorData(
             name="Frantic Factory: Storage Room",
             map=Maps.FranticFactory,
@@ -1082,7 +1082,7 @@ door_locations = {
             location=[1176.912, 6.5, 472.114, 1.0],
             group=6,
             placed=DoorType.boss,
-        ),  # T&S Portal in Storage Room
+        ),  # TnS Portal in Storage Room
         DoorData(
             name="Frantic Factory: Behind Chunky's Toy Box - big",
             map=Maps.FranticFactory,
@@ -1257,7 +1257,7 @@ door_locations = {
         DoorData(
             name="Frantic Factory: Production Room - Next to Diddy's Switch",
             map=Maps.FranticFactory,
-            logicregion=Regions.BeyondHatch,
+            logicregion=Regions.LowerCore,
             location=[430.6, 0.0, 980.6, 45.0],
             group=3,
         ),
@@ -1449,7 +1449,7 @@ door_locations = {
             group=2,
             moveless=False,
             placed=DoorType.boss,
-        ),  # T&S Door Near Cranky's
+        ),  # TnS Door Near Cranky's
         DoorData(
             name="Gloomy Galleon: Deep Hole",
             map=Maps.GloomyGalleon,
@@ -1460,7 +1460,7 @@ door_locations = {
             placed=DoorType.boss,
             door_type=[DoorType.boss, DoorType.wrinkly],
             dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_lighthouse_gate) or s.settings.activate_all_bananaports == ActivateAllBananaports.all,
-        ),  # T&S Door in meme hole
+        ),  # TnS Door in meme hole
         DoorData(
             name="Gloomy Galleon: Behind 2DS",
             map=Maps.GloomyGalleon,
@@ -1471,7 +1471,7 @@ door_locations = {
             placed=DoorType.boss,
             door_type=[DoorType.boss, DoorType.wrinkly],
             dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_shipyard_area_gate) or s.settings.activate_all_bananaports == ActivateAllBananaports.all,
-        ),  # T&S Door behind 2DS
+        ),  # TnS Door behind 2DS
         DoorData(
             name="Gloomy Galleon: Behind Enguarde Door",
             map=Maps.GloomyGalleon,
@@ -1483,7 +1483,7 @@ door_locations = {
             placed=DoorType.boss,
             door_type=[DoorType.boss, DoorType.wrinkly],
             dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_lighthouse_gate) or s.settings.activate_all_bananaports == ActivateAllBananaports.all,
-        ),  # T&S Door behind Enguarde Door
+        ),  # TnS Door behind Enguarde Door
         DoorData(
             name="Gloomy Galleon: Cactus",
             map=Maps.GloomyGalleon,
@@ -1494,7 +1494,7 @@ door_locations = {
             placed=DoorType.boss,
             door_type=[DoorType.boss, DoorType.wrinkly],
             dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_shipyard_area_gate) or s.settings.activate_all_bananaports == ActivateAllBananaports.all,
-        ),  # T&S Door near Cactus
+        ),  # TnS Door near Cactus
         DoorData(
             name="Gloomy Galleon: In hallway to Shipyard - Tiny switch",
             map=Maps.GloomyGalleon,
@@ -1896,7 +1896,7 @@ door_locations = {
             placed=DoorType.boss,
             door_type=[DoorType.boss, DoorType.wrinkly],
             dk_portal_logic=lambda s: s.settings.fungi_time_internal in (FungiTimeSetting.dusk, FungiTimeSetting.progressive),
-        ),  # T&S Portal behind DK Barn
+        ),  # TnS Portal behind DK Barn
         DoorData(
             name="Fungi Forest: Beanstalk Area",
             map=Maps.FungiForest,
@@ -1909,7 +1909,7 @@ door_locations = {
             door_type=[DoorType.boss, DoorType.wrinkly],
             dk_portal_logic=lambda s: s.settings.fungi_time_internal in (FungiTimeSetting.dusk, FungiTimeSetting.progressive)
             and (isBarrierRemoved(s, RemovedBarriersSelected.forest_green_tunnel) or s.settings.activate_all_bananaports == ActivateAllBananaports.all),
-        ),  # T&S Portal in Beanstalk Area
+        ),  # TnS Portal in Beanstalk Area
         DoorData(
             name="Fungi Forest: Near Snide's",
             map=Maps.FungiForest,
@@ -1920,7 +1920,7 @@ door_locations = {
             placed=DoorType.boss,
             door_type=[DoorType.boss, DoorType.wrinkly],
             dk_portal_logic=lambda s: s.settings.fungi_time_internal in (FungiTimeSetting.dusk, FungiTimeSetting.progressive),
-        ),  # T&S Portal near Snide's
+        ),  # TnS Portal near Snide's
         DoorData(
             name="Fungi Forest: Top of Giant Mushroom",
             map=Maps.FungiForest,
@@ -1928,7 +1928,7 @@ door_locations = {
             location=[1171.791, 1250.0, 1236.572, 52.0],
             group=5,
             placed=DoorType.boss,
-        ),  # T&S Portal at Top of GMush
+        ),  # TnS Portal at Top of GMush
         DoorData(
             name="Fungi Forest: Owl Area",
             map=Maps.FungiForest,
@@ -1939,11 +1939,11 @@ door_locations = {
             placed=DoorType.boss,
             door_type=[DoorType.boss, DoorType.wrinkly],
             dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.forest_yellow_tunnel) or s.settings.activate_all_bananaports == ActivateAllBananaports.all,
-        ),  # T&S Portal near Owl Race
+        ),  # TnS Portal near Owl Race
         DoorData(
             name="Fungi Forest: On top of Cage outside Conveyor Belt",
             map=Maps.FungiForest,
-            logicregion=Regions.MillArea,
+            logicregion=Regions.ForestTopOfMill,
             location=[4312.0, 224.0, 3493.0, 134.82],
             group=4,
         ),
@@ -1971,7 +1971,7 @@ door_locations = {
         DoorData(
             name="Fungi Forest: Watermill Roof - tower",
             map=Maps.FungiForest,
-            logicregion=Regions.MillArea,
+            logicregion=Regions.ForestTopOfMill,
             location=[4444.0, 321.0, 3628.0, 316.0],
             rx=-4,
             group=4,
@@ -2162,7 +2162,7 @@ door_locations = {
         # DoorData(
         #     name="Fungi Forest: Inside the Mushroom - Along the Wall near Diddy's Kasplat",
         #     map=Maps.ForestGiantMushroom,
-        #     logicregion=Regions.MushroomUpper,
+        #     logicregion=Regions.MushroomMiddle,
         #     location=[396.0, 610.0, 929.0, 174.0],
         #     group=5,
         # ),
@@ -2317,7 +2317,7 @@ door_locations = {
             moveless=False,
             logic=lambda l: (l.isdiddy and l.jetpack) or l.CanMoonkick() or ((l.isdiddy or l.istiny or (l.islanky and not l.isKrushaAdjacent(Kongs.lanky))) and l.advanced_platforming) or l.phasewalk,
             placed=DoorType.boss,
-        ),  # T&S Portal on Rotating Room | Lanky can backflip onto the building from the window sill
+        ),  # TnS Portal on Rotating Room | Lanky can backflip onto the building from the window sill
         DoorData(
             name="Crystal Caves: Near Snide's",
             map=Maps.CrystalCaves,
@@ -2326,7 +2326,7 @@ door_locations = {
             group=3,
             moveless=False,
             placed=DoorType.boss,
-        ),  # T&S Portal near Snide's
+        ),  # TnS Portal near Snide's
         DoorData(
             name="Crystal Caves: Giant Boulder Room",
             map=Maps.CrystalCaves,
@@ -2335,7 +2335,7 @@ door_locations = {
             group=4,
             moveless=False,
             placed=DoorType.boss,
-        ),  # T&S Portal in Giant Boulder Room
+        ),  # TnS Portal in Giant Boulder Room
         DoorData(
             name="Crystal Caves: On Sprint Cabin",
             map=Maps.CrystalCaves,
@@ -2346,7 +2346,7 @@ door_locations = {
             moveless=False,
             logic=lambda l: (l.isdiddy and l.jetpack) or (l.islanky and l.balloon) or l.CanMoonkick() or l.phasewalk,
             placed=DoorType.boss,
-        ),  # T&S Portal on Sprint Cabin
+        ),  # TnS Portal on Sprint Cabin
         DoorData(
             name="Crystal Caves: Near 5DI",
             map=Maps.CrystalCaves,
@@ -2354,7 +2354,7 @@ door_locations = {
             location=[120.997, 50.167, 1182.974, 75.146],
             group=5,
             placed=DoorType.boss,
-        ),  # T&S Portal near 5DI (Custom but treated as vanilla)
+        ),  # TnS Portal near 5DI (Custom but treated as vanilla)
         DoorData(
             name="Crystal Caves: Outside Lanky's Cabin",
             map=Maps.CrystalCaves,
@@ -2839,7 +2839,7 @@ door_locations = {
             location=[1543.986, 1381.167, 1629.089, 3.0],
             group=2,
             placed=DoorType.boss,
-        ),  # T&S Portal by Greenhouse
+        ),  # TnS Portal by Greenhouse
         DoorData(
             name="Creepy Castle: Small Plateau",
             map=Maps.CreepyCastle,
@@ -2847,7 +2847,7 @@ door_locations = {
             location=[1759.241, 903.75, 1060.8, 138.0],
             group=3,
             placed=DoorType.boss,
-        ),  # T&S Portal by W2
+        ),  # TnS Portal by W2
         DoorData(
             name="Creepy Castle: Back of Castle",
             map=Maps.CreepyCastle,
@@ -2855,7 +2855,7 @@ door_locations = {
             location=[1704.55, 368.026, 1896.767, 4.0],
             group=4,
             placed=DoorType.boss,
-        ),  # T&S Portal around back
+        ),  # TnS Portal around back
         DoorData(
             name="Creepy Castle: Near Funky's",
             map=Maps.CastleLowerCave,
@@ -2863,7 +2863,7 @@ door_locations = {
             location=[1619.429, 200.0, 313.484, 299.0],
             group=5,
             placed=DoorType.boss,
-        ),  # T&S Portal in Crypt Hub
+        ),  # TnS Portal in Crypt Hub
         DoorData(
             name="Creepy Castle: Near Candy's",
             map=Maps.CastleUpperCave,
@@ -2871,7 +2871,7 @@ door_locations = {
             location=[1025.262, 300.0, 1960.308, 359.0],
             group=6,
             placed=DoorType.boss,
-        ),  # T&S Portal in Dungeon Tunnel
+        ),  # TnS Portal in Dungeon Tunnel
         DoorData(
             name="Creepy Castle: Next to Small Pool outside of the Big Tree",
             map=Maps.CreepyCastle,

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -362,7 +362,7 @@ LogicRegions = {
     ], [], [
         TransitionFront(Regions.IslesMain, lambda l: True),
         TransitionFront(Regions.IslesMainUpper, lambda l: l.twirl and l.istiny and l.advanced_platforming),
-        TransitionFront(Regions.IslesAboveWaterfall, lambda l: l.advanced_platforming and ((l.isdiddy or l.isdonkey or l.ischunky) and not l.isKrushaAdjacent(l.kong)) or (l.istiny and l.twirl)),
+        TransitionFront(Regions.IslesAboveWaterfall, lambda l: l.advanced_platforming and (((l.isdiddy or l.isdonkey or l.ischunky) and not l.isKrushaAdjacent(l.kong)) or (l.istiny and l.twirl))),
         TransitionFront(Regions.IslesAirspace, lambda l: Events.IslesDiddyBarrelSpawn in l.Events and l.jetpack and l.isdiddy),
         TransitionFront(Regions.FungiForestLobby, lambda l: True, Transitions.IslesMainToForestLobby),
         TransitionFront(Regions.DKIslesMedals, lambda l: True),
@@ -373,7 +373,7 @@ LogicRegions = {
     ], [], [
         TransitionFront(Regions.IslesMain, lambda l: True),
         TransitionFront(Regions.IslesMainUpper, lambda l: l.advanced_platforming),
-        TransitionFront(Regions.CabinIsle, lambda l: l.CanMoonkick() or (l.advanced_platforming and ((l.isdiddy or l.isdonkey or l.ischunky) and not l.isKrushaAdjacent(l.kong)) or (l.istiny and l.twirl))),
+        TransitionFront(Regions.CabinIsle, lambda l: l.CanMoonkick() or (l.advanced_platforming and (((l.isdiddy or l.isdonkey or l.ischunky) and not l.isKrushaAdjacent(l.kong)) or (l.istiny and l.twirl)))),
         TransitionFront(Regions.AztecLobbyRoof, lambda l: l.advanced_platforming and l.istiny and l.twirl),
         TransitionFront(Regions.DKIslesMedals, lambda l: True),
     ]),

--- a/wiki/article_markdown/custom_locations/CustomLocationsCoins.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsCoins.MD
@@ -389,7 +389,8 @@
 | Around high W4 | 5 | `` | 
 | Below pole to R&D | 5 | `` | 
 | Above pole to R&D | 5 | `` | 
-| On elevators to upper production room | 3 | `` | 
+| On elevators to upper production room | 2 | `` | 
+| On elevators to upper production room | 1 | `` | 
 | Behind a box in Block Tower room | 4 | `` | 
 | Alcoves in Block Tower Room | 4 | `` | 
 | Around the spinning section in Production Room | 4 | `` | 

--- a/wiki/article_markdown/custom_locations/CustomLocationsDoors.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsDoors.MD
@@ -114,7 +114,7 @@
 | Frantic Factory Lobby | Frantic Factory: Lobby - Low Right | Wrinkly | `` | 
 | Frantic Factory | Frantic Factory: Arcade Room | Boss, Dk_Portal, Wrinkly | `` | 
 | Frantic Factory | Frantic Factory: Production Room | Boss, Dk_Portal, Wrinkly | `` | 
-| Frantic Factory | Frantic Factory: R&D | Boss, Dk_Portal, Wrinkly | `` | 
+| Frantic Factory | Frantic Factory: R and D | Boss, Dk_Portal, Wrinkly | `` | 
 | Frantic Factory | Frantic Factory: Block Tower | Boss, Dk_Portal, Wrinkly | `` | 
 | Frantic Factory | Frantic Factory: Storage Room | Boss, Dk_Portal, Wrinkly | `` | 
 | Frantic Factory | Frantic Factory: Behind Chunky's Toy Box - big | Wrinkly | `(l.ischunky and l.punch and l.triangle and l.climbing) or l.CanAccessRNDRoom()` | 


### PR DESCRIPTION
- Removed an & from the hints
- Owl Area is now known as Owl Tree Area
- Door locations are now in the correct hint region.
- When plandomizing hints, with progressive hints enabled, the mandatory slam hint will now first try to pick a different hint slot, before throwing an error. Instead of overwriting your plandomized hint.