### PR TITLE
Add new level to mushroom exterior

### DIFF
--- a/randomizer/CollectibleLogicFiles/FungiForest.py
+++ b/randomizer/CollectibleLogicFiles/FungiForest.py
@@ -49,12 +49,14 @@ LogicRegions = {
         Collectible(Collectibles.banana, Kongs.chunky, lambda l: True, None, 3),  # 2nd Ladder
         Collectible(Collectibles.bunch, Kongs.chunky, lambda l: True, None, 1),  # After 2nd Ladder
     ],
+    Regions.MushroomBlastLevelExterior: [
+        Collectible(Collectibles.banana, Kongs.donkey, lambda l: True, None, 2),  # On the ladder up to this level
+        Collectible(Collectibles.coin, Kongs.donkey, lambda l: True, None, 3),  # Around BBlast pad
+    ],
     Regions.MushroomLowerExterior: [
         Collectible(Collectibles.banana, Kongs.donkey, lambda l: True, None, 13),
-        Collectible(Collectibles.banana, Kongs.donkey, lambda l: l.climbing, None, 2),
         Collectible(Collectibles.balloon, Kongs.tiny, lambda l: l.feather, None, 1),
 
-        Collectible(Collectibles.coin, Kongs.donkey, lambda l: l.climbing, None, 3),  # Around BBlast pad
         Collectible(Collectibles.coin, Kongs.tiny, lambda l: True, None, 5),  # Around Tiny BP
     ],
     Regions.ForestBaboonBlast: [

--- a/randomizer/Enums/Regions.jsonc
+++ b/randomizer/Enums/Regions.jsonc
@@ -280,6 +280,7 @@
     "CrankyCastle": 256,
     "CrankyIsles": 257,
     "Snide": 258,
-    "AlcoveBeyondHatch": 259
+    "AlcoveBeyondHatch": 259,
+    "MushroomBlastLevelExterior": 260
   }
 }

