### PR TITLE
Krem Isle Dentistry

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -3767,6 +3767,15 @@ def CheckForIncompatibleSettings(settings: Settings) -> None:
             found_incompatibilities += "Cannot turn off Fast Start with a Random Starting Location. "
         if not settings.start_with_slam:
             found_incompatibilities += "Cannot turn off Fast Start unless you are guaranteed to start with a Progressive Slam. "
+    if not settings.shuffle_items:
+        if not settings.start_with_slam:
+            found_incompatibilities += "Cannot turn off Item Randomizer without starting with a Progressive Slam. "
+        if settings.training_barrels != TrainingBarrels.normal:
+            found_incompatibilities += "Cannot turn off Item Randomizer without starting with all Training Moves. "
+        if settings.climbing_status != ClimbingStatus.normal:
+            found_incompatibilities += "Cannot turn off Item Randomizer without starting with Climbing. "
+    if not settings.is_valid_item_pool():
+        found_incompatibilities +=  "Item pool is not a valid combination of items and cannot successfully fill the world. "
     if found_incompatibilities != "":
         raise Ex.SettingsIncompatibleException(found_incompatibilities)
 

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -3775,7 +3775,7 @@ def CheckForIncompatibleSettings(settings: Settings) -> None:
         if settings.climbing_status != ClimbingStatus.normal:
             found_incompatibilities += "Cannot turn off Item Randomizer without starting with Climbing. "
     if not settings.is_valid_item_pool():
-        found_incompatibilities +=  "Item pool is not a valid combination of items and cannot successfully fill the world. "
+        found_incompatibilities += "Item pool is not a valid combination of items and cannot successfully fill the world. "
     if found_incompatibilities != "":
         raise Ex.SettingsIncompatibleException(found_incompatibilities)
 

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -314,10 +314,10 @@ LogicRegions = {
         TransitionFront(Regions.HideoutHelmLobby, lambda l: l.settings.open_lobbies or (Events.CavesKeyTurnedIn in l.Events and Events.CastleKeyTurnedIn in l.Events), Transitions.IslesMainToHelmLobby),
         # These next two transitions are only necessary in LZR, so the assumption of level entry necessary for level 8 (that is never applied in LZR) is safe here
         TransitionFront(Regions.KremIsleTopLevel, lambda l: not l.assumeLevel8Entry and (l.settings.open_lobbies or (Events.CavesKeyTurnedIn in l.Events and Events.CastleKeyTurnedIn in l.Events))),
-        # This fall could be a logical point of progression, but you have to surive the drop
-        TransitionFront(Regions.KremIsleBeyondLift, lambda l: not l.assumeLevel8Entry and l.CanSurviveFallDamage()),
-        # If you were to die to fall damage here, you'd be sent to the Isles spawn. This is effectively a one-off deathwarp consideration.
-        TransitionFront(Regions.IslesMain, lambda l: True),
+        # This fall could be a logical point of progression, but you have to survive the drop OR have the keys and crouch drop there - the Open Lobbies check effectively prevents keys from being on the path for this transition in very rare worlds
+        TransitionFront(Regions.KremIsleBeyondLift, lambda l: l.CanSurviveFallDamage() or l.settings.open_lobbies or (Events.CavesKeyTurnedIn in l.Events and Events.CastleKeyTurnedIn in l.Events)),
+        # If you were to die to fall damage here, you'd be sent to the Isles spawn. This is effectively a one-off deathwarp consideration (but only if dying isn't catastrophic!)
+        TransitionFront(Regions.IslesMain, lambda l: lambda l: not l.settings.perma_death),
     ]),
 
     Regions.IslesSnideRoom: Region("Isles Snide Room", HintRegion.KremIsles, Levels.DKIsles, True, None, [

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -146,8 +146,6 @@ class Spoiler:
         self.tied_hint_regions = [HintRegion.NoRegion] * 35
         self.settings.finalize_world_settings(self)
         self.settings.update_valid_locations(self)
-        if not self.settings.is_valid_item_pool():
-            raise Ex.SettingsIncompatibleException("Item pool is not a valid combination of items and cannot successfully fill the world.")
 
     def FlushAllExcessSpoilerData(self):
         """Flush all spoiler data that is not needed for the final result."""


### PR DESCRIPTION
- Banned the Krem Isle Mouth entrance from being your random starting location in Quad Damage and OHKO
- Cleaned up the logic around the Krem Isle Mouth region to better handle some weirdly specific circumstances
- Shuffled some incompatible settings checks around to not crash out when patching from a lanky file. This isn't complete, as we need to handle a couple plando checks somewhere else as well. This PR just covers the most likely issues.