### PR TITLE
Seed gen fixes

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1773,8 +1773,8 @@ def Fill(spoiler: Spoiler) -> None:
     #     or Types.Key in spoiler.settings.shuffled_location_types
     # ):
     #     preplaced_items.extend(FillHelmLocations(spoiler, placed_types.copy(), preplaced_items))
-    if spoiler.settings.extreme_debugging:
-        DebugCheckAllReachable(spoiler, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types, placed_items=preplaced_items), "things in Helm")
+    # if spoiler.settings.extreme_debugging:
+    #     DebugCheckAllReachable(spoiler, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types, placed_items=preplaced_items), "things in Helm")
 
     # If keys are shuffled in the pool we want to ensure an item is on every boss
     # This is to support broader settings that rely on boss kills and to enable reads on the boss fill algorithm

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -1763,16 +1763,16 @@ def Fill(spoiler: Spoiler) -> None:
     if spoiler.settings.extreme_debugging:
         DebugCheckAllReachable(spoiler, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types, placed_items=preplaced_items), "Miscellaneous Items")
 
-    # Now we place the (generally) filler items
-    # If Helm is having locations shuffled and we're shuffling GBs, we have to fill Helm now.
-    # This is because GBs can't be in Helm, so we might run out of locations to place them if these spots aren't filled
-    if Types.Banana in spoiler.settings.shuffled_location_types and (
-        Types.Medal in spoiler.settings.shuffled_location_types
-        or Types.Crown in spoiler.settings.shuffled_location_types
-        or Types.Fairy in spoiler.settings.shuffled_location_types
-        or Types.Key in spoiler.settings.shuffled_location_types
-    ):
-        preplaced_items.extend(FillHelmLocations(spoiler, placed_types.copy(), preplaced_items))
+    # # Now we place the (generally) filler items
+    # # If Helm is having locations shuffled and we're shuffling GBs, we have to fill Helm now.
+    # # This is because GBs can't be in Helm, so we might run out of locations to place them if these spots aren't filled
+    # if Types.Banana in spoiler.settings.shuffled_location_types and (
+    #     Types.Medal in spoiler.settings.shuffled_location_types
+    #     or Types.Crown in spoiler.settings.shuffled_location_types
+    #     or Types.Fairy in spoiler.settings.shuffled_location_types
+    #     or Types.Key in spoiler.settings.shuffled_location_types
+    # ):
+    #     preplaced_items.extend(FillHelmLocations(spoiler, placed_types.copy(), preplaced_items))
     if spoiler.settings.extreme_debugging:
         DebugCheckAllReachable(spoiler, ItemPool.GetItemsNeedingToBeAssumed(spoiler.settings, placed_types, placed_items=preplaced_items), "things in Helm")
 

--- a/randomizer/ShuffleBosses.py
+++ b/randomizer/ShuffleBosses.py
@@ -351,6 +351,7 @@ def ShuffleBossesBasedOnOwnedItems(spoiler, ownedKongs: dict, ownedMoves: dict):
                 chosenBoss = random.choice(expandedBossOptions)
                 if chosenBoss in possibleEndgameBossSwaps:
                     spoiler.settings.krool_order.remove(chosenBoss)
+                    updateKRoolSettings(spoiler, chosenBoss)
             else:
                 # This is likely limited to lava water shenanigans
                 raise BossOutOfLocationsException("Fill has no valid boss placement combinations.")
@@ -375,6 +376,7 @@ def ShuffleBossesBasedOnOwnedItems(spoiler, ownedKongs: dict, ownedMoves: dict):
         possibleBosses = [map for map in getBosses(spoiler.settings) if map not in placedBossMaps and map not in spoiler.settings.krool_order]
         newEndgameBoss = random.choice(possibleBosses)
         spoiler.settings.krool_order.append(newEndgameBoss)
+        updateKRoolSettings(spoiler, newEndgameBoss)
         random.shuffle(spoiler.settings.krool_order)
         # UHHHH does this fuck with kongs assigned to phases? SURE HOPE NOT!
     newBossMaps = [None, None, None, None, None, None, None]
