### PR TITLE
Improve hint flexibility

### DIFF
--- a/randomizer/Enums/HintType.py
+++ b/randomizer/Enums/HintType.py
@@ -28,6 +28,6 @@ class HintType(IntEnum):
     ForeseenPathless = auto()
     Multipath = auto()
     RegionItemCount = auto()
-    ItemRegion = auto()
+    ItemHinting = auto()
     Plando = auto()
     RequiredSlamHint = auto()

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -10,7 +10,7 @@ import js
 import randomizer.ItemPool as ItemPool
 import randomizer.Lists.Exceptions as Ex
 import randomizer.ShuffleExits as ShuffleExits
-from randomizer.CompileHints import compileHints, compileMicrohints, compileSpoilerHints
+from randomizer.CompileHints import compileHints, compileMicrohints, compileSpoilerHints, getDoorRestrictionsForItem
 from randomizer.Enums.Events import Events
 from randomizer.Enums.Items import Items
 from randomizer.Enums.Kongs import GetKongs, Kongs
@@ -758,6 +758,10 @@ def ParePlaythrough(spoiler: Spoiler, PlaythroughLocations: List[Sphere]) -> Non
                 location.PlaceItem(spoiler, item)
                 # Make note of what hints are accessible without this WotH candidate in case it gets hinted later
                 AccessibleHintsForLocation[locationId] = spoiler.LogicVariables.Hints.copy()
+                # Some items have inherent door restrictions depending on the settings
+                restrictions = getDoorRestrictionsForItem(spoiler, item)
+                if len(restrictions) > 0:
+                    AccessibleHintsForLocation[locationId] = [hint for hint in AccessibleHintsForLocation[locationId] if hint in restrictions]
     # Record that dictionary of hint access for when we compile hints
     spoiler.accessible_hints_for_location = AccessibleHintsForLocation
     # Check if there are any empty spheres, if so remove them


### PR DESCRIPTION
- Plando can now properly plando all 35 hints without fear of hint failures
- Item hinting hints are now placed by the number of hint doors they have available. This will generally put hints to accessible items on accessible hints more often.
- Item hinting hints now include shopkeepers
- Progressive hints now have restrictions on hints to keys that unlock levels to provide a more consistent flow of hint knowledge. The restrictions are as follows:
  - In SLO, Hints to Keys 1/2 will be found by pack 5
  - In SLO, Hints to Keys 3/4 will be found by pack 7
  - In SLO, Hints to Key 5 will be found by pack 8
  - In CLO, Hints to Keys 1, 2, 4, and 5 will be found by pack 8
  - Hints to Kongs are unchanged (by pack 5)
  - This will (attempt to) affect WotH hint placement too!