### PR TITLE
progressively fixing

### DIFF
--- a/randomizer/Patching/ASMPatcher.py
+++ b/randomizer/Patching/ASMPatcher.py
@@ -469,6 +469,12 @@ CROSSHAIRS = {
 }
 
 
+def fixLankyIncompatibility(ROM_COPY: ROM):
+    """Ensure compatibility with .lanky files created during a specific time frame."""
+    offset_dict = populateOverlayOffsets(ROM_COPY)
+    writeValue(ROM_COPY, 0x80602AAC, Overlay.Static, 0x27A40018, offset_dict, 4)  # addiu $a0, $sp, 0x18I
+
+
 def patchAssemblyCosmetic(ROM_COPY: ROM, settings: Settings, has_dom: bool = True):
     """Patch assembly instructions that pertain to cosmetic changes."""
     offset_dict = populateOverlayOffsets(ROM_COPY)
@@ -2349,7 +2355,7 @@ def patchAssembly(ROM_COPY, spoiler):
     writeValue(ROM_COPY, 0x8060D01E, Overlay.Static, getLoSym("InvertedControls"), offset_dict)  # Change language store to inverted controls store
 
     writeFunction(ROM_COPY, 0x80602AB0, Overlay.Static, "filterSong", offset_dict)
-    writeValue(ROM_COPY, 0x80602AAC, Overlay.Static, 0x27A40018, offset_dict, 4)  # addiu $a0, $sp, 0x18I'm
+    writeValue(ROM_COPY, 0x80602AAC, Overlay.Static, 0x27A40018, offset_dict, 4)  # addiu $a0, $sp, 0x18I
     writeFunction(ROM_COPY, 0x80602B80, Overlay.Static, "filterSong_Cancelled", offset_dict)
     # Decompressed Overlays
     overlays_being_decompressed = [

--- a/randomizer/Patching/ApplyLocal.py
+++ b/randomizer/Patching/ApplyLocal.py
@@ -28,7 +28,7 @@ from randomizer.Patching.Hash import get_hash_images
 from randomizer.Patching.MusicRando import randomize_music
 from randomizer.Patching.Patcher import ROM
 from randomizer.Patching.Lib import recalculatePointerJSON, camelCaseToWords, writeText
-from randomizer.Patching.ASMPatcher import patchAssemblyCosmetic, disableDynamicReverb
+from randomizer.Patching.ASMPatcher import patchAssemblyCosmetic, disableDynamicReverb, fixLankyIncompatibility
 
 # from randomizer.Spoiler import Spoiler
 from randomizer.Settings import Settings, ExcludedSongs, DPadDisplays, KongModels
@@ -125,6 +125,8 @@ async def patching_response(data, from_patch_gen=False, lanky_from_history=False
         js.document.getElementById("patch_warning_message").innerHTML = (
             f"This patch was generated with version {patch_major}.{patch_minor}.{patch_patch} of the randomizer, but you are using version {major}.{minor}.{patch}. Cosmetic packs have been disabled for this patch."
         )
+        ROM_COPY = ROM()
+        fixLankyIncompatibility(ROM_COPY)
     elif from_patch_gen is True:
         sav = settings.rom_data
         if from_patch_gen:

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -1696,7 +1696,7 @@ class Settings:
             ProgressiveHintItem.req_pearl: 5,
             ProgressiveHintItem.req_cb: 3500,
         }
-        prog_max = prog_hint_max.get(self.progressive_hint_count, 0)
+        prog_max = prog_hint_max.get(self.progressive_hint_item, 0)
         if self.progressive_hint_count <= 0:
             # Disable progressive hints if hint text is 0, or less than 0
             self.progressive_hint_item = ProgressiveHintItem.off


### PR DESCRIPTION
- Fixed a bug where progressive hints would end up being disabled regardless of what the user chose.
- Fixed patch file incompatibility with versions that previously had that Override Cosmetics-dependant crash.