### PR TITLE
Fix switchsanity behavior when using plandomizer

### DIFF
--- a/ui/plando_validation.py
+++ b/ui/plando_validation.py
@@ -884,9 +884,17 @@ def enable_switch_plando(evt):
         switchElem = js.document.getElementById(f"plando_{switchEnum.name}_switch")
         if switchsanity == "all":
             mark_option_enabled(switchElem, ValidationError.switchsanity_not_enabled)
+            # If this switch is currently set to its vanilla value, change it
+            # to "Randomize".
+            if switchElem.value == SwitchVanillaMap[switchEnum.name]:
+                switchElem.value = ""
         elif switchEnum in [Switches.IslesHelmLobbyGone, Switches.IslesMonkeyport]:
             if switchsanity == "helm_access":
                 mark_option_enabled(switchElem, ValidationError.switchsanity_not_enabled)
+                # If this switch is currently set to its vanilla value, change
+                # it to "Randomize".
+                if switchElem.value == SwitchVanillaMap[switchEnum.name]:
+                    switchElem.value = ""
             else:
                 errString = 'To set this switch, Switchsanity must be set to "All" or "Helm Access Only".'
                 mark_option_disabled(switchElem, ValidationError.switchsanity_not_enabled, errString, SwitchVanillaMap[switchEnum.name])


### PR DESCRIPTION
Previously, if the user turned Switchsanity on when using the plandomizer, all of the switches would default to their vanilla settings. Now, turning on Switchsanity will set the corresponding switches to "Randomize" to match expected behavior. (This works correctly for all three Switchsanity settings.)