### PR TITLE
Color/Status for Starting Move Pools

### DIFF
--- a/static/js/rando_options.js
+++ b/static/js/rando_options.js
@@ -1278,6 +1278,7 @@ function item_rando_list_changed(evt) {
   } else {
     kongRando.removeAttribute("disabled");
   }
+  savesettings();
 }
 
 // Validate Fast Start Status
@@ -2060,6 +2061,87 @@ document
     moveSelectedStartingMoves(5);
   });
 
+document
+  .getElementById("starting_moves_modal")
+  .addEventListener("click", function (event) {
+    assessAllItemPoolCounts();
+  });
+
+document
+  .getElementById("starting_moves_list_count_1").addEventListener("change", function (event) {
+    assessItemPoolCount(1);
+  });
+
+document
+  .getElementById("starting_moves_list_count_2").addEventListener("change", function (event) {
+    assessItemPoolCount(2);
+  });
+
+document
+  .getElementById("starting_moves_list_count_3").addEventListener("change", function (event) {
+    assessItemPoolCount(3);
+  });
+
+document
+  .getElementById("starting_moves_list_count_4").addEventListener("change", function (event) {
+    assessItemPoolCount(4);
+  });
+
+document
+  .getElementById("starting_moves_list_count_5").addEventListener("change", function (event) {
+    assessItemPoolCount(5);
+  });
+
+function assessAllItemPoolCounts() {
+  // Determine the label/coloring status of all item pools at once. This also shows and hides entire columns.
+  found_not_empty_item_pool = false;
+  for (let i = 5; i >= 1; i--) {
+    assessItemPoolCount(i);
+
+    const list_selector = document.getElementById("starting_moves_list_" + i);
+    const selector_column = document.getElementById("starting_moves_list_column_" + i);
+    selector_column.removeAttribute("hidden");
+    const number_of_moves_in_pool = Array.from(list_selector.options).filter(option => !option.hidden).length;
+    if (!found_not_empty_item_pool && number_of_moves_in_pool > 0) {
+      found_not_empty_item_pool = true;
+      for (let j = i+2; j <= 5; j++) {
+        const empty_selector_column = document.getElementById("starting_moves_list_column_" + j);
+        empty_selector_column.setAttribute("hidden", "hidden");
+      }
+    }
+  }
+}
+
+function assessItemPoolCount(target_list_id) {
+  // Determine if the given item pool is starting with all, some, or none of the item in the list and update the UI accordingly.
+  const move_count = document.getElementById("starting_moves_list_count_" + target_list_id);
+  const list_selector = document.getElementById("starting_moves_list_" + target_list_id);
+  const mover_button = document.getElementById("starting_moves_list_mover_" + target_list_id);
+  const all_label = document.getElementById("starting_moves_list_all_" + target_list_id);
+  all_label.setAttribute("hidden", "hidden");
+  const some_label = document.getElementById("starting_moves_list_some_" + target_list_id);
+  some_label.setAttribute("hidden", "hidden");
+  const none_label = document.getElementById("starting_moves_list_none_" + target_list_id);
+  none_label.setAttribute("hidden", "hidden");
+  const number_of_moves_in_pool = Array.from(list_selector.options).filter(option => !option.hidden).length;
+  if (move_count.value == 0 || number_of_moves_in_pool == 0) {
+    none_label.removeAttribute("hidden");
+    list_selector.style = "border-color: red";
+    move_count.style = "border-color: red";
+    mover_button.style = "border-color: red";
+  } else if (move_count.value >= number_of_moves_in_pool) {
+      all_label.removeAttribute("hidden");
+      list_selector.style = "border-color: green";
+      move_count.style = "border-color: green";
+      mover_button.style = "border-color: green";
+  } else {
+    some_label.removeAttribute("hidden");
+    list_selector.style = "border-color: orange";
+    move_count.style = "border-color: orange";
+    mover_button.style = "border-color: orange";
+  }
+}
+
 function moveSelectedStartingMoves(target_list_id) {
   let selected_moves = [];
   for (let i = 1; i <= 5; i++) {
@@ -2084,6 +2166,7 @@ function moveSelectedStartingMoves(target_list_id) {
     }
     target_selector.appendChild(moved_move);
   }
+  assessAllItemPoolCounts();
   savesettings();
 }
 

