### PR TITLE
Set default preset

### DIFF
--- a/static/js/initalize.js
+++ b/static/js/initalize.js
@@ -607,6 +607,7 @@ function load_databases() {
     try {
       var settingsdb = settingsdatabase.result;
       settingsdb.createObjectStore("saved_settings");
+      preset_select_changed("default")
     } catch {}
   };
   settingsdatabase.onsuccess = async function () {
@@ -1115,9 +1116,21 @@ function preset_select_changed(event) {
   const element = document.getElementById("presets");
   let presets = null;
 
-  for (const val of progression_presets) {
-    if (val.name === element.value) {
-      presets = val;
+  // if event is a string lets select the second option in the progressions_presets
+  if (typeof event === "string") {
+    for (const val of progression_presets) {
+      if (val.name === "Beginner Settings") {
+        presets = val;
+        break;
+      }
+    }
+  }
+  else{
+    for (const val of progression_presets) {
+      if (val.name === element.value) {
+        presets = val;
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
This pull request includes changes to the `static/js/initalize.js` file to improve the handling of preset selections and ensure the default preset is loaded correctly.

Enhancements to preset handling:

* [`static/js/initalize.js`](diffhunk://#diff-2a83f41f58bc5257f5563b4d7893fbb64c2e7227169b21f0d56c5521be7999f1R610): Added a call to `preset_select_changed("default")` in the `load_databases` function to ensure the default preset is selected when the database is initialized.
* [`static/js/initalize.js`](diffhunk://#diff-2a83f41f58bc5257f5563b4d7893fbb64c2e7227169b21f0d56c5521be7999f1R1119-R1133): Modified the `preset_select_changed` function to handle string events, allowing the selection of the "Beginner Settings" preset when the event is a string.