### PR TITLE
cleanup settings logic

### DIFF
--- a/static/js/generate_buttons.js
+++ b/static/js/generate_buttons.js
@@ -552,7 +552,6 @@ async function import_settings_string(event) {
     }
 
     update_ui_states(null);
-    savesettings();
     generateToast("Imported settings string.<br />All non-cosmetic settings have been overwritten.");
 }
 

--- a/static/js/initalize.js
+++ b/static/js/initalize.js
@@ -493,14 +493,14 @@ async function update_music_select_options(isInitialLoad) {
 
   // If this is the initial load, we want to read from the database and restore
   // custom song selections.
-  if (isInitialLoad) {
-    let musicDb = await loadDataFromIndexedDB("saved_music");
-    let musicDbContents = JSON.parse(musicDb);
-    for (const [selectName, selectValue] of Object.entries(musicDbContents)) {
-      selectElem = document.getElementById(selectName);
-      selectElem.value = selectValue;
-    }
-  }
+  // if (isInitialLoad) {
+  //   let musicDb = await loadDataFromIndexedDB("saved_music");
+  //   let musicDbContents = JSON.parse(musicDb);
+  //   for (const [selectName, selectValue] of Object.entries(musicDbContents)) {
+  //     selectElem = document.getElementById(selectName);
+  //     selectElem.value = selectValue;
+  //   }
+  // }
 }
 
 jq = $;
@@ -536,31 +536,32 @@ async function savesettings() {
   });
 
   // Handle inputs with specific naming convention
-  document
-    .querySelectorAll("input[name^='starting_move_box_']:checked")
-    .forEach((input) => {
-      if (input.id.includes("start")) {
-        json[input.name] = "start";
-      } else if (input.id.includes("random")) {
-        json[input.name] = "random";
-      }
-    });
-
+  // Changed with the new selectors list
+  // document
+  //   .querySelectorAll("input[name^='starting_move_box_']:checked")
+  //   .forEach((input) => {
+  //     if (input.id.includes("start")) {
+  //       json[input.name] = "start";
+  //     } else if (input.id.includes("random")) {
+  //       json[input.name] = "random";
+  //     }
+  //   });
+  console.log(json)
   // Save JSON data to IndexedDB
   await saveDataToIndexedDB("saved_settings", JSON.stringify(json));
 }
 
 // Music settings have to be saved separately, because the value we're trying
 // to load may not exist on the page when load_data() is called.
-async function savemusicsettings() {
-  const musicJson = {};
+// async function savemusicsettings() {
+//   const musicJson = {};
 
-  document.querySelectorAll("select[id^='music_select_']").forEach((select) => {
-    musicJson[select.id] = select.value;
-  });
+//   document.querySelectorAll("select[id^='music_select_']").forEach((select) => {
+//     musicJson[select.id] = select.value;
+//   });
 
-  await saveDataToIndexedDB("saved_music", JSON.stringify(musicJson));
-}
+//   await saveDataToIndexedDB("saved_music", JSON.stringify(musicJson));
+// }
 
 document.querySelectorAll("#form input").forEach((input) => {
   input.addEventListener("input", savesettings);
@@ -568,10 +569,7 @@ document.querySelectorAll("#form input").forEach((input) => {
 });
 
 document.querySelectorAll("#form select").forEach((select) => {
-  select.addEventListener("change", () => {
-    savesettings();
-    savemusicsettings();
-  });
+  select.addEventListener("change", savesettings);
 });
 
 function filebox() {
@@ -1334,7 +1332,6 @@ function trigger_preset_event(event) {
         requestAnimationFrame(processQueue);
       } else {
         update_ui_states(null);
-        savesettings(); // Save settings after all updates
       }
     }
 
@@ -1465,7 +1462,6 @@ function load_data() {
     console.error("Error initializing settings:", error);
     preset_select_changed();
   }
-  savesettings();
 }
 
 function initialize_sliders() {

--- a/static/js/music_select.js
+++ b/static/js/music_select.js
@@ -158,9 +158,6 @@ async function import_music_selections(jsonString) {
           }
       }
   }
-
-  savesettings();
-  savemusicsettings();
 }
 
 function validate_music_file(fileContents) {
@@ -259,8 +256,6 @@ document
       window.confirm("Are you sure you want to reset all music selections?")
     ) {
       reset_music_selections_no_prompt();
-      savesettings();
-      savemusicsettings();
     }
   });
 

--- a/static/js/rando_options.js
+++ b/static/js/rando_options.js
@@ -1303,7 +1303,6 @@ function item_rando_list_changed(evt) {
   } else {
     kongRando.removeAttribute("disabled");
   }
