### PR TITLE
dk portal logic and crayon

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -1485,7 +1485,7 @@ def compileHints(spoiler: Spoiler) -> bool:
                     hinted_location_text = level_colors[region.level] + region.getHintRegionName() + level_colors[region.level]
                     message += f" Try looking in the {hinted_location_text}."
                 else:
-                    hinted_location_text = level_colors[region.level] + level_list[location.level] + level_colors[Levels.DKIsles]
+                    hinted_location_text = level_colors[region.level] + level_list[location.level] + level_colors[region.level]
                     message += f" Try collecting colored bananas in {hinted_location_text}."
             else:
                 # Option B: hint the kong + level the item is in, using similar systems as other hints to instead hint kasplats/shops/specific types of items

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -889,7 +889,7 @@ def compileHints(spoiler: Spoiler) -> bool:
             if location.item == Items.ProgressiveSlam:
                 slam_locations.append(id)
             # Never hint training moves for obvious reasons
-            if location.type in (Types.TrainingBarrel, Types.PreGivenMove, Types.Climbing, Types.Cranky, Types.Funky, Types.Candy):
+            if location.type in (Types.TrainingBarrel, Types.PreGivenMove, Types.Climbing, Types.Cranky, Types.Funky, Types.Candy, Types.Snide):
                 continue
             # If it's a woth item, it must be hinted so put it in the list
             if id in spoiler.woth_locations:

--- a/randomizer/Lists/DoorLocations.py
+++ b/randomizer/Lists/DoorLocations.py
@@ -2196,6 +2196,12 @@ door_locations = {
             group=10,
             moveless=False,
             door_type=[DoorType.wrinkly],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_shipyard_area_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Mech Fish Gate - far right",
@@ -2207,6 +2213,12 @@ door_locations = {
             group=10,
             moveless=False,
             door_type=[DoorType.wrinkly],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_shipyard_area_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Cannonball Area Exit",
@@ -2275,6 +2287,12 @@ door_locations = {
             group=3,
             moveless=False,
             door_type=[DoorType.wrinkly],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_lighthouse_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Lighthouse - Up the ledge",
@@ -2334,6 +2352,12 @@ door_locations = {
             group=12,
             moveless=False,
             door_type=[DoorType.wrinkly],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_lighthouse_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Tiny's 5D ship",
@@ -2344,6 +2368,12 @@ door_locations = {
             group=13,
             moveless=False,
             door_type=[DoorType.wrinkly],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_shipyard_area_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Lanky's 5D ship",
@@ -2354,6 +2384,12 @@ door_locations = {
             group=14,
             moveless=False,
             door_type=[DoorType.wrinkly],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_shipyard_area_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Lanky's 2D ship",
@@ -2363,6 +2399,12 @@ door_locations = {
             kong_lst=[Kongs.lanky],
             group=15,
             moveless=False,
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_shipyard_area_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Galleon Vanilla Level Entry",
@@ -2407,6 +2449,12 @@ door_locations = {
             location=[743, 20, 196, 270],
             group=20,
             kong_lst=[Kongs.chunky],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_lighthouse_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Seasick ship - start right",
@@ -2415,6 +2463,12 @@ door_locations = {
             location=[513, 20, 203, 90],
             group=20,
             kong_lst=[Kongs.chunky],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_lighthouse_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Seasick ship - after cannons front left",
@@ -2423,6 +2477,12 @@ door_locations = {
             location=[743, 20, 763, 270],
             group=20,
             kong_lst=[Kongs.chunky],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_lighthouse_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Seasick ship - after cannons front right",
@@ -2431,6 +2491,12 @@ door_locations = {
             location=[513, 20, 759, 90],
             group=20,
             kong_lst=[Kongs.chunky],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_lighthouse_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Seasick ship - after cannons center",
@@ -2439,6 +2505,12 @@ door_locations = {
             location=[622, 20, 1006, 180],
             group=20,
             kong_lst=[Kongs.chunky],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_lighthouse_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Left wall of Mech Fish",
@@ -2447,6 +2519,12 @@ door_locations = {
             location=[551, 39, 614, 246.35],
             group=21,
             kong_lst=[Kongs.diddy],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_shipyard_area_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Right wall of Mech Fish",
@@ -2455,6 +2533,12 @@ door_locations = {
             location=[140, 39, 504, 109.07],
             group=21,
             kong_lst=[Kongs.diddy],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_shipyard_area_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Chunky 5DS - Against a chest",
@@ -2463,6 +2547,12 @@ door_locations = {
             location=[1493, 0, 1561, 270],
             group=22,
             kong_lst=[Kongs.chunky],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_shipyard_area_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="Donkey 5DS - Next to the left cell bed",
@@ -2471,6 +2561,12 @@ door_locations = {
             location=[430, 0, 466, 0],
             group=23,
             kong_lst=[Kongs.donkey],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_shipyard_area_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
         DoorData(
             name="On top of the lighthouse",
@@ -2482,6 +2578,12 @@ door_locations = {
             moveless=False,
             door_type=[DoorType.wrinkly],
             kong_lst=[Kongs.diddy],
+            dk_portal_logic=lambda s: isBarrierRemoved(s, RemovedBarriersSelected.galleon_lighthouse_gate)
+            or (
+                s.settings.activate_all_bananaports == ActivateAllBananaports.all
+                and s.settings.bananaport_placement_rando == ShufflePortLocations.off
+                and s.settings.bananaport_rando == BananaportRando.off
+            ),
         ),
     ],
     Levels.FungiForest: [


### PR DESCRIPTION
- Fixed some logic that'd dictate when DK portals are allowed to exist in certain locations (because it'd otherwise brick seed gen)
- Fixed a bug where Snide could still be hinted, when you start with him unlocked.
- Fixed a bug where Wrinkly would pick the wrong crayon to colour part of her hints, sometimes.