### PR TITLE
Unbork scouring hints

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1072,7 +1072,7 @@ def CalculateFoolish(spoiler: Spoiler, WothLocations: List[Union[Locations, int]
             if bossLocation.item in MajorItems:
                 nonHintableNames.add(region.hint_name)
         # Ban shops from region count hinting. These are significantly worse regions to hint than any others.
-        if region.isShopRegion() and region.hint_name not in neverHintableNames:
+        if not region.isShopRegion() and region.hint_name not in neverHintableNames:
             # Count the number of region count hintable items in the region (again, ignore training moves)
             regionItemCount = sum(1 for loc in locations if loc.type not in (Types.TrainingBarrel, Types.PreGivenMove) and loc.item in regionCountHintableItems)
             if regionItemCount > 0:

--- a/static/presets/preset_files.json
+++ b/static/presets/preset_files.json
@@ -21,7 +21,7 @@
   {
     "name": "Balanced LZR",
     "description": "Preset focused on making loading zone randomizer seeds with reduced (but far from zero) chaos.",
-    "settings_string": "bKEIhEMhTHRBKlsa58VZXZhBEQEnAI9D6oGhEMiEqWxrnwH4jR6XL4huKcrSxO9TTghQAdo9IFBiMhjoStwFILdT2+BfgJJANQyiaoVYrBWiuAyC6ywUAdACDADqAgcAdgGEADuBAkAeAKFADyBgsAegOGAChDUB7AFuADKkQoqGclSUpWWzJcklG8COTtFpFwU/RUxYoExFAFetccjdqv99kUDkO5mLXkRQBms2ZRJFgAXGAAXGgATHAATHgAPagAPIAALIgAHJAAPJgALKAAHbAAWpy5Q5LhU6YUEX0CclggwwlVOZjaYy0LSuWF4K0OKC2GjIqBOLDATBgRjQpjinliikyIz4ADoBSgF0AKoBLgIbOAA"
+    "settings_string": "bKEIhEMhTHRBKlsa58VZXZhBEQEnAI9D6oGhEMiEqWxrnwH4jR6XL4huKcrSxO9TTghQAdo9IFBiMhjoStwFILdT2+BfgJJANQyiaoVYrBWiuAyC6ywUAdACDADqAgcAdgGEADuBAkAeAKFADyBgsAegOGAGCCFCGoD2ALcAGVIhRUM5KkpSstmS5JKN4EcnaLSLgp+ipixQJiKAK9a45G7Vf77IoHIdzMWvIigDNZsyiSLAAuMAAuNAAmOAAmPAAe1AAeQAAWRAAOSAAeTAAWUAAO2AAtTFyhyXCp0woIvoE5LBBhhKqczG0xloWlcsLwVocUFsNGRUCcWGAmDAjGhTHFPLFFJkRnwAHQClALoAVQCXAgwNnAA"
   },
   {
     "name": "No Style, All Keys",

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -34,7 +34,7 @@ with open("static/presets/preset_files.json", "r") as file:
 # Add a custom preset for testing
 # If we're not running on github actions, add the custom preset
 if not os.environ.get("GITHUB_ACTIONS"):
-    valid_presets.append(("Custom", "bKEHhEMhTHSpbGufFWUIGiA9HSLGAQ3EGWsQgvXz+AbPHwwmjnd1K9lZmcU2dWxfCnA+qBoRDIhKlsa58B+I0eu0uXxCnLE2nBCgKPSA6K01fAUgt1PX4EkAyaKE0SMgusllgoA6AEGAHUBA4A7AMIAHcCBIA8AUKAHkDBYA9AcMAFCGnj2yFI9RUM5alpTLm0W8DODo9Rbgp+iuiwCJ6KAK9a45G7Vf77IoHMWIoAzZ5EkWABMYABMaAA8cAA8eAAsgAAsiAAckAAcmAAcoAAanLlDkuFTphCSCL6BOSDDCVU5mNpjBxaFpXLArQ5bDQnFgqVBgJgwIxIUxxTSeRSZEalAFUAlwEMnAA"))
+    valid_presets.append(("Custom", "bKEIhEMhTHRBKlsa58VZXZhBEQEnAI9D6oGhEMiEqWxrnwH4jR6XL4huKcrSxO9TTghQAdo9IFBiMhjoStwFILdT2+BfgJJANQyiaoVYrBWiuAyC6ywUAdACDADqAgcAdgGEADuBAkAeAKFADyBgsAegOGAGCCFCGoD2ALcAGVIhRUM5KkpSstmS5JKN4EcnaLSLgp+ipixQJiKAK9a45G7Vf77IoHIdzMWvIigDNZsyiSLAAuMAAuNAAmOAAmPAAe1AAeQAAWRAAOSAAeTAAWUAAO2AAtTlyhyXCp0woIvoE5LBBhhKqczG0xloWlcsLwVocUFsNGRUCcWGAmDAjGhTHFPLFFJkRnwAHQClALoAVQCXAgwNnAA"))
 
 
 @parameterized_class(('name', 'settings_string'), valid_presets)
@@ -43,7 +43,7 @@ class TestSpoiler(unittest.TestCase):
     def test_settings_string(self):
         """Confirm that settings strings decryption is working and generate a spoiler log with it."""
         # The settings string is defined from the preset_files.json file
-        self.settings_string = "bKEIhEMhTHRBKlsa58Z2rK7MIEw4Kv3LYRjK0SEvAI9HRDHuIQXr5/ADCaLinVCnA+PxGj0uXxDcWa206MSvY04IUFR6QHCQx4OUBSCnt8C/ASSAahlE1QqxWCtFcBkF5kssFAXQAgwE6gIHA3YBhAI7gQJBXgChQM8gYLB3oDhgRgggNMnsyVG3ACZSAUVDOKpSU7LZouaS6RcFPgVsWARMBQCXrXHI3ar/fZFA5DuZi19EUAZrNnk9scSRYAFxgAFxoAExwAEx4AD2oADyAACyIAByQADyYACygAB2wAFqcuUOS4VAoNTmNaA4tC03FcsLwVocUFsNFATiwwEwYEY0EVTHFFJkRnwAVAClALoAbwBVAJcFCgwNIyycAA"
+        # self.settings_string = "bKEIhEMhTHRBKlsa58Z2rK7MIEw4Kv3LYRjK0SEvAI9HRDHuIQXr5/ADCaLinVCnA+PxGj0uXxDcWa206MSvY04IUFR6QHCQx4OUBSCnt8C/ASSAahlE1QqxWCtFcBkF5kssFAXQAgwE6gIHA3YBhAI7gQJBXgChQM8gYLB3oDhgRgggNMnsyVG3ACZSAUVDOKpSU7LZouaS6RcFPgVsWARMBQCXrXHI3ar/fZFA5DuZi19EUAZrNnk9scSRYAFxgAFxoAExwAEx4AD2oADyAACyIAByQADyYACygAB2wAFqcuUOS4VAoNTmNaA4tC03FcsLwVocUFsNFATiwwEwYEY0EVTHFFJkRnwAVAClALoAbwBVAJcFCgwNIyycAA"
         settings_dict = decrypt_settings_string_enum(self.settings_string)
         settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
 


### PR DESCRIPTION
Fixed an issue where scouring hints would only hint shop regions instead of only NOT-shop regions
Updated BLZR - Climbing returns as a starting move and the Extra microhints are removed