--- a/static/styles/gui.css
+++ b/static/styles/gui.css
@@ -1120,3 +1120,9 @@ input[type=range][disabled]::-ms-fill-upper {
 .btn-custom-large {
   font-size: 20px;
 }
+
+.move_count_button {
+  width: 15%;
+  display: inline-block;
+  margin-top: 0;
+}

--- a/templates/rando_options.html
+++ b/templates/rando_options.html
@@ -472,7 +472,10 @@
                 <br/>
                 <em>Use the presets at the bottom as quick actions.</em>
                 <div class="flex-container" style="justify-content: space-around; margin-top: 15px;">
-                    <div class="flex-column-container">
+                    <div id="starting_moves_list_column_1" class="flex-column-container">
+                        <b id="starting_moves_list_all_1" style="font-style: italic; color: green;">Start with All</b>
+                        <b id="starting_moves_list_some_1" style="font-style: italic; color: orange;">Start with Some</b>
+                        <b id="starting_moves_list_none_1" style="font-style: italic; color: red;">Start with None</b>
                         <button type="button" class="btn btn-secondary" id="starting_moves_list_mover_1">Pool 1</button>
                         <select id="starting_moves_list_1" name="starting_moves_list_1" class="starting_moves_list multi-select" multiple>
                             {% for item in custom_starting_moves %}
@@ -485,8 +488,7 @@
                                 display_name="Move Count"
                                 name="starting_moves_list_count_1"
                                 id="starting_moves_list_count_1"
-                                style="width: 15%; display: inline-block; margin-top: 0;"
-                                class="form-control center-div"
+                                class="form-control center-div move_count_button"
                                 type="number"
                                 data-toggle="tooltip"
                                 title="Amount of moves given from this item pool."
@@ -494,7 +496,10 @@
                                 placeholder="0"
                                 />
                     </div>
-                    <div class="flex-column-container">
+                    <div id="starting_moves_list_column_2" class="flex-column-container">
+                        <b id="starting_moves_list_all_2" style="font-style: italic; color: green;">Start with All</b>
+                        <b id="starting_moves_list_some_2" style="font-style: italic; color: orange;">Start with Some</b>
+                        <b id="starting_moves_list_none_2" style="font-style: italic; color: red;">Start with None</b>
                         <button type="button" class="btn btn-secondary" id="starting_moves_list_mover_2">Pool 2</button>
                         <select id="starting_moves_list_2" name="starting_moves_list_2" class="starting_moves_list multi-select" multiple>
                         </select>
@@ -504,8 +509,7 @@
                                 display_name="Move Count"
                                 name="starting_moves_list_count_2"
                                 id="starting_moves_list_count_2"
-                                style="width: 15%; display: inline-block; margin-top: 0;"
-                                class="form-control center-div"
+                                class="form-control center-div move_count_button"
                                 type="number"
                                 data-toggle="tooltip"
                                 title="Amount of moves given from this item pool."
@@ -513,7 +517,10 @@
                                 placeholder="0"
                                 />
                     </div>
-                    <div class="flex-column-container">
+                    <div id="starting_moves_list_column_3" class="flex-column-container">
+                        <b id="starting_moves_list_all_3" style="font-style: italic; color: green;">Start with All</b>
+                        <b id="starting_moves_list_some_3" style="font-style: italic; color: orange;">Start with Some</b>
+                        <b id="starting_moves_list_none_3" style="font-style: italic; color: red;">Start with None</b>
                         <button type="button" class="btn btn-secondary" id="starting_moves_list_mover_3">Pool 3</button>
                         <select id="starting_moves_list_3" name="starting_moves_list_3" class="starting_moves_list multi-select" multiple>
                         </select>
@@ -523,8 +530,7 @@
                                 display_name="Move Count"
                                 name="starting_moves_list_count_3"
                                 id="starting_moves_list_count_3"
-                                style="width: 15%; display: inline-block; margin-top: 0;"
-                                class="form-control center-div"
+                                class="form-control center-div move_count_button"
                                 type="number"
                                 data-toggle="tooltip"
                                 title="Amount of moves given from this item pool."
@@ -532,7 +538,10 @@
                                 placeholder="0"
                                 />
                     </div>
-                    <div class="flex-column-container">
+                    <div id="starting_moves_list_column_4" class="flex-column-container">
+                        <b id="starting_moves_list_all_4" style="font-style: italic; color: green;">Start with All</b>
+                        <b id="starting_moves_list_some_4" style="font-style: italic; color: orange;">Start with Some</b>
+                        <b id="starting_moves_list_none_4" style="font-style: italic; color: red;">Start with None</b>
                         <button type="button" class="btn btn-secondary" id="starting_moves_list_mover_4">Pool 4</button>
                         <select id="starting_moves_list_4" name="starting_moves_list_4" class="starting_moves_list multi-select" multiple>
                         </select>
@@ -542,8 +551,7 @@
                                 display_name="Move Count"
                                 name="starting_moves_list_count_4"
                                 id="starting_moves_list_count_4"
-                                style="width: 15%; display: inline-block; margin-top: 0;"
-                                class="form-control center-div"
+                                class="form-control center-div move_count_button"
                                 type="number"
                                 data-toggle="tooltip"
                                 title="Amount of moves given from this item pool."
@@ -551,7 +559,10 @@
                                 placeholder="0"
                                 />
                     </div>
-                    <div class="flex-column-container">
+                    <div id="starting_moves_list_column_5" class="flex-column-container">
+                        <b id="starting_moves_list_all_5" style="font-style: italic; color: green;">Start with All</b>
+                        <b id="starting_moves_list_some_5" style="font-style: italic; color: orange;">Start with Some</b>
+                        <b id="starting_moves_list_none_5" style="font-style: italic; color: red;">Start with None</b>
                         <button type="button" class="btn btn-secondary" id="starting_moves_list_mover_5">Pool 5</button>
                         <select id="starting_moves_list_5" name="starting_moves_list_5" class="starting_moves_list multi-select" multiple>
                         </select>
@@ -561,8 +572,7 @@
                                 display_name="Move Count"
                                 name="starting_moves_list_count_5"
                                 id="starting_moves_list_count_5"
-                                style="width: 15%; display: inline-block; margin-top: 0;"
-                                class="form-control center-div"
+                                class="form-control center-div move_count_button"
                                 type="number"
                                 data-toggle="tooltip"
                                 title="Amount of moves given from this item pool."


### PR DESCRIPTION
Improved the user experience of the starting move selectors:
- A color outline will help visually indicate if you are going to start with all/some/none of the items in that pool
- Pools beyond the first empty item pool will no longer be shown to simplify the modal some. There is still a cap of 5 pools.