### PR TITLE
Fix code scanning alert no. 39: Uncontrolled data used in path expression

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -12,6 +12,7 @@ from datetime import datetime as Datetime
 from io import BytesIO
 from multiprocessing import Process, Queue
 from os import environ, listdir, makedirs, path, remove, walk
+from werkzeug.utils import secure_filename
 from queue import Empty
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -514,11 +515,11 @@ def get_seed():
     hash = request.args.get("hash")
     # check if hash contains special characters not in an approved list.
     if all(c in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=" for c in hash):
-        file_name = hash
+        file_name = secure_filename(hash)
     else:
         return make_response(json.dumps({"error": "error"}), 205)
     fullpath = path.normpath(path.join("generated_seeds/", str(file_name) + ".json"))
-    if not fullpath.startswith("generated_seeds/") and not fullpath.startswith("generated_seeds\\"):
+    if not fullpath.startswith(path.normpath("generated_seeds/")):
         raise Exception("not allowed")
     # Check if the file exists
     if path.isfile(fullpath):


### PR DESCRIPTION
Fixes [https://github.com/2dos/DK64-Randomizer/security/code-scanning/39](https://github.com/2dos/DK64-Randomizer/security/code-scanning/39)

To fix the problem, we need to ensure that the constructed file path is securely validated. This involves:
1. Normalizing the path using `os.path.normpath` to remove any ".." segments.
2. Ensuring that the normalized path starts with the intended base directory.
3. Using `werkzeug.utils.secure_filename` to sanitize the file name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
