### PR TITLE
Prevent fast start off with some settings

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -3009,7 +3009,8 @@ def BlockCompletionOfLevelSet(settings: Settings, lockedLevels):
 
 def Generate_Spoiler(spoiler: Spoiler) -> Tuple[bytes, Spoiler]:
     """Generate a complete spoiler based on input settings."""
-    # Init logic vars with settings
+    # Check for settings incompatibilities
+    CheckForIncompatibleSettings(spoiler.settings)
     if spoiler.settings.wrinkly_hints == WrinklyHints.fixed_racing:
         ValidateFixedHints(spoiler.settings)
     # Reset LocationList for a new fill
@@ -3218,6 +3219,18 @@ def ValidateFixedHints(settings: Settings) -> None:
         raise Ex.SettingsIncompatibleException("Fixed hints require starting with exactly 2 Kongs.")
     if settings.enable_plandomizer and len(settings.plandomizer_dict["hints"]) > 5:
         raise Ex.SettingsIncompatibleException("Fixed hints are incompatible with more than 5 plandomized hints.")
+
+
+def CheckForIncompatibleSettings(settings: Settings) -> None:
+    """Check for known settings conflicts and throw an exception immediately."""
+    found_incompatibilities = ""
+    if not settings.fast_start_beginning_of_game:
+        if settings.shuffle_loading_zones == ShuffleLoadingZones.all:
+            found_incompatibilities += "Cannot turn off Fast Start with LZR. "
+        if settings.random_starting_region:
+            found_incompatibilities += "Cannot turn off Fast Start with a Random Starting Location. "
+    if found_incompatibilities != "":
+        raise Ex.SettingsIncompatibleException(found_incompatibilities)
 
 
 def DebugCheckAllReachable(spoiler: Spoiler, owned, what_just_got_placed):

--- a/templates/qualityoflife.html.jinja2
+++ b/templates/qualityoflife.html.jinja2
@@ -109,7 +109,12 @@
                 </div>
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip" title="Training Barrels complete, start with Simian Slam, spawn in DK Isles, Japes lobby entrance open.">
-                        <input class="form-check-input" type="checkbox" name="fast_start_beginning_of_game" display_name="Fast Start - Beginning of Game" value="True"/>
+                        <input class="form-check-input" 
+                                type="checkbox" 
+                                name="fast_start_beginning_of_game" 
+                                id="fast_start_beginning_of_game" 
+                                display_name="Fast Start - Beginning of Game" 
+                                value="True"/>
                         Fast Start - Beginning of Game
                     </label>
                 </div>

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -302,6 +302,7 @@
                         <input class="form-check-input"
                                 type="checkbox"
                                 name="random_starting_region"
+                                id="random_starting_region"
                                 display_name="Random Starting Location"
                                 value="True"/>
                         Random Starting Location

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -44,6 +44,7 @@ from ui.rando_options import (
     updateDoorOneNumAccess,
     updateDoorTwoNumAccess,
     updateWinConNumAccess,
+    validate_fast_start_status,
 )
 
 js.check_seed_info_tab()
@@ -89,4 +90,5 @@ disable_helm_hurry(None)
 disable_remove_barriers(None)
 disable_faster_checks(None)
 toggle_vanilla_door_rando(None)
+validate_fast_start_status(None)
 enable_plandomizer(None)

--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -508,6 +508,7 @@ def toggle_counts_boxes(event):
 @bind("change", "level_randomization")
 def change_level_randomization(evt):
     """Disable certain page flags depending on level randomization."""
+    validate_fast_start_status(evt)
     level = document.getElementById("level_randomization")
     boss_location = document.getElementById("boss_location_rando")
     boss_kong = document.getElementById("boss_kong_rando")
@@ -996,6 +997,19 @@ def item_rando_list_changed(evt):
     plando_disable_tns_custom_locations(None)
 
 
+@bind("click", "random_starting_region")
+def validate_fast_start_status(evt):
+    """Confirm that fast start is eligible to be disabled with the given settings."""
+    loading_zone_status = document.getElementById("level_randomization")
+    is_random_starting_region = document.getElementById("random_starting_region").checked
+    fast_start = document.getElementById("fast_start_beginning_of_game")
+    if is_random_starting_region or loading_zone_status.value in ("loadingzone", "loadingzonesdecoupled"):
+        fast_start.setAttribute("disabled", "disabled")
+        fast_start.checked = False
+    else:
+        fast_start.removeAttribute("disabled")
+
+
 def should_reset_select_on_preset(selectElement):
     """Return true if the element should be reset when applying a preset."""
     if js.document.querySelector("#nav-cosmetics").contains(selectElement):
@@ -1142,6 +1156,7 @@ def update_ui_states(event):
     toggle_medals_box(None)
     toggle_extreme_prices_option(None)
     toggle_vanilla_door_rando(None)
+    validate_fast_start_status(None)
     sliders = js.document.getElementsByClassName("pretty-slider")
     for s in range(len(sliders)):
         event = js.document.createEvent("HTMLEvents")


### PR DESCRIPTION
Gotta ban fast start off + (LZR or random starting location)
This setup leaves room to ban settings in both the front end and the back end if we know they'll cause problems