### PR TITLE
woth level access fix (and friends

### DIFF
--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -996,12 +996,12 @@ class Spoiler:
                 filtered_hint = filtered_hint.replace("\x0d", "")
                 human_hint_list[name] = filtered_hint
             humanspoiler["Wrinkly Hints"] = human_hint_list
-            humanspoiler["Unhinted Score"] = self.unhinted_score
-            humanspoiler["Potentially Awful Locations"] = {}
-            for location_description in self.poor_scoring_locations:
-                humanspoiler["Potentially Awful Locations"][location_description] = self.poor_scoring_locations[location_description]
-            if hasattr(self, "hint_swap_advisory"):
-                humanspoiler["Hint Swap Advisory"] = self.hint_swap_advisory
+            # humanspoiler["Unhinted Score"] = self.unhinted_score
+            # humanspoiler["Potentially Awful Locations"] = {}
+            # for location_description in self.poor_scoring_locations:
+            #     humanspoiler["Potentially Awful Locations"][location_description] = self.poor_scoring_locations[location_description]
+            # if hasattr(self, "hint_swap_advisory"):
+            #     humanspoiler["Hint Swap Advisory"] = self.hint_swap_advisory
         self.json = json.dumps(humanspoiler, indent=4)
 
     def UpdateKasplats(self, kasplat_map: Dict[Locations, Kongs]) -> None:

--- a/templates/macros.html.jinja2
+++ b/templates/macros.html.jinja2
@@ -1,4 +1,4 @@
-{% macro list_selector(list, name, title, tooltip, size, includeDisclaimer=False, overrideDisclaimer="") %}
+{% macro list_selector(list, name, title, tooltip, size, includeDisclaimer=0, overrideDisclaimer="") %}
     <!-- Icon triggers modal -->
     <input class="customize"
            type="button"

--- a/templates/music.html.jinja2
+++ b/templates/music.html.jinja2
@@ -111,7 +111,7 @@
                                value="True" checked/>
                         Music Filtering
                     </label>
-                    {{ list_selector(song_filters, "music_filtering", "Music Filtering", "This will open a popup that will let you customize how the game applies additional filters.", 2, True, "These filters only work for .candy files.") }}
+                    {{ list_selector(song_filters, "music_filtering", "Music Filtering", "This will open a popup that will let you customize how the game applies additional filters.", 2, 1, "These filters only work for .candy files.") }}
                     {# Remove end </div> as it's included in the macro for formatting #}
             </div>
         </div>

--- a/templates/overworld.html.jinja2
+++ b/templates/overworld.html.jinja2
@@ -38,7 +38,7 @@
                                 value="True"/>
                             Remove Barriers
                         </label>
-                        {{ list_selector(remove_barriers, "remove_barriers", "REMOVE BARRIERS", "This will open a popup that will let you customize what barriers are removed.&#10;This defaults to All options.", 12, True) }}
+                        {{ list_selector(remove_barriers, "remove_barriers", "REMOVE BARRIERS", "This will open a popup that will let you customize what barriers are removed.&#10;This defaults to All options.", 12, 1) }}
                         {# Remove end </div> as it's included in the macro for formatting #}
                     <div class="form-check form-switch item-switch">
                         <label data-toggle="tooltip"
@@ -62,7 +62,7 @@
                                 value="True"/>
                             Faster Checks
                         </label>
-                        {{ list_selector(faster_checks, "faster_checks", "FASTER CHECKS", "This will open a popup that will let you customize what checks are sped up.&#10;This defaults to All options.", 12, True) }}
+                        {{ list_selector(faster_checks, "faster_checks", "FASTER CHECKS", "This will open a popup that will let you customize what checks are sped up.&#10;This defaults to All options.", 12, 1) }}
                         {# Remove end </div> as it's included in the macro for formatting #}
                     <div class="form-check form-switch item-switch">
                         <label data-toggle="tooltip"
@@ -113,7 +113,7 @@
                                 </option>
                             </select>
                             <div style="padding: 5px;">
-                                {{ list_selector(glitches, "glitches", "GLITCHES", "This will open a popup that will let you customize what tricks are considered by logic with glitch logic.&#10;This defaults to All options.", 16, True) }}
+                                {{ list_selector(glitches, "glitches", "GLITCHES", "This will open a popup that will let you customize what tricks are considered by logic with glitch logic.&#10;This defaults to All options.", 16, 1) }}
                                 {# Remove end </div> as it's included in the macro for formatting #}
                             </div>
                         </div>

--- a/templates/qualityoflife.html.jinja2
+++ b/templates/qualityoflife.html.jinja2
@@ -15,7 +15,7 @@
                                checked/>
                         Misc Changes
                     </label>
-                    {{ list_selector(misc_changes, "misc_changes", "MISC CHANGES", "This will open a popup that will let you customize what Quality of Life Options are active.&#10;This defaults to All options.", 18, True) }}
+                    {{ list_selector(misc_changes, "misc_changes", "MISC CHANGES", "This will open a popup that will let you customize what Quality of Life Options are active.&#10;This defaults to All options.", 18, 1) }}
                     {# Remove end </div> as it's included in the macro for formatting #}
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"

--- a/templates/rando_options.html.jinja2
+++ b/templates/rando_options.html.jinja2
@@ -20,7 +20,7 @@
                                 <path d="M14.876,2.672a3.309,3.309,0,0,0-5.752,0L.414,18.19a3.178,3.178,0,0,0,.029,3.189A3.264,3.264,0,0,0,3.29,23H20.71a3.264,3.264,0,0,0,2.847-1.621,3.178,3.178,0,0,0,.029-3.189ZM12,19a1,1,0,1,1,1-1A1,1,0,0,1,12,19Zm1-5a1,1,0,0,1-2,0V8a1,1,0,0,1,2,0Z"/>
                             </svg>
                         </span>
-                        {{ list_selector(itemRando, "item_rando_list", "ITEM RANDO SELECTOR", "This will open a popup that will let you customize what items are shuffled in the pool.&#10;This defaults to All options.", 15, True) }}
+                        {{ list_selector(itemRando, "item_rando_list", "ITEM RANDO SELECTOR", "This will open a popup that will let you customize what items are shuffled in the pool.&#10;This defaults to All options.", 15, 1) }}
                     {# Remove end </div> as it's included in the macro for formatting #}
                     <div class="form-check form-switch item-switch" style="max-height: 24px;">
                         <label data-toggle="tooltip" title="Sparkling enemies can drop major items. Highly chaotic, adding lots of checks all over the world.">
@@ -141,7 +141,7 @@
                                 value="True"/>
                         Colored Bananas
                     </label>
-                    {{ list_selector(cb_rando_levels, "cb_rando_list", "LEVELS", "This will open a popup that will let you customize what levels have CB rando in the game.&#10;This defaults to All options.", 8, True) }}
+                    {{ list_selector(cb_rando_levels, "cb_rando_list", "LEVELS", "This will open a popup that will let you customize what levels have CB rando in the game.&#10;This defaults to All options.", 8, 1) }}
                 {# Remove end </div> as it's included in the macro for formatting #}
                 <div class="item-select">
                     <p class="select-title">Bananaports</p>
@@ -167,7 +167,7 @@
                             </option>
                         </select>
                         <div style="padding: 5px;">
-                            {{ list_selector(vanilla_warps, "warp_level_list", "LEVEL SELECTOR", "This will open a popup that will let you customize what levels' warps are in the pool. Any level not selected will have its vanilla warp locations.&#10;This defaults to All levels.", 10, True) }}
+                            {{ list_selector(vanilla_warps, "warp_level_list", "LEVEL SELECTOR", "This will open a popup that will let you customize what levels' warps are in the pool. Any level not selected will have its vanilla warp locations.&#10;This defaults to All levels.", 10, 1) }}
                         {# Remove end </div> as it's included in the macro for formatting #}
                     </div>
                 </div>
@@ -187,7 +187,7 @@
                                 value="True"/>
                         Shuffle Enemies
                     </label>
-                    {{ list_selector(enemies, "enemies", "ENEMIES", "This will open a popup that will let you customize what enemies appear in the game.&#10;This defaults to All options.", 16, True) }}
+                    {{ list_selector(enemies, "enemies", "ENEMIES", "This will open a popup that will let you customize what enemies appear in the game.&#10;This defaults to All options.", 16, 1) }}
                 {# Remove end </div> as it's included in the macro for formatting #}
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"
@@ -200,7 +200,7 @@
                                value="True"/>
                         Shuffle Bonus Barrels
                     </label>
-                    {{ list_selector(minigames, "minigames_list", "MINIGAME SELECTOR", "This will open a popup that will let you customize what Bonus Games are in the pool.&#10;This defaults to All minigames.", 18, True) }}
+                    {{ list_selector(minigames, "minigames_list", "MINIGAME SELECTOR", "This will open a popup that will let you customize what Bonus Games are in the pool.&#10;This defaults to All minigames.", 18, 1) }}
                 {# Remove end </div> as it's included in the macro for formatting #}
                 {{ toggle_input("enemy_speed_rando", "Shuffle Enemy Speed", "Enemy speeds are randomized.") }}
                 {{ toggle_input("randomize_enemy_sizes", "Random Enemy Size", "The size of enemies is randomized.") }}


### PR DESCRIPTION
- Reworked how the WotH paring would handle things not on the path to anything else. Now it checks if the items are necessary to beat the game with fewer assumptions. If it is still required to beat the game, it remains WotH.
- Added fill exceptions for when the extremely rare pathless phase would leak through the path generation. It now crashes out and prompts the user to report it. This is far, far, FAR, **_FAR_** better than letting the seed leak out into the world.
- Fixed an issue where the multiselector disclaimer about "when none are selected all are selected" wasn't appearing for some reason. This was fixed by making it a 0/1 int switch instead of a boolean, which worked for ??? reasons.