### PR TITLE
Fix CLO T&S

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -1481,11 +1481,12 @@ def compileHints(spoiler: Spoiler) -> bool:
             if coin_flip == 1:
                 # Option A: hint the region the item is in
                 region = spoiler.RegionList[GetRegionIdOfLocation(spoiler, loc_id)]
-                if region.hint_name != HintRegion.Bosses:
+                if not region.isCBRegion():
                     hinted_location_text = level_colors[region.level] + region.getHintRegionName() + level_colors[region.level]
+                    message += f" Try looking in the {hinted_location_text}."
                 else:
-                    hinted_location_text = level_colors[Levels.DKIsles] + region.getHintRegionName() + level_colors[Levels.DKIsles]
-                message += f" Try looking in the {hinted_location_text}."
+                    hinted_location_text = level_colors[region.level] + level_list[location.level] + level_colors[Levels.DKIsles]
+                    message += f" Try collecting colored bananas in {hinted_location_text}."
             else:
                 # Option B: hint the kong + level the item is in, using similar systems as other hints to instead hint kasplats/shops/specific types of items
                 level_color = level_colors[location.level]

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -111,7 +111,7 @@ class Settings:
         if self.hard_troff_n_scoff:
             self.troff_min = [0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8]  # Add 20% to the minimum for hard T&S
         # In hard level progression we go through levels in a random order, so we set every level's troff min weight to the largest weight
-        if self.hard_level_progression:
+        if self.level_randomization == LevelRandomization.level_order_complex:
             self.troff_min = [self.troff_min[-1] for x in self.troff_min]
 
         CompleteVanillaPrices()

--- a/static/js/rando_options.js
+++ b/static/js/rando_options.js
@@ -1148,8 +1148,8 @@ function toggle_item_rando() {
   if (disabled || !shopsInPool) {
     elements.smallerShops.checked = false;
   }
-  elements.moveVanilla.toggleAttribute("disabled", shopsInPool);
-  elements.moveRando.toggleAttribute("disabled", shopsInPool);
+  elements.moveVanilla.toggleAttribute("disabled", shopsInPool && !disabled);
+  elements.moveRando.toggleAttribute("disabled", shopsInPool && !disabled);
   elements.enemyDropRando.toggleAttribute("disabled", disabled);
   if (disabled) {
     elements.enemyDropRando.checked = false;


### PR DESCRIPTION
- Fixed an issue where CLO T&S could roll noticeably lower than intended
- Item Hinting hints now also combine a level's medal rewards and boss when pointing at something you could obtain by collecting colored bananas. This is to match the behavior of path hints hinting things in the same way.
- Fixed an issue where the "Move Randomizer" dropdown that nobody uses wasn't working quite right, preventing some settings from being created.