### PR TITLE
minor fixes

### DIFF
--- a/randomizer/Lists/CBLocations/DKIslesCBLocations.py
+++ b/randomizer/Lists/CBLocations/DKIslesCBLocations.py
@@ -315,7 +315,7 @@ ColoredBananaGroupList = [
         name="Tree in training area",
         konglist=[Kongs.tiny],
         region=Regions.TrainingGrounds,
-        logic=lambda l: (l.istiny and l.twirl),
+        logic=lambda l: l.climbing and (l.istiny and l.twirl),
         locations=[
             [5, 1.0, 810, 244, 710],
         ],

--- a/randomizer/Lists/CustomLocations.py
+++ b/randomizer/Lists/CustomLocations.py
@@ -1278,7 +1278,7 @@ CustomLocations = {
         CustomLocation(map=Maps.FranticFactory, name="Past Tiny Production Bonus", x=400, y=858.5, z=1615, max_size=32, logic_region=Regions.UpperCore, logic=lambda l: l.twirl and l.tiny, group=1),
         CustomLocation(map=Maps.FranticFactory, name="On Production outside box", x=988, y=322, z=1175, max_size=40, logic_region=Regions.UpperCore, group=1),
         CustomLocation(map=Maps.FranticFactory, name="Storage Room Corner", x=974, y=66.5, z=908, max_size=32, logic_region=Regions.BeyondHatch, group=4),
-        CustomLocation(map=Maps.FranticFactory, name="Cranky and Candy Room", x=316, y=165, z=805, max_size=64, logic_region=Regions.BeyondHatch, group=4),
+        CustomLocation(map=Maps.FranticFactory, name="Cranky and Candy Room", x=316, y=165, z=805, max_size=64, logic_region=Regions.BeyondHatch, group=4, banned_types=[LocationTypes.MelonCrate]),
         CustomLocation(
             map=Maps.FranticFactory, name="Near Candy", x=319.03137207031, y=165.5, z=596.36285400391, rot_y=359, max_size=64, logic_region=Regions.BeyondHatch, vanilla_crate=True, group=4
         ),

--- a/randomizer/Lists/DoorLocations.py
+++ b/randomizer/Lists/DoorLocations.py
@@ -220,6 +220,7 @@ door_locations = {
             logicregion=Regions.JapesHillTop,
             location=[896.0, 852.0, 2427.0, 90.75],
             group=5,
+            moveless=False,
         ),
         DoorData(
             name="Alcove Above Diddy Tunnel - right",
@@ -339,6 +340,7 @@ door_locations = {
             logicregion=Regions.JapesHill,
             location=[1928.0, 520.0, 2283.4, 140.0],
             group=5,
+            moveless=False,
         ),
         DoorData(
             name="Next to Lanky's Painting Room - left",
@@ -795,7 +797,7 @@ door_locations = {
             group=2,
             moveless=False,
             logic=lambda l: l.isdonkey and l.strongKong,
-            door_type=[DoorType.wrinkly, DoorType.dk_portal],
+            door_type=[DoorType.wrinkly],
         ),
         DoorData(
             name="Near Tag Barrel near Snides - strong kong",
@@ -1047,6 +1049,7 @@ door_locations = {
             logicregion=Regions.FactoryArcadeTunnel,
             location=[1778.702, 1106.667, 1220.515, 357.0],
             group=2,
+            moveless=False,
             placed=DoorType.boss,
         ),  # TnS Portal in Arcade Room
         DoorData(
@@ -1268,6 +1271,7 @@ door_locations = {
             location=[1652.5, 1106.0, 1253.75, 43.0],
             scale=0.8669,
             group=2,
+            moveless=False,
         ),
         DoorData(
             name="Block Tower Room - Next to Tiny Barrel",
@@ -2013,6 +2017,7 @@ door_locations = {
             logicregion=Regions.MillArea,
             location=[3240.033, 268.5, 3718.017, 178.0],
             group=4,
+            moveless=False,
             logic=lambda l: Events.Day in l.Events,
             placed=DoorType.boss,
             door_type=[DoorType.boss, DoorType.wrinkly],
@@ -2048,6 +2053,7 @@ door_locations = {
             logicregion=Regions.ForestTopOfMill,
             location=[4312.0, 224.0, 3493.0, 134.82],
             group=4,
+            moveless=False,
         ),
         DoorData(
             name="Watermill - front - right",

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -1176,6 +1176,7 @@ class Settings:
         phases = [Maps.KroolDonkeyPhase, Maps.KroolDiddyPhase, Maps.KroolLankyPhase, Maps.KroolTinyPhase, Maps.KroolChunkyPhase]
         if self.krool_in_boss_pool:
             phases.extend([Maps.JapesBoss, Maps.AztecBoss, Maps.FactoryBoss, Maps.GalleonBoss, Maps.FungiBoss, Maps.CavesBoss, Maps.CastleBoss])
+        possible_phases = phases.copy()
         if self.krool_phase_order_rando:
             random.shuffle(phases)
         if self.krool_random:
@@ -1197,9 +1198,7 @@ class Settings:
             # Fill cleared out phases with available phases
             for i in range(len(phases)):
                 if phases[i] is None:
-                    available_phases = [
-                        map_id for map_id in [Maps.KroolDonkeyPhase, Maps.KroolDiddyPhase, Maps.KroolLankyPhase, Maps.KroolTinyPhase, Maps.KroolChunkyPhase] if map_id not in planned_phases
-                    ]
+                    available_phases = [map_id for map_id in possible_phases if map_id not in planned_phases]
                     phases[i] = random.choice(available_phases)
                     planned_phases.append(phases[i])
             for i in range(len(phases)):

--- a/randomizer/ShufflePorts.py
+++ b/randomizer/ShufflePorts.py
@@ -135,7 +135,7 @@ def isCustomLocationValid(spoiler, location: CustomLocation, map_id: Maps, level
             return False
     if spoiler.settings.bananaport_placement_rando == ShufflePortLocations.vanilla_only:
         if not location.vanilla_port:
-            return False
+            return LocationTypes.Bananaport not in location.banned_types
     if spoiler.settings.bananaport_placement_rando == ShufflePortLocations.half_vanilla or (
         spoiler.settings.bananaport_placement_rando == ShufflePortLocations.on and not spoiler.settings.useful_bananaport_placement
     ):

--- a/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
@@ -1516,7 +1516,7 @@
 | Rear tunnel | 5 |  | 
 | Around rear dirt patch | 10 |  | 
 | Exit tunnel | 10 |  | 
-| Tree in training area | 5 | `(l.istiny and l.twirl)` | 
+| Tree in training area | 5 | `l.climbing and (l.istiny and l.twirl)` | 
 | Around treehouse tree | 10 |  | 
 | Training area | 5 |  | 
 | Above the lake | Balloon |  | 

--- a/wiki/article_markdown/custom_locations/CustomLocationsDoors.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsDoors.MD
@@ -80,7 +80,7 @@
 | Angry Aztec | 5Door Temple Staircase - back | Boss, Dk_Portal, Wrinkly |  | 
 | Angry Aztec | Entrance Tunnel - next to Coconut Switch | Boss, Dk_Portal, Wrinkly |  | 
 | Angry Aztec | Entrance Tunnel - left (near the oasis end) | Boss, Dk_Portal, Wrinkly |  | 
-| Angry Aztec | in the sealed quicksand tunnel | Wrinkly, Dk_Portal | `l.isdonkey and l.strongKong` | 
+| Angry Aztec | in the sealed quicksand tunnel | Wrinkly | `l.isdonkey and l.strongKong` | 
 | Angry Aztec | Near Tag Barrel near Snides - strong kong | Wrinkly | `l.isdonkey and l.strongKong` | 
 | Aztec Llama Temple | In Face Matching Game - right | Wrinkly | `(l.islanky and l.grape) or l.phasewalk` | 
 | Aztec Llama Temple | In Face Matching Game - left | Wrinkly | `(l.islanky and l.grape) or l.phasewalk` | 

--- a/wiki/article_markdown/custom_locations/CustomLocationsMiscellaneous.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsMiscellaneous.MD
@@ -146,7 +146,7 @@
 | Frantic Factory | Past Tiny Production Bonus |  | `l.twirl and l.tiny, group=1)` | 
 | Frantic Factory | On Production outside box |  |  | 
 | Frantic Factory | Storage Room Corner |  |  | 
-| Frantic Factory | Cranky and Candy Room |  |  | 
+| Frantic Factory | Cranky and Candy Room | MelonCrate |  | 
 | Frantic Factory | Near Candy |  |  | 
 | Frantic Factory | Dark Room Corner |  | `(l.punch and l.chunky) or l.phasewalk, group=4` | 
 | Frantic Factory | Arcade Room Bench |  |  | 


### PR DESCRIPTION
- Fixed a bug preventing seeds with vanilla bananaport location shuffle from generating
- Fixed plando k.rool phases resolving to exclusively k.rool phases when set to Random (regardless of k.rool phases in boss pool setting)
- Fixed a CB group in Training Grounds not requiring climbing when it should
- Fixed the Aztec Level entrance spawning on quicksand
- Fixed another location where a meloncrate could block autowalking out of a tns portal