### PR TITLE
Fix code scanning alert no. 41: Uncontrolled data used in path expression

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -517,8 +517,8 @@ def get_seed():
         file_name = hash
     else:
         return make_response(json.dumps({"error": "error"}), 205)
-    fullpath = path.normpath(path.join("generated_seeds/", str(file_name) + ".json"))
-    if not fullpath.startswith("generated_seeds/") and not fullpath.startswith("generated_seeds\\"):
+    fullpath = path.realpath(path.join("generated_seeds/", str(file_name) + ".json"))
+    if not fullpath.startswith(path.realpath("generated_seeds/")):
         raise Exception("not allowed")
     # Check if the file exists
     if path.isfile(fullpath):


### PR DESCRIPTION
Fixes [https://github.com/2dos/DK64-Randomizer/security/code-scanning/41](https://github.com/2dos/DK64-Randomizer/security/code-scanning/41)

To fix the problem, we need to ensure that the constructed file path is securely validated before being used. This involves normalizing the path and ensuring it is contained within a safe root directory. We will use `os.path.realpath` to resolve the absolute path and then check that it starts with the intended directory.

1. Normalize the path using `os.path.realpath` to remove any ".." segments.
2. Check that the normalized path starts with the `generated_seeds/` directory.
3. Update the code to use the validated path for file operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
