### PR TITLE
connector hint fixes, climbing type rework

### DIFF
--- a/randomizer/Enums/Settings.py
+++ b/randomizer/Enums/Settings.py
@@ -808,6 +808,17 @@ class TrainingBarrels(IntEnum):
     shuffled = 1
 
 
+class ClimbingStatus(IntEnum):
+    """Determins if and how climbing is randomized.
+
+    normal: Climbing is a starting move.
+    shuffled: Climbing is an item that can be found in the world.
+    """
+
+    normal = 0
+    shuffled = 1
+
+
 class WinCondition(IntEnum):
     """The condition needed to complete the game.
 

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -8,7 +8,7 @@ import randomizer.Enums.Kongs as KongObject
 from randomizer.Enums.Items import Items
 from randomizer.Enums.Locations import Locations
 from randomizer.Enums.Plandomizer import GetItemsFromPlandoItem
-from randomizer.Enums.Settings import HardModeSelected, MoveRando, ShockwaveStatus, ShuffleLoadingZones, TrainingBarrels, CBRando
+from randomizer.Enums.Settings import ClimbingStatus, HardModeSelected, MoveRando, ShockwaveStatus, ShuffleLoadingZones, TrainingBarrels, CBRando
 from randomizer.Enums.Types import Types
 from randomizer.Enums.Levels import Levels
 from randomizer.Lists.Item import ItemFromKong
@@ -54,6 +54,8 @@ def PlaceConstants(spoiler):
         typesOfItemsShuffled.append(Types.Shop)
         if settings.training_barrels == TrainingBarrels.shuffled:
             typesOfItemsShuffled.append(Types.TrainingBarrel)
+        if settings.climbing_status == ClimbingStatus.shuffled:
+            typesOfItemsShuffled.append(Types.Climbing)
         if settings.shockwave_status != ShockwaveStatus.vanilla:
             typesOfItemsShuffled.append(Types.Shockwave)
     if settings.shuffle_loading_zones == ShuffleLoadingZones.levels:
@@ -153,6 +155,7 @@ def AllItemsUnrestricted(settings):
     allItems.extend(ImportantSharedMoves)
     allItems.extend(JunkSharedMoves)
     allItems.extend(TrainingBarrelAbilities().copy())
+    allItems.extend(ClimbingAbilities().copy())
     if settings.shockwave_status == ShockwaveStatus.shuffled_decoupled:
         allItems.append(Items.Camera)
         allItems.append(Items.Shockwave)
@@ -219,6 +222,8 @@ def AllItems(settings):
 
         if settings.training_barrels == TrainingBarrels.shuffled:
             allItems.extend(TrainingBarrelAbilities().copy())
+        if settings.climbing_status == ClimbingStatus.shuffled:
+            allItems.extend(ClimbingAbilities().copy())
         if settings.shockwave_status == ShockwaveStatus.shuffled_decoupled:
             allItems.append(Items.Camera)
             allItems.append(Items.Shockwave)
@@ -428,8 +433,13 @@ def Instruments(settings):
 
 def TrainingBarrelAbilities():
     """Return all training barrel abilities."""
-    barrelAbilities = [Items.Vines, Items.Swim, Items.Oranges, Items.Barrels, Items.Climbing]
+    barrelAbilities = [Items.Vines, Items.Swim, Items.Oranges, Items.Barrels]
     return barrelAbilities
+
+
+def ClimbingAbilities():
+    """Return all climbing abilities."""
+    return [Items.Climbing]
 
 
 def Upgrades(settings):
@@ -438,6 +448,9 @@ def Upgrades(settings):
     # Add training barrel items to item pool if shuffled
     if settings.training_barrels == TrainingBarrels.shuffled:
         upgrades.extend(TrainingBarrelAbilities())
+    # Add climbing to item pool if shuffled
+    if settings.climbing_status == ClimbingStatus.shuffled:
+        upgrades.extend(ClimbingAbilities())
     # Add either progressive upgrade items or individual ones depending on settings
     slam_count = 3
     if settings.start_with_slam:
@@ -675,6 +688,8 @@ def GetItemsNeedingToBeAssumed(settings, placed_types, placed_items=[]):
         itemPool.extend(RarewareCoinItems())
     if Types.TrainingBarrel in unplacedTypes:
         itemPool.extend(TrainingBarrelAbilities())
+    if Types.Climbing in unplacedTypes:
+        itemPool.extend(ClimbingAbilities())
     if Types.Kong in unplacedTypes:
         itemPool.extend(Kongs(settings))
     if Types.Medal in unplacedTypes:
@@ -712,6 +727,8 @@ def GetItemsNeedingToBeAssumed(settings, placed_types, placed_items=[]):
         itemPool.extend(AllKongMoves())
         if settings.training_barrels == TrainingBarrels.shuffled:
             itemPool.extend(TrainingBarrelAbilities().copy())
+        if settings.climbing_status == ClimbingStatus.shuffled:
+            itemPool.extend(ClimbingAbilities().copy())
         if settings.shockwave_status == ShockwaveStatus.shuffled_decoupled:
             itemPool.extend(ShockwaveTypeItems(settings))
     # With a list of specifically placed items, we can't assume those

--- a/randomizer/Lists/Item.py
+++ b/randomizer/Lists/Item.py
@@ -30,7 +30,7 @@ class Item:
             self.movetype = data[0]
             self.index = data[1]
             self.rando_flag = data[2]
-        if type in (Types.TrainingBarrel, Types.Shockwave):
+        if type in (Types.TrainingBarrel, Types.Shockwave, Types.Climbing):
             self.movetype = data[0]
             self.flag = data[1]
             self.rando_flag = data[2]
@@ -106,7 +106,7 @@ ItemList = {
     Items.Swim: Item("Diving", True, Types.TrainingBarrel, Kongs.any, [MoveTypes.Flag, "dive", 386]),
     Items.Oranges: Item("Oranges", True, Types.TrainingBarrel, Kongs.any, [MoveTypes.Flag, "orange", 388]),
     Items.Barrels: Item("Barrels", True, Types.TrainingBarrel, Kongs.any, [MoveTypes.Flag, "barrel", 389]),
-    Items.Climbing: Item("Climbing", True, Types.TrainingBarrel, Kongs.any, [MoveTypes.Flag, "climbing", 0x297]),
+    Items.Climbing: Item("Climbing", True, Types.Climbing, Kongs.any, [MoveTypes.Flag, "climbing", 0x297]),
     Items.ProgressiveSlam: Item("Progressive Slam", True, Types.Shop, Kongs.any, [MoveTypes.Slam, 2, -1]),
     Items.ProgressiveSlam2: Item("Progressive Slam ", False, Types.Constant, Kongs.any),  # Only used for the starting move list selector modal
     Items.ProgressiveSlam3: Item("Progressive Slam  ", False, Types.Constant, Kongs.any),  # Only used for the starting move list selector modal

--- a/randomizer/Lists/Plandomizer.py
+++ b/randomizer/Lists/Plandomizer.py
@@ -215,7 +215,7 @@ for locationEnum, locationObj in LocationList.items():
         continue
     # Do not include training barrels or pre-given move locations. We will fill
     # those automatically based on the user's selected starting moves.
-    if locationObj.type in [Types.TrainingBarrel, Types.PreGivenMove]:
+    if locationObj.type in [Types.TrainingBarrel, Types.PreGivenMove, Types.Climbing]:
         continue
     # Do not include the shopkeepers.
     if locationObj.type in [Types.Cranky, Types.Funky, Types.Candy, Types.Snide]:

--- a/randomizer/Patching/ASMPatcher.py
+++ b/randomizer/Patching/ASMPatcher.py
@@ -709,7 +709,9 @@ class Minigame8BitImage:
 
 def alter8bitRewardImages(ROM_COPY, offset_dict: dict, arcade_item: Items = Items.NintendoCoin, jetpac_item: Items = Items.RarewareCoin):
     """Alter the image that is displayed in DK Arcade/Jetpac for their respective rewards."""
-    colorless_potions = ItemPool.ImportantSharedMoves + ItemPool.JunkSharedMoves + ItemPool.TrainingBarrelAbilities() + [Items.Shockwave, Items.Camera, Items.CameraAndShockwave]
+    colorless_potions = (
+        ItemPool.ImportantSharedMoves + ItemPool.JunkSharedMoves + ItemPool.TrainingBarrelAbilities() + ItemPool.ClimbingAbilities() + [Items.Shockwave, Items.Camera, Items.CameraAndShockwave]
+    )
     # Image.open(f"{hash_dir}rw_coin.png").resize(dim).save(f"{arcade_dir}rwcoin.png")  # Rareware Coin
     # Image.open(f"{hash_dir}melon_slice.png").resize(dim).save(f"{arcade_dir}melon.png")  # Watermelon Slice
     db = [

--- a/randomizer/Patching/ItemRando.py
+++ b/randomizer/Patching/ItemRando.py
@@ -261,7 +261,7 @@ def getTextRewardIndex(item) -> int:
         return 5
     elif item.new_item == Types.NintendoCoin:
         return 6
-    elif item.new_item in (Types.Shop, Types.Shockwave, Types.TrainingBarrel):
+    elif item.new_item in (Types.Shop, Types.Shockwave, Types.TrainingBarrel, Types.Climbing):
         return 8
     elif item.new_item in (Types.Snide, Types.Cranky, Types.Candy, Types.Funky):
         return 15
@@ -325,7 +325,7 @@ def getActorIndex(item):
             Items.IceTrapSlow: CustomActors.IceTrapSlow,
         }
         return trap_types.get(item.new_subitem, CustomActors.IceTrapBubble)
-    elif item.new_item in (Types.Shop, Types.Shockwave, Types.TrainingBarrel):
+    elif item.new_item in (Types.Shop, Types.Shockwave, Types.TrainingBarrel, Types.Climbing):
         if (item.new_flag & 0x8000) == 0:
             slot = 5
         else:
@@ -513,7 +513,7 @@ def place_randomized_items(spoiler, original_flut: list):
                         if item.new_item == Types.Kong:
                             if item.new_flag in kong_flags:
                                 arcade_reward_index = kong_flags.index(item.new_flag) + 15
-                        elif item.new_item in (Types.Shop, Types.TrainingBarrel, Types.Shockwave):
+                        elif item.new_item in (Types.Shop, Types.TrainingBarrel, Types.Shockwave, Types.Climbing):
                             if (item.new_flag & 0x8000) == 0:
                                 slot = 5
                             else:
@@ -544,7 +544,7 @@ def place_randomized_items(spoiler, original_flut: list):
                             Types.JunkItem,
                         )
                         jetpac_reward_index = 0
-                        if item.new_item in (Types.Shop, Types.TrainingBarrel, Types.Shockwave):
+                        if item.new_item in (Types.Shop, Types.TrainingBarrel, Types.Shockwave, Types.Climbing):
                             jetpac_reward_index = 9
                         elif item.new_item in jetpac_rewards:
                             jetpac_reward_index = jetpac_rewards.index(item.new_item)
@@ -692,6 +692,8 @@ def place_randomized_items(spoiler, original_flut: list):
                             ROM_COPY.write(medal_index)
                         elif item.new_item == Types.RarewareCoin:
                             ROM_COPY.write(slots.index(Types.NintendoCoin))
+                        elif item.new_item == Types.Climbing:
+                            ROM_COPY.write(slots.index(Types.TrainingBarrel))
                         elif item.new_item == Types.FakeItem:
                             trap_types = {
                                 Items.IceTrapBubble: 16,

--- a/randomizer/Patching/Lib.py
+++ b/randomizer/Patching/Lib.py
@@ -861,6 +861,7 @@ def getItemNumberString(count: int, item_type: Types) -> str:
         Types.Crown: "Crown",
         Types.Coin: "Company Coin",
         Types.TrainingBarrel: "Move",
+        Types.Climbing: "Move",
         Types.Kong: "Kong",
         Types.Medal: "Medal",
         Types.Shockwave: "Move",

--- a/randomizer/ShuffleItems.py
+++ b/randomizer/ShuffleItems.py
@@ -140,7 +140,7 @@ def ShuffleItems(spoiler):
                 flag=old_flag,
                 placement_data=placement_info,
                 is_reward_point=item_location.is_reward,
-                is_shop=item_location.type in (Types.Shop, Types.TrainingBarrel, Types.Shockwave),
+                is_shop=item_location.type in (Types.Shop, Types.TrainingBarrel, Types.Shockwave, Types.Climbing),
                 price=price,
                 placement_index=placement_index,
                 kong=old_kong,

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -194,6 +194,7 @@ class Spoiler:
             Types.Shop: "Moves",
             Types.Shockwave: "Moves",
             Types.TrainingBarrel: "Moves",
+            Types.Climbing: "Moves",
             Types.Banana: "Golden Bananas",
             Types.Blueprint: "Blueprints",
             Types.Fairy: "Fairies",

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -34,7 +34,7 @@ with open("static/presets/preset_files.json", "r") as file:
 # Add a custom preset for testing
 # If we're not running on github actions, add the custom preset
 if not os.environ.get("GITHUB_ACTIONS"):
-    valid_presets.append(("Custom", "bKEIhEMhTHRBKlsa58VZXZhBEQEnAI9D6oGhEMiEqWxrnwH4jR6XL4huKcrSxO9TTghQAdo9IFBiMhjoStwFILdT2+BfgJJANQyiaoVYrBWiuAyC6ywUAdACDADqAgcAdgGEADuBAkAeAKFADyBgsAegOGAGCCFCGoD2ALcAGVIhRUM5KkpSstmS5JKN4EcnaLSLgp+ipixQJiKAK9a45G7Vf77IoHIdzMWvIigDNZsyiSLAAuMAAuNAAmOAAmPAAe1AAeQAAWRAAOSAAeTAAWUAAO2AAtTlyhyXCp0woIvoE5LBBhhKqczG0xloWlcsLwVocUFsNGRUCcWGAmDAjGhTHFPLFFJkRnwAHQClALoAVQCXAgwNnAA"))
+    valid_presets.append(("Custom", "bKEHBEMpjoglS2OerK7MIGiAk4BHofVA4IhkQlS2Nc+EaePxGj0uXxCnFid6mnBCgKPSBIYjIY6FuApBbqe3wL8BJIBqE0VVCrFYK0VwGQXWSywUBdACDATqAgcDdgGEAjuBAkFeAKFAzyBgsHegOGBGCCFCGoD2yLcAGVIlRWs5KkpTstmS5JLNFvAjk7RaRcFP0VEWARMRQBXrXHI3ar/fZFA5DuZi19EUAZrNmVjiSLAAuMAAuNAAmOAAmPAAe1AAeQAAWRAAOSAAeTAAWUAAO2AAtTlyhyXCp0woIvoE5LBBhhKrgzG0xrQHFoWlcsLwVocUFsNKgTiwwEwYEZTHFPIpMiM+AA6AUoBdACqAS4GGlRjOAA"))
 
 
 @parameterized_class(('name', 'settings_string'), valid_presets)


### PR DESCRIPTION
- Fixed entrance hints not properly traversing through connectors indefinitely
- Reworked the climbing Types to isolate climbing as a setting. This fixes the issue where intentionally starting with climbing could still cause climbing to be hinted as a training move.