@@ -465,3 +467,31 @@ def CorrectBossKongLocations(spoiler):
     spoiler.LocationList[Locations.ForestKey].kong = spoiler.settings.boss_kongs[4]
     spoiler.LocationList[Locations.CavesKey].kong = spoiler.settings.boss_kongs[5]
     spoiler.LocationList[Locations.CastleKey].kong = spoiler.settings.boss_kongs[6]
+
+
+def updateKRoolSettings(spoiler, phase):
+    """Make sure the settings match the phases in the K. Rool order."""
+    if phase == Maps.KroolDonkeyPhase:
+        spoiler.settings.krool_donkey = not spoiler.settings.krool_donkey
+    elif phase == Maps.KroolDiddyPhase:
+        spoiler.settings.krool_diddy = not spoiler.settings.krool_diddy
+    elif phase == Maps.KroolLankyPhase:
+        spoiler.settings.krool_lanky = not spoiler.settings.krool_lanky
+    elif phase == Maps.KroolTinyPhase:
+        spoiler.settings.krool_tiny = not spoiler.settings.krool_tiny
+    elif phase == Maps.KroolChunkyPhase:
+        spoiler.settings.krool_chunky = not spoiler.settings.krool_chunky
+    elif phase == Maps.JapesBoss:
+        spoiler.settings.krool_dillo1 = not spoiler.settings.krool_dillo1
+    elif phase == Maps.AztecBoss:
+        spoiler.settings.krool_dog1 = not spoiler.settings.krool_dog1
+    elif phase == Maps.FactoryBoss:
+        spoiler.settings.krool_madjack = not spoiler.settings.krool_madjack
+    elif phase == Maps.GalleonBoss:
+        spoiler.settings.krool_pufftoss = not spoiler.settings.krool_pufftoss
+    elif phase == Maps.FungiBoss:
+        spoiler.settings.krool_dog2 = not spoiler.settings.krool_dog2
+    elif phase == Maps.CavesBoss:
+        spoiler.settings.krool_dillo2 = not spoiler.settings.krool_dillo2
+    elif phase == Maps.CastleBoss:
+        spoiler.settings.krool_kutout = not spoiler.settings.krool_kutout

--- a/randomizer/ShuffleDoors.py
+++ b/randomizer/ShuffleDoors.py
@@ -285,7 +285,7 @@ def ShuffleVanillaDoors(spoiler):
                 vanilla_door_indexes.append(door_index)
         random.shuffle(vanilla_door_indexes)
         # One random vanilla T&S per level is locked to being a T&S
-        locked_tns_options = [idx for idx in vanilla_door_indexes if door_locations[level][idx].default_placed == DoorType.boss and door_locations[level][idx].door_type != "wrinkly"]
+        locked_tns_options = [idx for idx in vanilla_door_indexes if door_locations[level][idx].default_placed == DoorType.boss and DoorType.boss in door_locations[level][idx].door_type]
         locked_tns_index = random.choice(locked_tns_options)
         locked_tns = door_locations[level][locked_tns_index]
         locked_tns.assignPortal(spoiler)

--- a/randomizer/ShuffleExits.py
+++ b/randomizer/ShuffleExits.py
@@ -370,7 +370,12 @@ def GenerateLevelOrderUnrestricted(settings):
         unplacedLevels.remove(Levels.HideoutHelm)
     for i in range(len(newLevelOrder.keys())):
         if newLevelOrder[i + 1] is None:
-            newLevelOrder[i + 1] = random.choice(unplacedLevels)
+            # Helm can't be in levels 1 or 2 in Simple Level Order
+            if not settings.hard_level_progression and i < 2:
+                validLevels = [x for x in unplacedLevels if x != Levels.HideoutHelm]
+            else:
+                validLevels = unplacedLevels
+            newLevelOrder[i + 1] = random.choice(validLevels)
             unplacedLevels.remove(newLevelOrder[i + 1])
     return newLevelOrder
 


### PR DESCRIPTION
- Fixed K. Rool logic using the wrong phases.
- Removed the "Unable to fill Helm" error. We're no longer filling Helm first.
- Fixed Helm being level 1 or 2 in SLO
- Fixed Japes alcove tns generating