### PR TITLE
Enemy fixes

### DIFF
--- a/randomizer/Lists/EnemyTypes.py
+++ b/randomizer/Lists/EnemyTypes.py
@@ -171,6 +171,7 @@ class EnemyLoc:
                 return interaction.can_bypass
         return False
 
+
 BEAVER_DEFAULT_SIZE = 80
 KLAPTRAP_DEFAULT_SIZE = 65
 ZINGER_DEFAULT_SIZE = 70

--- a/randomizer/Lists/EnemyTypes.py
+++ b/randomizer/Lists/EnemyTypes.py
@@ -171,6 +171,10 @@ class EnemyLoc:
                 return interaction.can_bypass
         return False
 
+BEAVER_DEFAULT_SIZE = 80
+KLAPTRAP_DEFAULT_SIZE = 65
+ZINGER_DEFAULT_SIZE = 70
+BARREL_ENEMY_DEFAULT_SIZE = 50
 
 EnemyMetaData = {
     Enemies.BeaverBlue: EnemyData(
@@ -181,7 +185,7 @@ EnemyMetaData = {
         bbbarrage_min_scale=70,
         beaver=True,
         interaction=InteractionMethods(),
-        default_size=80,
+        default_size=BEAVER_DEFAULT_SIZE,
     ),  #
     Enemies.Book: EnemyData(
         name="Book",
@@ -201,7 +205,7 @@ EnemyMetaData = {
         crown_weight=7,
         disruptive=1,
         interaction=InteractionMethods(kill_melee=False, kill_orange=False, kill_shockwave=False),
-        default_size=70,
+        default_size=ZINGER_DEFAULT_SIZE,
     ),  #
     Enemies.Klobber: EnemyData(
         name="Klobber",
@@ -211,7 +215,7 @@ EnemyMetaData = {
         killable=False,
         disruptive=2,
         interaction=InteractionMethods(kill_gun=False, kill_melee=False),
-        default_size=100,
+        default_size=BARREL_ENEMY_DEFAULT_SIZE,
     ),
     Enemies.Klump: EnemyData(
         name="Klump",
@@ -230,7 +234,7 @@ EnemyMetaData = {
         killable=False,
         disruptive=2,
         interaction=InteractionMethods(kill_gun=False, kill_melee=False),
-        default_size=100,
+        default_size=BARREL_ENEMY_DEFAULT_SIZE,
     ),
     Enemies.KlaptrapGreen: EnemyData(
         name="Klaptrap (Green)",
@@ -239,7 +243,7 @@ EnemyMetaData = {
         simple=True,
         bbbarrage_min_scale=100,
         interaction=InteractionMethods(),
-        default_size=65,
+        default_size=KLAPTRAP_DEFAULT_SIZE,
     ),  #
     Enemies.ZingerLime: EnemyData(
         name="Zinger (Lime Thrower)",
@@ -248,7 +252,7 @@ EnemyMetaData = {
         crown_weight=5,
         disruptive=1,
         interaction=InteractionMethods(kill_orange=False, kill_melee=False, kill_shockwave=False),
-        default_size=70,
+        default_size=ZINGER_DEFAULT_SIZE,
     ),  #
     Enemies.KlaptrapPurple: EnemyData(
         name="Klaptrap (Purple)",
@@ -257,7 +261,7 @@ EnemyMetaData = {
         killable=False,
         disruptive=1,
         interaction=InteractionMethods(kill_gun=False, kill_melee=False, kill_shockwave=False),
-        default_size=65,
+        default_size=KLAPTRAP_DEFAULT_SIZE,
     ),  #
     Enemies.KlaptrapRed: EnemyData(
         name="Klaptrap (Red)",
@@ -266,7 +270,7 @@ EnemyMetaData = {
         killable=False,
         disruptive=1,
         interaction=InteractionMethods(kill_melee=False, kill_shockwave=False),
-        default_size=65,
+        default_size=KLAPTRAP_DEFAULT_SIZE,
     ),  #
     Enemies.BeaverGold: EnemyData(
         name="Beaver (Gold)",
@@ -276,7 +280,7 @@ EnemyMetaData = {
         bbbarrage_min_scale=70,
         beaver=True,
         interaction=InteractionMethods(),
-        default_size=80,
+        default_size=BEAVER_DEFAULT_SIZE,
     ),  #
     Enemies.MushroomMan: EnemyData(
         name="Mushroom Man",
@@ -517,7 +521,7 @@ EnemyMetaData = {
         disruptive=1,
         interaction=InteractionMethods(kill_melee=False, kill_orange=False, kill_shockwave=False),
         selector_enabled=False,
-        default_size=70,
+        default_size=ZINGER_DEFAULT_SIZE,
     ),
     Enemies.Scarab: EnemyData(
         name="Scarab",

--- a/randomizer/Patching/EnemyRando.py
+++ b/randomizer/Patching/EnemyRando.py
@@ -192,6 +192,7 @@ minigame_maps_total.extend(minigame_maps_nolimit)
 minigame_maps_total.extend(minigame_maps_beavers)
 bbbarrage_maps = (Maps.BusyBarrelBarrageEasy, Maps.BusyBarrelBarrageNormal, Maps.BusyBarrelBarrageHard)
 banned_speed_maps = list(bbbarrage_maps).copy() + minigame_maps_beavers.copy()
+banned_size_maps = list(bbbarrage_maps).copy() + minigame_maps_beavers.copy()
 replacement_priority = {
     EnemySubtype.GroundSimple: [EnemySubtype.GroundBeefy, EnemySubtype.Water, EnemySubtype.Air],
     EnemySubtype.GroundBeefy: [EnemySubtype.GroundSimple, EnemySubtype.Water, EnemySubtype.Air],
@@ -418,7 +419,7 @@ def writeEnemy(spoiler, cont_map_spawner_address: int, new_enemy_id: int, spawne
             ROM_COPY.writeMultipleBytes(get_out_timer, 1)
             ROM_COPY.writeMultipleBytes(get_out_timer, 1)
         # Scale Adjustment
-        if EnemyMetaData[new_enemy_id].default_size is not None:
+        if (EnemyMetaData[new_enemy_id].default_size is not None) and (cont_map_id not in banned_size_maps):
             scale = EnemyMetaData[new_enemy_id].default_size
             ROM_COPY.seek(cont_map_spawner_address + spawner.offset + 0xF)
             if cont_map_id == Maps.JapesTinyHive:

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -648,7 +648,7 @@ class Settings:
         self.enemy_rando = False
         self.crown_enemy_rando = CrownEnemyRando.off
         self.enemy_speed_rando = False
-        self.normalize_enemy_sizes = True
+        self.normalize_enemy_sizes = False
         self.randomize_enemy_sizes = False
         self.cb_rando = CBRando.off
         self.coin_rando = False


### PR DESCRIPTION
- Reduce the default size of Klobbers/Kabooms
- Disable size rando in beaver bother/busy barrel barrage
- If size rando is off, enemy sizes will no longer be normalized