### PR TITLE
minigame logic fix

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -195,7 +195,7 @@ def should_skip_location(location, location_obj, spoiler, settings, region):
 
     # Skip bonus barrels based on settings and logic
     if location.bonusBarrel:
-        if (
+        if not (
             (location.bonusBarrel is MinigameType.BonusBarrel and settings.bonus_barrels == MinigameBarrels.skip)
             or (location.bonusBarrel is MinigameType.HelmBarrelFirst and (settings.helm_barrels == MinigameBarrels.skip or settings.helm_room_bonus_count == HelmBonuses.zero))
             or (location.bonusBarrel is MinigameType.HelmBarrelSecond and (settings.helm_barrels == MinigameBarrels.skip or settings.helm_room_bonus_count != HelmBonuses.two))


### PR DESCRIPTION
Missed an inversion - this meant that minigame logic was not being applied when it should and applied when it shouldn't.