### PR TITLE
Better error codes, bug fixes

### DIFF
--- a/randomizer/Enums/Plandomizer.py
+++ b/randomizer/Enums/Plandomizer.py
@@ -98,8 +98,6 @@ class PlandoItems(IntEnum):
 
     # BananaHoard is not used.
 
-    # Hints are not used as plando items.
-
     Cranky = auto()
     Funky = auto()
     Candy = auto()
@@ -111,6 +109,43 @@ class PlandoItems(IntEnum):
     LankyBlueprint = auto()
     TinyBlueprint = auto()
     ChunkyBlueprint = auto()
+
+    # Hints are individually placed as plando items.
+    JapesDonkeyHint = auto()
+    JapesDiddyHint = auto()
+    JapesLankyHint = auto()
+    JapesTinyHint = auto()
+    JapesChunkyHint = auto()
+    AztecDonkeyHint = auto()
+    AztecDiddyHint = auto()
+    AztecLankyHint = auto()
+    AztecTinyHint = auto()
+    AztecChunkyHint = auto()
+    FactoryDonkeyHint = auto()
+    FactoryDiddyHint = auto()
+    FactoryLankyHint = auto()
+    FactoryTinyHint = auto()
+    FactoryChunkyHint = auto()
+    GalleonDonkeyHint = auto()
+    GalleonDiddyHint = auto()
+    GalleonLankyHint = auto()
+    GalleonTinyHint = auto()
+    GalleonChunkyHint = auto()
+    ForestDonkeyHint = auto()
+    ForestDiddyHint = auto()
+    ForestLankyHint = auto()
+    ForestTinyHint = auto()
+    ForestChunkyHint = auto()
+    CavesDonkeyHint = auto()
+    CavesDiddyHint = auto()
+    CavesLankyHint = auto()
+    CavesTinyHint = auto()
+    CavesChunkyHint = auto()
+    CastleDonkeyHint = auto()
+    CastleDiddyHint = auto()
+    CastleLankyHint = auto()
+    CastleTinyHint = auto()
+    CastleChunkyHint = auto()
 
 
 ItemToPlandoItemMap = {
@@ -231,6 +266,41 @@ ItemToPlandoItemMap = {
     Items.DKIslesLankyBlueprint: PlandoItems.LankyBlueprint,
     Items.DKIslesTinyBlueprint: PlandoItems.TinyBlueprint,
     Items.DKIslesChunkyBlueprint: PlandoItems.ChunkyBlueprint,
+    Items.JapesDonkeyHint: PlandoItems.JapesDonkeyHint,
+    Items.JapesDiddyHint: PlandoItems.JapesDiddyHint,
+    Items.JapesLankyHint: PlandoItems.JapesLankyHint,
+    Items.JapesTinyHint: PlandoItems.JapesTinyHint,
+    Items.JapesChunkyHint: PlandoItems.JapesChunkyHint,
+    Items.AztecDonkeyHint: PlandoItems.AztecDonkeyHint,
+    Items.AztecDiddyHint: PlandoItems.AztecDiddyHint,
+    Items.AztecLankyHint: PlandoItems.AztecLankyHint,
+    Items.AztecTinyHint: PlandoItems.AztecTinyHint,
+    Items.AztecChunkyHint: PlandoItems.AztecChunkyHint,
+    Items.FactoryDonkeyHint: PlandoItems.FactoryDonkeyHint,
+    Items.FactoryDiddyHint: PlandoItems.FactoryDiddyHint,
+    Items.FactoryLankyHint: PlandoItems.FactoryLankyHint,
+    Items.FactoryTinyHint: PlandoItems.FactoryTinyHint,
+    Items.FactoryChunkyHint: PlandoItems.FactoryChunkyHint,
+    Items.GalleonDonkeyHint: PlandoItems.GalleonDonkeyHint,
+    Items.GalleonDiddyHint: PlandoItems.GalleonDiddyHint,
+    Items.GalleonLankyHint: PlandoItems.GalleonLankyHint,
+    Items.GalleonTinyHint: PlandoItems.GalleonTinyHint,
+    Items.GalleonChunkyHint: PlandoItems.GalleonChunkyHint,
+    Items.ForestDonkeyHint: PlandoItems.ForestDonkeyHint,
+    Items.ForestDiddyHint: PlandoItems.ForestDiddyHint,
+    Items.ForestLankyHint: PlandoItems.ForestLankyHint,
+    Items.ForestTinyHint: PlandoItems.ForestTinyHint,
+    Items.ForestChunkyHint: PlandoItems.ForestChunkyHint,
+    Items.CavesDonkeyHint: PlandoItems.CavesDonkeyHint,
+    Items.CavesDiddyHint: PlandoItems.CavesDiddyHint,
+    Items.CavesLankyHint: PlandoItems.CavesLankyHint,
+    Items.CavesTinyHint: PlandoItems.CavesTinyHint,
+    Items.CavesChunkyHint: PlandoItems.CavesChunkyHint,
+    Items.CastleDonkeyHint: PlandoItems.CastleDonkeyHint,
+    Items.CastleDiddyHint: PlandoItems.CastleDiddyHint,
+    Items.CastleLankyHint: PlandoItems.CastleLankyHint,
+    Items.CastleTinyHint: PlandoItems.CastleTinyHint,
+    Items.CastleChunkyHint: PlandoItems.CastleChunkyHint,
 }
 
 PlandoItemToItemMap = {
@@ -299,6 +369,41 @@ PlandoItemToItemMap = {
     PlandoItems.Funky: Items.Funky,
     PlandoItems.Candy: Items.Candy,
     PlandoItems.Snide: Items.Snide,
+    PlandoItems.JapesDonkeyHint: Items.JapesDonkeyHint,
+    PlandoItems.JapesDiddyHint: Items.JapesDiddyHint,
+    PlandoItems.JapesLankyHint: Items.JapesLankyHint,
+    PlandoItems.JapesTinyHint: Items.JapesTinyHint,
+    PlandoItems.JapesChunkyHint: Items.JapesChunkyHint,
+    PlandoItems.AztecDonkeyHint: Items.AztecDonkeyHint,
+    PlandoItems.AztecDiddyHint: Items.AztecDiddyHint,
+    PlandoItems.AztecLankyHint: Items.AztecLankyHint,
+    PlandoItems.AztecTinyHint: Items.AztecTinyHint,
+    PlandoItems.AztecChunkyHint: Items.AztecChunkyHint,
+    PlandoItems.FactoryDonkeyHint: Items.FactoryDonkeyHint,
+    PlandoItems.FactoryDiddyHint: Items.FactoryDiddyHint,
+    PlandoItems.FactoryLankyHint: Items.FactoryLankyHint,
+    PlandoItems.FactoryTinyHint: Items.FactoryTinyHint,
+    PlandoItems.FactoryChunkyHint: Items.FactoryChunkyHint,
+    PlandoItems.GalleonDonkeyHint: Items.GalleonDonkeyHint,
+    PlandoItems.GalleonDiddyHint: Items.GalleonDiddyHint,
+    PlandoItems.GalleonLankyHint: Items.GalleonLankyHint,
+    PlandoItems.GalleonTinyHint: Items.GalleonTinyHint,
+    PlandoItems.GalleonChunkyHint: Items.GalleonChunkyHint,
+    PlandoItems.ForestDonkeyHint: Items.ForestDonkeyHint,
+    PlandoItems.ForestDiddyHint: Items.ForestDiddyHint,
+    PlandoItems.ForestLankyHint: Items.ForestLankyHint,
+    PlandoItems.ForestTinyHint: Items.ForestTinyHint,
+    PlandoItems.ForestChunkyHint: Items.ForestChunkyHint,
+    PlandoItems.CavesDonkeyHint: Items.CavesDonkeyHint,
+    PlandoItems.CavesDiddyHint: Items.CavesDiddyHint,
+    PlandoItems.CavesLankyHint: Items.CavesLankyHint,
+    PlandoItems.CavesTinyHint: Items.CavesTinyHint,
+    PlandoItems.CavesChunkyHint: Items.CavesChunkyHint,
+    PlandoItems.CastleDonkeyHint: Items.CastleDonkeyHint,
+    PlandoItems.CastleDiddyHint: Items.CastleDiddyHint,
+    PlandoItems.CastleLankyHint: Items.CastleLankyHint,
+    PlandoItems.CastleTinyHint: Items.CastleTinyHint,
+    PlandoItems.CastleChunkyHint: Items.CastleChunkyHint,
 }
 
 PlandoItemToItemListMap = {

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -78,7 +78,7 @@ def PlaceConstants(spoiler):
     if settings.key_8_helm:
         helm_key = getHelmKey(spoiler.settings)
         if helm_key in KeysToPlace(spoiler.settings, excludeHelmKey=False):
-            spoiler.LocationList[Locations.HelmKey].PlaceConstantItem(spoiler, getHelmKey(spoiler.settings))
+            spoiler.LocationList[Locations.HelmKey].PlaceConstantItem(spoiler, helm_key)
         else:
             spoiler.LocationList[Locations.HelmKey].PlaceConstantItem(spoiler, Items.NoItem)
         # If Helm is not last, and we're locking key 8 and we're using the SLO ruleset,

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -82,6 +82,7 @@ class LogicVarHolder:
         self.assumeInfiniteCoins = False
         self.assumeAztecEntry = False
         self.assumeLevel4Entry = False
+        self.assumeLevel8Entry = False  # Extra important to never assume this in LZR!
         self.assumeUpperIslesAccess = False
         self.assumeKRoolAccess = False
 

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -281,6 +281,7 @@ LogicRegions = {
         TransitionFront(Regions.GloomyGalleonLobbyEntrance, lambda l: (l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events or l.CanPhaseswim()) and (l.swim or l.assumeLevel4Entry), Transitions.IslesMainToGalleonLobby),
         TransitionFront(Regions.KremIsleBeyondLift, lambda l: l.settings.open_lobbies or Events.AztecKeyTurnedIn in l.Events or l.CanMoonkick() or l.tbs or l.CanMoontail()),
         TransitionFront(Regions.KremIsleTopLevel, lambda l: l.hasMoveSwitchsanity(Switches.IslesMonkeyport)),
+        TransitionFront(Regions.HideoutHelmLobby, lambda l: l.assumeLevel8Entry and (l.settings.open_lobbies or (Events.CavesKeyTurnedIn in l.Events and Events.CastleKeyTurnedIn in l.Events)), Transitions.IslesMainToHelmLobby, isGlitchTransition=True),
     ]),
 
     Regions.KremIsleBeyondLift: Region("Krem Isle Beyond Lift", HintRegion.KremIsles, Levels.DKIsles, False, None, [
@@ -310,9 +311,9 @@ LogicRegions = {
     Regions.KremIsleMouth: Region("Krem Isle Mouth", HintRegion.KremIsles, Levels.DKIsles, False, None, [], [], [
         # You fall through the mouth if the lobby hasn't been opened (if you used a glitch to get in or LZR)
         TransitionFront(Regions.HideoutHelmLobby, lambda l: l.settings.open_lobbies or (Events.CavesKeyTurnedIn in l.Events and Events.CastleKeyTurnedIn in l.Events), Transitions.IslesMainToHelmLobby),
-        TransitionFront(Regions.KremIsleTopLevel, lambda l: l.settings.open_lobbies or (Events.CavesKeyTurnedIn in l.Events and Events.CastleKeyTurnedIn in l.Events)),
+        TransitionFront(Regions.KremIsleTopLevel, lambda l: not l.assumeLevel8Entry and l.settings.open_lobbies or (Events.CavesKeyTurnedIn in l.Events and Events.CastleKeyTurnedIn in l.Events)),
         # This fall could be a logical point of progression, but you have to surive the drop
-        TransitionFront(Regions.KremIsleBeyondLift, lambda l: l.CanSurviveFallDamage()),
+        TransitionFront(Regions.KremIsleBeyondLift, lambda l: not l.assumeLevel8Entry and l.CanSurviveFallDamage()),
         # If you were to die to fall damage here, you'd be sent to the Isles spawn. This is effectively a one-off deathwarp consideration.
         TransitionFront(Regions.IslesMain, lambda l: True),
     ]),

--- a/randomizer/LogicFiles/HideoutHelm.py
+++ b/randomizer/LogicFiles/HideoutHelm.py
@@ -42,7 +42,7 @@ LogicRegions = {
         LocationLogic(Locations.HelmMainEnemy_Start0, lambda l: True),
         LocationLogic(Locations.HelmMainEnemy_Start1, lambda l: True),
     ], [], [
-        TransitionFront(Regions.HideoutHelmLobby, lambda l: True, Transitions.HelmToIsles),
+        TransitionFront(Regions.HideoutHelmLobby, lambda l: Events.HelmFinished in l.Events, Transitions.HelmToIsles),
         TransitionFront(Regions.HideoutHelmSwitchRoom, lambda l: (l.handstand and l.islanky) or l.advanced_platforming),
         TransitionFront(Regions.HideoutHelmAfterBoM, lambda l: l.settings.helm_setting == HelmSetting.skip_all or Events.HelmFinished in l.Events),  # W1
     ]),

--- a/ui/plando_validation.py
+++ b/ui/plando_validation.py
@@ -910,9 +910,12 @@ def set_plando_switches(evt):
 @bind("click", "key_8_helm")
 def lock_key_8_in_helm(evt):
     """If key 8 is locked in Helm, force that location to hold key 8."""
-    key_8_locked_in_helm = js.document.getElementById("key_8_helm").checked
+    helm_is_shuffled = js.document.getElementById("shuffle_helm_location").checked
+    is_level_order = js.document.getElementById("level_randomization").value in ["level_order", "level_order_complex"]
+    helm_key_lock = js.document.getElementById("key_8_helm").checked
     end_of_helm = js.document.getElementById("plando_HelmKey_item")
-    if key_8_locked_in_helm:
+    # If the settings require Key 8 to be at the End of Helm...
+    if helm_key_lock and not (is_level_order and helm_is_shuffled):
         # Forcibly select Key 8 for the End of Helm dropdown and disable it.
         errString = 'The "Lock Key 8 in Helm" setting has been chosen.'
         mark_option_disabled(end_of_helm, ValidationError.key_8_locked_in_helm, errString, Items.HideoutHelmKey.name)


### PR DESCRIPTION
- Improved the error codes to be both more and less human understandable. A gibberish error code was added if we needed to identify a specific location pointed out by the error, but this isn't common.
- Added the ability to plando hint items
- Paths now assume level 8 entry. This means MP (or whatever replaces it in switchsanity) will not be on the path to everything in level 8. This does **NOT** apply to the top level checks like the sax pad or Pound the X - these should still have MP on the path to them. Let me know if some path or WotH looks suspicious.
- Fixed an issue where the logic might expect you to exit Helm before it's shut off in LZR
- Fixed an issue with plando where it might force Key 8 to be at the End of Helm when it didn't need to be there