### PR TITLE
Quick fix

### DIFF
--- a/randomizer/Patching/ApplyLocal.py
+++ b/randomizer/Patching/ApplyLocal.py
@@ -261,9 +261,6 @@ async def patching_response(data, from_patch_gen=False, lanky_from_history=False
             ROM_COPY.seek(sav + 0xC3)
             ROM_COPY.writeMultipleBytes(int(settings.crosshair_outline), 1)
 
-            ROM_COPY.seek(sav + 0x114)
-            ROM_COPY.writeMultipleBytes(int(settings.troff_brighten), 1)
-
             patchAssemblyCosmetic(ROM_COPY, settings)
             music_data, music_names = randomize_music(settings)
             music_text = []

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -432,7 +432,7 @@ class Settings:
         # Not making these a series of settings that can be toggled by the user yet.
         # If people want to be able to toggle this, we can make a simple UI switch and the back-end has already been handled appropriately
         self.sprint_barrel_requires_sprint = True
-        self.fix_lanky_tiny_prod = False
+        self.fix_lanky_tiny_prod = True
 
         self.chaos_blockers = False
 


### PR DESCRIPTION
- Removes a reference that sets the byte that's being used by the lanky/tiny prod feature
- Enables lanky/tiny prod spawning feature. Currently there's no option for this as the poll was heavily skewed on the side of liking it (73% vs. 27%). But, we'll likely add it to some form of option later on