### PR TITLE
Fix code scanning alert no. 40: Uncontrolled data used in path expression

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -12,6 +12,7 @@ from datetime import datetime as Datetime
 from io import BytesIO
 from multiprocessing import Process, Queue
 from os import environ, listdir, makedirs, path, remove, walk
+from werkzeug.utils import secure_filename
 from queue import Empty
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -512,13 +513,10 @@ def get_seed():
     """Get the lanky for a seed."""
     # Get the hash from the query string.
     hash = request.args.get("hash")
-    # check if hash contains special characters not in an approved list.
-    if all(c in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=" for c in hash):
-        file_name = hash
-    else:
-        return make_response(json.dumps({"error": "error"}), 205)
+    # Sanitize the hash parameter
+    file_name = secure_filename(hash)
     fullpath = path.normpath(path.join("generated_seeds/", str(file_name) + ".json"))
-    if not fullpath.startswith("generated_seeds/") and not fullpath.startswith("generated_seeds\\"):
+    if not fullpath.startswith(path.normpath("generated_seeds/")):
         raise Exception("not allowed")
     # Check if the file exists
     if path.isfile(fullpath):


### PR DESCRIPTION
Fixes [https://github.com/2dos/DK64-Randomizer/security/code-scanning/40](https://github.com/2dos/DK64-Randomizer/security/code-scanning/40)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root folder. Additionally, we should use `werkzeug.utils.secure_filename` to sanitize the `hash` parameter to eliminate any special characters.

1. Import `secure_filename` from `werkzeug.utils`.
2. Use `secure_filename` to sanitize the `hash` parameter.
3. Normalize the constructed file path using `os.path.normpath`.
4. Check that the normalized path starts with the root folder.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