--- a/randomizer/Lists/BananaCoinLocations.py
+++ b/randomizer/Lists/BananaCoinLocations.py
@@ -5209,8 +5209,7 @@ BananaCoinGroupList = {
             map_id=Maps.FungiForest,
             name="Behind the second lowest ladder in the Giant Mushroom Area",
             konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
-            region=Regions.MushroomLowerExterior,
-            logic=lambda l: l.climbing,
+            region=Regions.MushroomBlastLevelExterior,
             locations=[
                 [1.0, 705, 589, 1256],
                 [1.0, 727, 589, 1273],
@@ -5662,8 +5661,7 @@ BananaCoinGroupList = {
             map_id=Maps.FungiForest,
             name="Around BBlast Pad",
             konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
-            region=Regions.MushroomLowerExterior,
-            logic=lambda l: l.climbing,
+            region=Regions.MushroomBlastLevelExterior,
             locations=[
                 [1.0, 324.719970703125, 589.3333129882812, 973.1728515625],
                 [1.0, 321.9471130371094, 589.3333129882812, 922.9804077148438],

--- a/randomizer/Lists/CBLocations/FungiForestCBLocations.py
+++ b/randomizer/Lists/CBLocations/FungiForestCBLocations.py
@@ -683,8 +683,7 @@ ColoredBananaGroupList = [
         map_id=Maps.FungiForest,
         name="Behind ladder leading to Giant Mushroom middle entrance",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
-        region=Regions.MushroomLowerExterior,
-        logic=lambda l: l.climbing,
+        region=Regions.MushroomBlastLevelExterior,
         locations=[[5, 1.0, 697, 595, 1251], [5, 1.0, 757, 595, 1300]],
     ),
     ColoredBananaGroup(
@@ -692,8 +691,7 @@ ColoredBananaGroupList = [
         map_id=Maps.FungiForest,
         name="Around baboon blast platform",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
-        region=Regions.MushroomLowerExterior,
-        logic=lambda l: l.climbing,
+        region=Regions.MushroomBlastLevelExterior,
         locations=[
             [1, 1.0, 407, 589, 846],
             [1, 1.0, 354, 589, 843],
@@ -712,8 +710,7 @@ ColoredBananaGroupList = [
         map_id=Maps.FungiForest,
         name="On BBlast pad",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
-        region=Regions.MushroomLowerExterior,
-        logic=lambda l: l.climbing,
+        region=Regions.MushroomBlastLevelExterior,
         locations=[[5, 1.0, 340, 605, 951]],
     ),
     ColoredBananaGroup(
@@ -1321,9 +1318,8 @@ ColoredBananaGroupList = [
         map_id=Maps.FungiForest,
         name="Path to Baboon Blast pad (Donkey)",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
-        region=Regions.MushroomLowerExterior,
+        region=Regions.MushroomBlastLevelExterior,
         vanilla=True,
-        logic=lambda l: l.climbing,
         locations=[
             [1, 1.0, 458.903564453125, 570.3333740234375, 862.6621704101562],
             [1, 1.0, 461.7091369628906, 495.3333740234375, 857.4607543945312],
@@ -2145,8 +2141,7 @@ BalloonList = [
         name="At first giant mushroom level by rocketbarrel barrel",
         speed=4,
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
-        region=Regions.MushroomLowerExterior,
-        logic=lambda l: l.climbing,
+        region=Regions.MushroomBlastLevelExterior,
         points=[[523, 590, 505], [245, 580, 819]],
     ),
     Balloon(

--- a/randomizer/Lists/CustomLocations.py
+++ b/randomizer/Lists/CustomLocations.py
@@ -3237,8 +3237,7 @@ CustomLocations = {
             z=1296.0,
             rot_y=534,
             max_size=64,
-            logic_region=Regions.MushroomLowerExterior,
-            logic=lambda l: l.climbing,
+            logic_region=Regions.MushroomBlastLevelExterior,
             group=4,
         ),
         # CrownLocation(
@@ -3248,7 +3247,7 @@ CustomLocations = {
         #     y=589,
         #     z=1297,
         #     max_size=64,
-        #     logic_region=Regions.MushroomLowerExterior,
+        #     logic_region=Regions.MushroomBlastLevelExterior,
         #     group=4,
         # ),
         CustomLocation(

--- a/randomizer/Lists/FairyLocations.py
+++ b/randomizer/Lists/FairyLocations.py
@@ -607,10 +607,9 @@ fairy_locations = {
         FairyData(
             name="Above BBlast Entrance",
             map=Maps.FungiForest,
-            region=Regions.MushroomLowerExterior,
+            region=Regions.MushroomBlastLevelExterior,
             fence=Fence(126, 941, 545, 1020),
             spawn_y=764,
-            logic=lambda l: l.camera and l.climbing,
         ),
         FairyData(
             name="Near Crown",

--- a/randomizer/Lists/MapsAndExits.py
+++ b/randomizer/Lists/MapsAndExits.py
@@ -141,6 +141,7 @@ RegionMapList = {
     Regions.MushroomMiddle: Maps.ForestGiantMushroom,
     Regions.MushroomUpperMid: Maps.ForestGiantMushroom,
     Regions.MushroomLowerExterior: Maps.FungiForest,
+    Regions.MushroomBlastLevelExterior: Maps.FungiForest,
     Regions.MushroomUpper: Maps.ForestGiantMushroom,
     Regions.MushroomNightDoor: Maps.ForestGiantMushroom,
     Regions.MushroomNightExterior: Maps.FungiForest,

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -78,6 +78,7 @@ LogicRegions = {
         TransitionFront(Regions.FungiForestStart, lambda l: True),
         TransitionFront(Regions.MushroomLower, lambda l: True, Transitions.ForestMainToLowerMushroom),
         TransitionFront(Regions.MushroomLowerExterior, lambda l: (l.jetpack and l.isdiddy) or (l.advanced_platforming and l.twirl and l.istiny)),
+        TransitionFront(Regions.MushroomBlastLevelExterior, lambda l: l.jetpack and l.isdiddy),
         TransitionFront(Regions.MushroomUpperMidExterior, lambda l: l.jetpack and l.isdiddy),
         TransitionFront(Regions.MushroomUpperExterior, lambda l: l.jetpack and l.isdiddy),
         TransitionFront(Regions.MushroomNightExterior, lambda l: l.jetpack and l.isdiddy),
@@ -105,24 +106,30 @@ LogicRegions = {
 
     Regions.MushroomUpperMidExterior: Region("Mushroom Upper Mid Exterior", HintRegion.MushroomExterior, Levels.FungiForest, False, None, [], [], [
         TransitionFront(Regions.GiantMushroomArea, lambda l: True),
-        TransitionFront(Regions.MushroomLowerExterior, lambda l: True),
+        TransitionFront(Regions.MushroomBlastLevelExterior, lambda l: True),
         TransitionFront(Regions.MushroomMiddle, lambda l: True, Transitions.ForestLowerExteriorToUpperMushroom),
+    ]),
+
+    Regions.MushroomBlastLevelExterior: Region("Mushroom Blast Level Exterior", HintRegion.MushroomExterior, Levels.FungiForest, False, None, [
+        LocationLogic(Locations.ForestMainEnemy_NearBBlast, lambda l: True),
+    ], [], [
+        TransitionFront(Regions.MushroomLowerExterior, lambda l: True),
+        TransitionFront(Regions.MushroomUpperMidExterior, lambda l: l.climbing),
+        TransitionFront(Regions.ForestBaboonBlast, lambda l: l.blast and l.isdonkey)  # , Transitions.ForestMainToBBlast)
     ]),
 
     Regions.MushroomLowerExterior: Region("Mushroom Lower Exterior", HintRegion.MushroomExterior, Levels.FungiForest, True, None, [
         LocationLogic(Locations.ForestKasplatLowerMushroomExterior, lambda l: not l.settings.kasplat_rando),
-        LocationLogic(Locations.ForestMainEnemy_NearBBlast, lambda l: l.climbing),
     ], [], [
         TransitionFront(Regions.GiantMushroomArea, lambda l: True),
-        TransitionFront(Regions.MushroomUpperMidExterior, lambda l: l.climbing),
+        TransitionFront(Regions.MushroomBlastLevelExterior, lambda l: l.climbing),
         TransitionFront(Regions.MushroomLower, lambda l: True, Transitions.ForestLowerExteriorToLowerMushroom),
-        TransitionFront(Regions.ForestBaboonBlast, lambda l: l.blast and l.isdonkey and l.climbing)  # , Transitions.ForestMainToBBlast)
     ]),
 
     Regions.ForestBaboonBlast: Region("Forest Baboon Blast", HintRegion.MushroomExterior, Levels.FungiForest, False, None, [
         LocationLogic(Locations.ForestDonkeyBaboonBlast, lambda l: l.isdonkey, MinigameType.BonusBarrel),
     ], [], [
-        TransitionFront(Regions.MushroomLowerExterior, lambda l: True)
+        TransitionFront(Regions.MushroomBlastLevelExterior, lambda l: True)
     ]),
 
     Regions.MushroomMiddle: Region("Mushroom Middle", HintRegion.MushroomInterior, Levels.FungiForest, False, -1, [

--- a/randomizer/ShufflePorts.py
+++ b/randomizer/ShufflePorts.py
@@ -160,7 +160,7 @@ REGION_KLUMPS = {
     Regions.RandD: [Regions.RandDUpper],
     Regions.MiddleCore: [Regions.SpinningCore, Regions.UpperCore],
     Regions.MushroomUpperExterior: [Regions.MushroomNightExterior],
-    Regions.MushroomLowerExterior: [Regions.MushroomUpperMidExterior, Regions.GiantMushroomArea],
+    Regions.MushroomLowerExterior: [Regions.MushroomUpperMidExterior, Regions.MushroomBlastLevelExterior, Regions.GiantMushroomArea],
     Regions.MillArea: [Regions.ForestTopOfMill, Regions.ForestVeryTopOfMill],
     Regions.CrystalCavesMain: [Regions.CavesBlueprintPillar, Regions.CavesBananaportSpire, Regions.CavesBonusCave],
 }

--- a/typings/randomizer/Enums/Regions.d.ts
+++ b/typings/randomizer/Enums/Regions.d.ts
@@ -258,4 +258,5 @@ export enum Regions {
     CrankyIsles = 257,
     Snide = 258,
     AlcoveBeyondHatch = 259,
+    MushroomBlastLevelExterior = 260,
 }

--- a/typings/randomizer/Enums/Regions.pyi
+++ b/typings/randomizer/Enums/Regions.pyi
@@ -260,3 +260,4 @@ class Regions(IntEnum):
     CrankyIsles = 257
     Snide = 258
     AlcoveBeyondHatch = 259
+    MushroomBlastLevelExterior = 260

--- a/wiki/article_markdown/custom_locations/CustomLocationsCoins.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsCoins.MD
@@ -550,7 +550,7 @@
 | On the pink tunnel rim on the Giant Mushroom side | 3 | `l.jetpack and l.isdiddy` | 
 | Behind the lowest ladder in the Giant Mushroom area | 2 |  | 
 | Around the lower platform in the Giant Mushroom Area | 6 |  | 
-| Behind the second lowest ladder in the Giant Mushroom Area | 2 | `l.climbing` | 
+| Behind the second lowest ladder in the Giant Mushroom Area | 2 |  | 
 | Above the second lowest ladder in the Giant Mushroom Area | 2 |  | 
 | On the entryways to the 3 top rooms in the Giant Mushroom Area | 3 |  | 
 | On the Giant Mushroom top | 12 | `(l.jetpack and l.isdiddy) or (l.islanky and l.handstand)` | 
@@ -569,7 +569,7 @@
 | Behind the well exit | 3 |  | 
 | Near the thornvine barn | 3 |  | 
 | On Thorny Hedge | 3 | `l.isdonkey and l.strongKong` | 
-| Around BBlast Pad | 3 | `l.climbing` | 
+| Around BBlast Pad | 3 |  | 
 | Behind Clock | 3 |  | 
 | On Mushroom near Mill far tag | 3 | `l.climbing` | 
 | Around Crown Pad | 3 |  | 

--- a/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
@@ -809,9 +809,9 @@
 | By middle exit of giant mushroom | 5 |  | 
 | Around Tiny BP | 10 |  | 
 | Behind ladder to BBlast | 5 |  | 
-| Behind ladder leading to Giant Mushroom middle entrance | 10 | `l.climbing` | 
-| Around baboon blast platform | 10 | `l.climbing` | 
-| On BBlast pad | 5 | `l.climbing` | 
+| Behind ladder leading to Giant Mushroom middle entrance | 10 |  | 
+| Around baboon blast platform | 10 |  | 
+| On BBlast pad | 5 |  | 
 | On path to giant mushroom middle entrance | 15 |  | 
 | Entrance of Light room | 5 |  | 
 | Each side of back T&S on top of giant mushroom | 10 |  | 
@@ -838,7 +838,7 @@
 | In purple tunnel (Donkey) | 5 |  | 
 | In blue tunnel (Donkey) | 5 |  | 
 | Path to thornvine barn (Donkey) | 5 |  | 
-| Path to Baboon Blast pad (Donkey) | 2 | `l.climbing` | 
+| Path to Baboon Blast pad (Donkey) | 2 |  | 
 | Path to Baboon Blast pad (Donkey) | 3 |  | 
 | On thornvine barn switch (Donkey) | 5 | `l.strongKong` | 
 | W5 (Donkey) | 5 |  | 
@@ -880,7 +880,7 @@
 | Barn area right side | Balloon |  | 
 | Barn area left side | Balloon |  | 
 | Around beanstalk | Balloon |  | 
-| At first giant mushroom level by rocketbarrel barrel | Balloon | `l.climbing` | 
+| At first giant mushroom level by rocketbarrel barrel | Balloon |  | 
 | By second level entrance | Balloon |  | 
 | By high W5 | Balloon |  | 
 | By T&S on top of giant mushroom | Balloon |  | 

--- a/wiki/article_markdown/custom_locations/CustomLocationsFairies.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsFairies.MD
@@ -88,7 +88,7 @@
 | Fungi Forest | Above Blue Tunnel | `l.camera` | 
 | Fungi Forest | Above the Clock | `l.camera` | 
 | Fungi Forest | Above the Well | `l.camera and (((l.can_use_vines or l.CanMoonkick()) and l.climbing) or (l.jetpack and l.isdiddy))` | 
-| Fungi Forest | Above BBlast Entrance | `l.camera and l.climbing` | 
+| Fungi Forest | Above BBlast Entrance | `l.camera` | 
 | Fungi Forest | Near Crown | `l.camera` | 
 | Fungi Forest | Top of Giant Mushroom | `l.camera` | 
 | Fungi Forest | Owl Tree Tunnel | `l.camera` | 

--- a/wiki/article_markdown/custom_locations/CustomLocationsMiscellaneous.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsMiscellaneous.MD
@@ -276,7 +276,7 @@
 | Fungi Forest | Near Giant Mushroom |  |  | 
 | Fungi Forest | Near Yellow Tunnel | DirtPatch, Bananaport |  | 
 | Fungi Forest | Near Lower Baboon Blast Ladder |  |  | 
-| Fungi Forest | Near Baboon Blast |  | `l.climbing` | 
+| Fungi Forest | Near Baboon Blast |  |  | 
 | Fungi Forest | Above Upper Baboon Blast Ladder |  |  | 
 | Fungi Forest | Highest Giant Mushroom Platform |  |  | 
 | Fungi Forest | Behind Rabbit |  |  | 


### PR DESCRIPTION
- Added a new region to the mushroom exterior for the level the blast platform is on. This is remove the climbing requirement from a number of checks and collectibles on that level.
- Fixed an issue where SLO + Helm Key Lock could put a Key in a location it could not otherwise normally be placed.
- Altered the WotH paring algorithm so it doesn't double check sans-assumptions in LZR. LZR doesn't leverage these assumptions in a way that should confuse paths, so it *should* already be properly culling things without double checking.