### PR TITLE
Add climbing to the reverse PlandoItems map

### DIFF
--- a/randomizer/Enums/Plandomizer.py
+++ b/randomizer/Enums/Plandomizer.py
@@ -235,6 +235,7 @@ PlandoItemToItemMap = {
     PlandoItems.Swim: Items.Swim,
     PlandoItems.Oranges: Items.Oranges,
     PlandoItems.Barrels: Items.Barrels,
+    PlandoItems.Climbing: Items.Climbing,
     PlandoItems.BaboonBlast: Items.BaboonBlast,
     PlandoItems.StrongKong: Items.StrongKong,
     PlandoItems.GorillaGrab: Items.GorillaGrab,


### PR DESCRIPTION
I suspect this might have something to do with a plando bug regarding climbing.