### PR TITLE
Plandomizer: prevent TnS bosses from being chosen as K. Rool phases...

### DIFF
--- a/static/js/rando_options.js
+++ b/static/js/rando_options.js
@@ -668,6 +668,30 @@ function plando_disable_isles_medals(evt) {
 
 document.getElementById("cb_rando").addEventListener("change", plando_disable_isles_medals);
 
+// Disable K. Rool phases as bosses if they are not in the boss pool.
+function plando_disable_krool_phases_as_bosses(evt) {
+  const kroolInBossPool = document.getElementById("krool_in_boss_pool").checked;
+  const tnsBossOptions = document.getElementsByClassName("plando-tns-boss");
+
+  if (kroolInBossPool) {
+    for (let option of tnsBossOptions) {
+      option.removeAttribute("disabled");
+    }
+  } else {
+    for (let option of tnsBossOptions) {
+      option.setAttribute("disabled", "disabled");
+    }
+    for (let i = 0; i < 5; i++) {
+      const kroolPhase = document.getElementById(`plando_krool_order_${i}`);
+      if (kroolPhase.value.includes("Boss")) {
+        kroolPhase.value = "";
+      }
+    }
+  }
+}
+
+document.getElementById("krool_in_boss_pool").addEventListener("click", plando_disable_krool_phases_as_bosses);
+
 // Make changes to the plando tab based on other settings
 document.getElementById("nav-plando-tab").addEventListener("click", function(evt) {
     disable_krool_phases(evt);
@@ -689,6 +713,7 @@ document.getElementById("nav-plando-tab").addEventListener("click", function(evt
     plando_disable_wrinkly_custom_locations(evt);
     plando_disable_tns_custom_locations(evt);
     plando_disable_isles_medals(evt);
+    plando_disable_krool_phases_as_bosses(evt);
 });
 
 // Disable Boss Kong and Boss Location Rando if Vanilla levels and Kong Rando

--- a/templates/plandomizer/plandomizer_general.html.jinja2
+++ b/templates/plandomizer/plandomizer_general.html.jinja2
@@ -310,7 +310,13 @@
                                     -- Randomize --
                                 </option>
                                 {% for phase in plando_phases %}
-                                  <option value="{{phase["value"]}}">
+                                  <option value="{{phase["value"]}}"
+                                  {% if "Boss" in phase["value"] %}
+                                    class="plando-tns-boss"
+                                  {% else %}
+                                    class="plando-krool-phase"
+                                  {% endif %}
+                                  >
                                     {{phase["name"]}}
                                   </option>
                                 {% endfor %}

--- a/ui/plando_settings.py
+++ b/ui/plando_settings.py
@@ -237,6 +237,7 @@ async def import_plando_options(jsonString):
     js.plando_toggle_custom_wrinkly_locations(None)
     js.plando_toggle_custom_locations_tab(None)
     js.plando_disable_isles_medals(None)
+    js.plando_disable_krool_phases_as_bosses(None)
     lock_key_8_in_helm(None)
     validate_custom_arena_locations(None)
     validate_custom_crate_locations(None)


### PR DESCRIPTION
...if K. Rool phases are not shuffled into the boss pool.