### PR TITLE
dos' doors implementation

### DIFF
--- a/randomizer/Enums/Settings.jsonc
+++ b/randomizer/Enums/Settings.jsonc
@@ -1092,7 +1092,8 @@
     "cb_rando_enabled": 201,
     "cb_rando_list_selected": 202,
     "crown_enemy_difficulty": 203,
-    "dk_portal_location_rando_v2": 204
+    "dk_portal_location_rando_v2": 204,
+    "dos_door_rando": 205
   },
   /*
     SettingsStringDataType:
@@ -1661,7 +1662,8 @@
     "SettingsStringEnum.starting_moves_list_5": {
       "obj": "SettingsStringDataType.list"
     },
-    "SettingsStringEnum.starting_moves_list_count_5": { "obj": "SettingsStringDataType.int16" }
+    "SettingsStringEnum.starting_moves_list_count_5": { "obj": "SettingsStringDataType.int16" },
+    "SettingsStringEnum.dos_door_rando": { "obj": "SettingsStringDataType.bool" }
   },
   // ALL LIST SETTINGS NEED AN ENTRY HERE!
   // Another map for list settings, for the underlying data type of the list.

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -3598,7 +3598,7 @@ def ShuffleMisc(spoiler: Spoiler) -> None:
     if spoiler.settings.progressive_hint_item != ProgressiveHintItem.off:
         SetProgressiveHintDoorLogic(spoiler)
     # T&S and Wrinkly Door Shuffle
-    if spoiler.settings.vanilla_door_rando:
+    if spoiler.settings.vanilla_door_rando:  # Includes Dos' Doors
         ShuffleVanillaDoors(spoiler)
         if spoiler.settings.dk_portal_location_rando_v2 != DKPortalRando.off:
             ShuffleDoors(spoiler, True)

--- a/randomizer/Lists/DoorLocations.py
+++ b/randomizer/Lists/DoorLocations.py
@@ -81,6 +81,7 @@ class DoorData:
         default_kong=None,
         door_type: list[DoorType] = [DoorType.boss, DoorType.dk_portal, DoorType.wrinkly],
         dk_portal_logic=None,
+        dos_door=False,
     ):
         """Initialize with provided data."""
         self.name = name
@@ -100,6 +101,7 @@ class DoorData:
         self.placed = placed
         self.default_kong = default_kong
         self.default_placed = placed  # info about what door_type a door location is in vanilla
+        self.dos_door = dos_door  # We need extra doors in Japes to make Dos' Doors work - this flag is for specifically that
         self.door_type = door_type.copy()  # denotes what types it can be
         if dk_portal_logic is None:
             self.dk_portal_logic = lambda s: False
@@ -222,6 +224,7 @@ door_locations = {
             placed=DoorType.wrinkly,
             door_type=[DoorType.wrinkly],
             default_kong=Kongs.tiny,
+            dos_door=True,
         ),  # Tiny Door
         DoorData(
             name="Japes Lobby - Close Left",
@@ -323,6 +326,7 @@ door_locations = {
             location=[1857.0, 539.0, 3196.0, 79.5],
             group=6,
             moveless=False,
+            dos_door=True,
         ),
         DoorData(
             name="Behind Rambi Door - watery room - left",
@@ -602,6 +606,7 @@ door_locations = {
             location=[903.167, 280, 1044.455, 180],
             group=11,
             placed=DoorType.dk_portal,
+            dos_door=True,
         ),
         DoorData(
             name="Diddy Mountain - Next to the slam switch",
@@ -744,6 +749,7 @@ door_locations = {
             placed=DoorType.wrinkly,
             door_type=[DoorType.wrinkly],
             default_kong=Kongs.tiny,
+            dos_door=True,
         ),  # Tiny Door
         DoorData(
             name="Aztec Lobby - Behind Feather Door",
@@ -1384,6 +1390,7 @@ door_locations = {
             placed=DoorType.wrinkly,
             door_type=[DoorType.wrinkly],
             default_kong=Kongs.donkey,
+            dos_door=True,
         ),  # DK Door
         DoorData(
             name="Factory Lobby - Top Left",
@@ -1831,6 +1838,7 @@ door_locations = {
             placed=DoorType.wrinkly,
             door_type=[DoorType.wrinkly],
             default_kong=Kongs.tiny,
+            dos_door=True,
         ),  # Tiny Door
         DoorData(
             name="Galleon Lobby - Close Left",
@@ -2517,6 +2525,7 @@ door_locations = {
             placed=DoorType.wrinkly,
             door_type=[DoorType.wrinkly],
             default_kong=Kongs.tiny,
+            dos_door=True,
         ),  # Custom Location (Removing Wheel)
         DoorData(
             name="Forest Lobby - Near Entrance",
@@ -3050,6 +3059,7 @@ door_locations = {
             placed=DoorType.wrinkly,
             door_type=[DoorType.wrinkly],
             default_kong=Kongs.lanky,
+            dos_door=True,
         ),  # Lanky Door
         DoorData(
             name="Caves Lobby - Far Right",
@@ -3740,6 +3750,7 @@ door_locations = {
             placed=DoorType.wrinkly,
             door_type=[DoorType.wrinkly],
             default_kong=Kongs.chunky,
+            dos_door=True,
         ),  # Chunky Door
         DoorData(
             name="Near Greenhouse",

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -756,6 +756,7 @@ class Settings:
             "exit": 0,
         }
         self.vanilla_door_rando = False
+        self.dos_door_rando = False
         self.minigames_list_selected = []
         self.item_rando_list_selected = []
         self.misc_changes_selected = []
@@ -957,6 +958,12 @@ class Settings:
             ]
             ItemPool.JunkSharedMoves = [Items.ProgressiveAmmoBelt, Items.ProgressiveAmmoBelt]
 
+        # Dos' Doors require all of these to be on - it's a variant on vanilla door shuffle
+        if self.dos_door_rando:
+            self.vanilla_door_rando = True
+            # The UI should force this, but DK Portal Rando must be at least somewhat enabled for Dos' Doors
+            if self.dk_portal_location_rando_v2 == DKPortalRando.off:
+                self.dk_portal_location_rando_v2 = DKPortalRando.main_only
         # If we're using the vanilla door shuffle, turn both wrinkly and tns rando on
         if self.vanilla_door_rando:
             self.wrinkly_location_rando = True

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -305,6 +305,7 @@ class Spoiler:
         settings["Randomize Banana Fairies"] = self.settings.random_fairies
         settings["Randomize Battle Arenas"] = self.settings.crown_placement_rando
         settings["Vanilla Door Shuffle"] = self.settings.vanilla_door_rando
+        settings["Dos' Doors"] = self.settings.dos_door_rando
         settings["Randomize Wrinkly Doors"] = self.settings.wrinkly_location_rando
         settings["Randomize T&S Portals"] = self.settings.tns_location_rando
         settings["Puzzle Randomization"] = self.settings.puzzle_rando_difficulty.name

--- a/static/js/rando_options.js
+++ b/static/js/rando_options.js
@@ -480,6 +480,31 @@ document
   .getElementById("faster_checks_enabled")
   .addEventListener("click", disable_faster_checks);
 
+// Force Vanilla Door Rando on and enforce DK Portal Rando is enabled
+function toggle_dos_door_rando() {
+  const dosDoorRando  = document.getElementById("dos_door_rando");
+  const vanillaDoorShuffle = document.getElementById("vanilla_door_rando");
+  const dkPortalRandoSelect = document.getElementById("dk_portal_location_rando_v2");
+  const dkPortalRandoVanilla = document.querySelector("#dk_portal_location_rando_v2 option[id='off']");
+
+  if (dosDoorRando.checked) {
+    vanillaDoorShuffle.checked = true;
+    vanillaDoorShuffle.setAttribute("disabled", "disabled");
+    if (dkPortalRandoSelect.value == "off") {
+      dkPortalRandoSelect.value = "main_only";
+    }
+    dkPortalRandoVanilla.setAttribute("disabled", "disabled");
+    toggle_vanilla_door_rando();
+  } else {
+    vanillaDoorShuffle.removeAttribute("disabled");
+    dkPortalRandoVanilla.removeAttribute("disabled");
+  }
+}
+
+document
+  .getElementById("dos_door_rando")
+  .addEventListener("click", toggle_dos_door_rando);
+
 // Force Wrinkly and T&S Rando to be on when Vanilla Door Rando is on
 function toggle_vanilla_door_rando() {
   const vanillaDoorShuffle = document.getElementById("vanilla_door_rando");
@@ -2258,6 +2283,7 @@ function update_ui_states() {
   enable_plandomizer(null);
   toggle_medals_box(null);
   toggle_vanilla_door_rando(null);
+  toggle_dos_door_rando(null);
   validate_fast_start_status(null);
 
   const sliders = document.getElementsByClassName("pretty-slider");

--- a/templates/rando_options.html
+++ b/templates/rando_options.html
@@ -101,14 +101,8 @@
                 {{ toggle_input("random_patches", "Random Dirt Patch Locations", "Dirt Patches for Rainbow Coins are in random locations.", False, "Dirt Patches") }}
                 {{ toggle_input("coin_rando", "Random Banana Coin Locations", "Shuffle the locations of coins within each Level.", False, "Banana Coins") }}
                 {{ toggle_input("random_fairies", "Random Banana Fairy Locations", "Fairy checks are in random locations.", False, "Banana Fairies") }}
-                {{ toggle_input("wrinkly_location_rando", "Random Wrinkly Door Locations", "Wrinkly Door Locations are randomized.", False, "Wrinkly Doors") }}
-                {{ toggle_input("tns_location_rando", "Random Troff 'n' Scoff Portal Locations", "T&S Portal Locations are randomized.", False, "Troff 'n' Scoff Portals") }}
-                {{ toggle_input("vanilla_door_rando", "Vanilla Door Shuffle", "Wrinkly Doors and T&S Portals are shuffled among the vanilla locations.") }}
                 {{ toggle_input("crown_placement_rando", "Random Battle Crown Pad Locations", "Crown Locations are randomized. There's 1 in each level, except Isles which has two.", False, "Battle Crowns") }}
                 {{ toggle_input("random_crates", "Random Melon Crate Locations", "Melon Crate Locations are randomized.", False, "Melon Crates") }}
-                <div class="spacer"></div>
-            </div>
-            <div class="flex-container">
                 <div class="form-check form-switch item-switch">
                     <label data-toggle="tooltip"
                             title="Colored Banana Locations are randomized.">
@@ -122,27 +116,8 @@
                     </label>
                     {{ list_selector(cb_rando_levels, "cb_rando_list", "LEVELS", "This will open a popup that will let you customize what levels have CB rando in the game.&#10;This defaults to All options.", 8, 1) }}
                 {# Remove end </div> as it's included in the macro for formatting #}
-                <div class="spacer"></div>
-                <div class="item-select">
-                    <p class="select-title">DK Portals</p>
-                    <select name="dk_portal_location_rando_v2"
-                            id="dk_portal_location_rando_v2"
-                            display_name="Random DK Portal Locations"
-                            class="form-select"
-                            aria-label="Randomization type"
-                            data-toggle="tooltip"
-                            title="DK Portal Locations are randomized.">
-                        <option id="off" selected value="off">
-                            Vanilla
-                        </option>
-                        <option id="main_only" value="main_only" title="Will only place portals in the main level maps of the 7 levels">
-                            Main Maps only
-                        </option>
-                        <option id="on" value="on">
-                            On
-                        </option>
-                    </select>
-                </div>
+            </div>
+            <div class="flex-container">
                 <div class="item-select">
                     <p class="select-title">Kasplats</p>
                     <select name="kasplat_rando_setting"
@@ -190,6 +165,32 @@
                             {{ list_selector(vanilla_warps, "warp_level_list", "LEVEL SELECTOR", "This will open a popup that will let you customize what levels' warps are in the pool. Any level not selected will have its vanilla warp locations.&#10;This defaults to All levels.", 10, 1) }}
                         {# Remove end </div> as it's included in the macro for formatting #}
                     </div>
+                </div>
+            </div>
+            <div class="flex-container" style="margin-top: 20px;">
+                {{ toggle_input("wrinkly_location_rando", "Random Wrinkly Door Locations", "Wrinkly Door Locations are randomized.", False, "Wrinkly Doors") }}
+                {{ toggle_input("tns_location_rando", "Random Troff 'n' Scoff Portal Locations", "T&S Portal Locations are randomized.", False, "Troff 'n' Scoff Portals") }}
+                {{ toggle_input("vanilla_door_rando", "Vanilla Door Shuffle", "Wrinkly Doors and T&S Portals are shuffled among the vanilla locations.") }}
+                {{ toggle_input("dos_door_rando", "Dos' Doors", "Vanilla Door Shuffle with some restrictions:&#10;- One T&S per level&#10;- One hint door in each lobby&#10;- DK Portal Rando enabled") }}
+                <div class="item-select">
+                    <p class="select-title">DK Portals</p>
+                    <select name="dk_portal_location_rando_v2"
+                            id="dk_portal_location_rando_v2"
+                            display_name="Random DK Portal Locations"
+                            class="form-select"
+                            aria-label="Randomization type"
+                            data-toggle="tooltip"
+                            title="DK Portal Locations are randomized.">
+                        <option id="off" selected value="off">
+                            Vanilla
+                        </option>
+                        <option id="main_only" value="main_only" title="Will only place portals in the main level maps of the 7 levels">
+                            Main Maps only
+                        </option>
+                        <option id="on" value="on">
+                            On
+                        </option>
+                    </select>
                 </div>
             </div>
         </div>

--- a/typings/randomizer/Enums/Settings.d.ts
+++ b/typings/randomizer/Enums/Settings.d.ts
@@ -707,6 +707,7 @@ export enum SettingsStringEnum {
     cb_rando_list_selected = 202,
     crown_enemy_difficulty = 203,
     dk_portal_location_rando_v2 = 204,
+    dos_door_rando = 205,
 }
 
 export enum SettingsStringDataType {
@@ -1005,6 +1006,7 @@ export const SettingsStringTypeMap = {
     SettingsStringEnum.starting_moves_list_count_4: SettingsStringDataType.int16,
     SettingsStringEnum.starting_moves_list_5: SettingsStringDataType.list,
     SettingsStringEnum.starting_moves_list_count_5: SettingsStringDataType.int16,
+    SettingsStringEnum.dos_door_rando: SettingsStringDataType.bool,
 }
 
 export const SettingsStringListTypeMap = {

--- a/typings/randomizer/Enums/Settings.pyi
+++ b/typings/randomizer/Enums/Settings.pyi
@@ -655,6 +655,7 @@ class SettingsStringEnum(IntEnum):
     cb_rando_list_selected = 202
     crown_enemy_difficulty = 203
     dk_portal_location_rando_v2 = 204
+    dos_door_rando = 205
 
 class SettingsStringDataType(IntEnum):
     bool = 1
@@ -951,6 +952,7 @@ SettingsStringTypeMap: dict = {
     SettingsStringEnum.starting_moves_list_count_4: SettingsStringDataType.int16,
     SettingsStringEnum.starting_moves_list_5: SettingsStringDataType.list,
     SettingsStringEnum.starting_moves_list_count_5: SettingsStringDataType.int16,
+    SettingsStringEnum.dos_door_rando: SettingsStringDataType.bool,
 }
 
 SettingsStringListTypeMap: dict = {


### PR DESCRIPTION
Introduced a new door placement variant: Dos' Doors:
- This is a variant on Vanilla Door Shuffle that leverages vanilla locations to rebalance hint door locations
- Exactly one hint door will be placed in each lobby. The location of this door will not change, and it will always be accessible.
- Exactly one T&S will be placed in the game on an eligible location in each level.
- Eligible locations for that T&S and the remaining hints doors are the vanilla T&S locations.
- Exception: Japes only has 3 T&S portals, so we include the level entry portal and a custom location in the Hive area.
- Dos' Doors enforces DK Portal rando to not be off