### PR TITLE
Plandomizer: Japes rock and shopkeepers

### DIFF
--- a/randomizer/Enums/Plandomizer.py
+++ b/randomizer/Enums/Plandomizer.py
@@ -100,6 +100,11 @@ class PlandoItems(IntEnum):
 
     # Hints are not used as plando items.
 
+    Cranky = auto()
+    Funky = auto()
+    Candy = auto()
+    Snide = auto()
+
     # Five generic blueprint items to represent all specific blueprints.
     DonkeyBlueprint = auto()
     DiddyBlueprint = auto()
@@ -181,6 +186,10 @@ ItemToPlandoItemMap = {
     Items.JunkAmmo: PlandoItems.JunkItem,
     Items.JunkFilm: PlandoItems.JunkItem,
     Items.JunkOrange: PlandoItems.JunkItem,
+    Items.Cranky: PlandoItems.Cranky,
+    Items.Funky: PlandoItems.Funky,
+    Items.Candy: PlandoItems.Candy,
+    Items.Snide: PlandoItems.Snide,
     # All of the individual blueprints map to the same five plando items.
     Items.JungleJapesDonkeyBlueprint: PlandoItems.DonkeyBlueprint,
     Items.JungleJapesDiddyBlueprint: PlandoItems.DiddyBlueprint,
@@ -286,6 +295,10 @@ PlandoItemToItemMap = {
     PlandoItems.ProgressiveSlam: Items.ProgressiveSlam,
     PlandoItems.ProgressiveAmmoBelt: Items.ProgressiveAmmoBelt,
     PlandoItems.ProgressiveInstrumentUpgrade: Items.ProgressiveInstrumentUpgrade,
+    PlandoItems.Cranky: Items.Cranky,
+    PlandoItems.Funky: Items.Funky,
+    PlandoItems.Candy: Items.Candy,
+    PlandoItems.Snide: Items.Snide,
 }
 
 PlandoItemToItemListMap = {

--- a/randomizer/PlandoUtils.py
+++ b/randomizer/PlandoUtils.py
@@ -273,10 +273,24 @@ kongSpecificMoveItemSet = {
 }
 
 # Kong-specific shops have a handful of banned items.
-kongSpecificShopRestrictedItemSet = {PlandoItems.Vines.name, PlandoItems.Climbing.name, PlandoItems.Swim.name, PlandoItems.Oranges.name, PlandoItems.Barrels.name, PlandoItems.Shockwave.name}
+kongSpecificShopRestrictedItemSet = {
+    PlandoItems.Vines.name,
+    PlandoItems.Climbing.name,
+    PlandoItems.Swim.name,
+    PlandoItems.Oranges.name,
+    PlandoItems.Barrels.name,
+    PlandoItems.Shockwave.name,
+}
 
 # General shops have few restrictions.
-shopRestrictedItemSet = {PlandoItems.RainbowCoin.name, PlandoItems.JunkItem.name}
+shopRestrictedItemSet = {
+    PlandoItems.RainbowCoin.name,
+    PlandoItems.JunkItem.name,
+    PlandoItems.Cranky.name,
+    PlandoItems.Funky.name,
+    PlandoItems.Candy.name,
+    PlandoItems.Snide.name,
+}
 
 # Add the restricted items for each shop location. (This will also cover the
 # blueprint redemptions, which is fine.)
@@ -322,9 +336,6 @@ for locEnum, locObj in LocationList.items():
         ItemRestrictionsPerLocation[locEnum.name].add(PlandoItems.HunkyChunky.name)
         ItemRestrictionsPerLocation[locEnum.name].add(PlandoItems.PonyTailTwirl.name)
         ItemRestrictionsPerLocation[locEnum.name].add(PlandoItems.Barrels.name)
-
-# This one rock can't have Kongs as a reward.
-ItemRestrictionsPerLocation[Locations.IslesDonkeyJapesRock.name].update(KongSet)
 
 # These specific locations cannot have fake items on them.
 badFakeItemLocationList = [


### PR DESCRIPTION
- Users can now place Kongs as a reward on the Japes rock. Why would anyone want to do this? Ask SniperWave.
- Users can now place shopkeepers as rewards. They cannot be placed in shops.