### PR TITLE
Random settings: fix for chaos ratio

### DIFF
--- a/static/presets/weights/weights_files.json
+++ b/static/presets/weights/weights_files.json
@@ -452,9 +452,9 @@
     },
     "chaos_blockers": 0.25,
     "chaos_ratio": {
-      "min": 0.1,
-      "max": 0.35,
-      "mean": 0.25
+      "min": 10,
+      "max": 35,
+      "mean": 25
     },
     "chunky_phase_slam_req": {
       "random": 1
@@ -884,9 +884,9 @@
     },
     "chaos_blockers": 0.6,
     "chaos_ratio": {
-      "min": 0.25,
-      "max": 0.7,
-      "mean": 0.4
+      "min": 25,
+      "max": 70,
+      "mean": 40
     },
     "chunky_phase_slam_req": {
       "blue": 0.7,
@@ -1359,9 +1359,9 @@
     },
     "chaos_blockers": 0.6,
     "chaos_ratio": {
-      "min": 0.25,
-      "max": 0.7,
-      "mean": 0.4
+      "min": 25,
+      "max": 70,
+      "mean": 40
     },
     "chunky_phase_slam_req": {
       "blue": 0.7,

--- a/wiki/article_markdown/custom_locations/RandomSettingsDifficult.MD
+++ b/wiki/article_markdown/custom_locations/RandomSettingsDifficult.MD
@@ -63,7 +63,7 @@ The generated settings will be of greater difficulty. Requirements for B. Locker
 	- Creepy Castle: 90%
 	- DK Isles: 50%
 - Chaos B. Lockers: 60%
-- Chaos Ratio: Between 0.25 and 0.7, usually close to 0.4
+- Chaos Ratio: Between 25 and 70, usually close to 40
 - Chunky Phase Slam Requirement: 
 	- Blue: 70%
 	- Red: 30%

--- a/wiki/article_markdown/custom_locations/RandomSettingsDifficultWithQolShuffle.MD
+++ b/wiki/article_markdown/custom_locations/RandomSettingsDifficultWithQolShuffle.MD
@@ -56,7 +56,7 @@ The generated settings will be of greater difficulty. Requirements for B. Locker
 	- Creepy Castle: 90%
 	- DK Isles: 50%
 - Chaos B. Lockers: 60%
-- Chaos Ratio: Between 0.25 and 0.7, usually close to 0.4
+- Chaos Ratio: Between 25 and 70, usually close to 40
 - Chunky Phase Slam Requirement: 
 	- Blue: 70%
 	- Red: 30%

--- a/wiki/article_markdown/custom_locations/RandomSettingsStandard.MD
+++ b/wiki/article_markdown/custom_locations/RandomSettingsStandard.MD
@@ -63,7 +63,7 @@ The generated settings will be of average difficulty. Requirements for B. Locker
 	- Creepy Castle: 70%
 	- DK Isles: 20%
 - Chaos B. Lockers: 25%
-- Chaos Ratio: Between 0.1 and 0.35, usually close to 0.25
+- Chaos Ratio: Between 10 and 35, usually close to 25
 - Chunky Phase Slam Requirement: 
 	- Random: 100%
 - Helm Door 2 Requirement Item: 


### PR DESCRIPTION
These needed to be percentage values instead of decimals.