-  savesettings();
 }
 
 // Validate Fast Start Status
@@ -2192,7 +2191,6 @@ function moveSelectedStartingMoves(target_list_id) {
     target_selector.appendChild(moved_move);
   }
   assessAllItemPoolCounts();
-  savesettings();
 }
 
 // Move all starting moves back to list #1.

--- a/ui/plando_settings.py
+++ b/ui/plando_settings.py
@@ -264,7 +264,6 @@ async def import_plando_options(jsonString):
     validate_no_kasplat_items_with_location_shuffle(None)
     full_validate_no_reward_with_random_location()
     validate_item_limits(None)
-    js.savesettings()
 
 
 def raise_plando_validation_error(err_string: str) -> None:

--- a/ui/plando_validation.py
+++ b/ui/plando_validation.py
@@ -979,7 +979,6 @@ def reset_plando_options(evt):
     """
     if js.window.confirm("Are you sure you want to reset all plandomizer settings?"):
         reset_plando_options_no_prompt()
-        js.savesettings()
 
 
 # Plando options where the value is of type Levels.


### PR DESCRIPTION
This pull request includes multiple changes across several JavaScript files to clean up and simplify the codebase by removing unnecessary calls to the `savesettings` and `savemusicsettings` functions. The most important changes are grouped and summarized below.

### Removal of `savesettings` calls:

* [`static/js/generate_buttons.js`](diffhunk://#diff-e9ee7c494bdb576dca9cf391c3cbe7389bf3feafdff5e28275fca2b644e77ac3L555): Removed the `savesettings` call from `import_settings_string` function.
* [`static/js/initalize.js`](diffhunk://#diff-2a83f41f58bc5257f5563b4d7893fbb64c2e7227169b21f0d56c5521be7999f1L1337): Removed the `savesettings` call from `trigger_preset_event` and `load_data` functions. [[1]](diffhunk://#diff-2a83f41f58bc5257f5563b4d7893fbb64c2e7227169b21f0d56c5521be7999f1L1337) [[2]](diffhunk://#diff-2a83f41f58bc5257f5563b4d7893fbb64c2e7227169b21f0d56c5521be7999f1L1468)
* [`static/js/rando_options.js`](diffhunk://#diff-d94881518aa508eb1fea1c5fcc35190492d43c005553b2882f94f43a0165e936L1306): Removed the `savesettings` call from `item_rando_list_changed` and `moveSelectedStartingMoves` functions. [[1]](diffhunk://#diff-d94881518aa508eb1fea1c5fcc35190492d43c005553b2882f94f43a0165e936L1306) [[2]](diffhunk://#diff-d94881518aa508eb1fea1c5fcc35190492d43c005553b2882f94f43a0165e936L2195)

### Commented out `savesettings` and `savemusicsettings` calls:

* [`static/js/initalize.js`](diffhunk://#diff-2a83f41f58bc5257f5563b4d7893fbb64c2e7227169b21f0d56c5521be7999f1L539-R572): Commented out the `savesettings` and `savemusicsettings` calls in `savesettings` and `savemusicsettings` functions, and updated event listeners accordingly.
* [`static/js/music_select.js`](diffhunk://#diff-99d7326fd5d66547759c05bd5c0dc98c73230ebb390ae65f29cae2f086e94884L161-L163): Commented out the `savesettings` and `savemusicsettings` calls in `import_music_selections` and document event listener. [[1]](diffhunk://#diff-99d7326fd5d66547759c05bd5c0dc98c73230ebb390ae65f29cae2f086e94884L161-L163) [[2]](diffhunk://#diff-99d7326fd5d66547759c05bd5c0dc98c73230ebb390ae65f29cae2f086e94884L262-L263)

### Removal of `savesettings` call in Python:

* [`ui/plando_settings.py`](diffhunk://#diff-cc6866ba52f72a6f0836c4a27f5dafa798499ed7efa260fd575141efe662eb04L267): Removed the `savesettings` call from `import_plando_options` function.
* [`ui/plando_validation.py`](diffhunk://#diff-f9a3eb61c97c624ce7475a28d716cd10116debbf68f130005dc16eba294ee024L982): Removed the `savesettings` call from `reset_plando_options` function.

### Commented out code for initial load of music selections:

* [`static/js/initalize.js`](diffhunk://#diff-2a83f41f58bc5257f5563b4d7893fbb64c2e7227169b21f0d56c5521be7999f1L496-R503): Commented out the code block for loading music selections from the database during the initial load in `update_music_select_options` function.