### PR TITLE
A small fix for dev, a giant fix for playerkind

### DIFF
--- a/ui/rando_options.py
+++ b/ui/rando_options.py
@@ -1005,7 +1005,7 @@ def validate_fast_start_status(evt):
     fast_start = document.getElementById("fast_start_beginning_of_game")
     if is_random_starting_region or loading_zone_status.value in ("loadingzone", "loadingzonesdecoupled"):
         fast_start.setAttribute("disabled", "disabled")
-        fast_start.checked = False
+        fast_start.checked = True
     else:
         fast_start.removeAttribute("disabled")
 


### PR DESCRIPTION
- Fixed a bug where enabling LZR, DLZR or Random Starting Location would force *disable* Fast Start, instead of force *enabling* it.