### PR TITLE
fixed boss plando w/ helm shuffled, better generic failure exception

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -1418,7 +1418,7 @@ def compileHints(spoiler: Spoiler) -> bool:
                 elif item.type == Types.Shockwave:
                     item_name = "fairy moves"
                     item_color = "\x06"
-                elif item.type == Types.TrainingBarrel:
+                elif item.type in (Types.TrainingBarrel, Types.Climbing):
                     item_name = "training moves"
                 elif item.type in (Types.Cranky, Types.Funky, Types.Candy, Types.Snide):
                     item_name = "shopkeepers"

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -113,9 +113,9 @@ def KasplatShuffle(spoiler: Spoiler, LogicVariables: LogicVarHolder) -> None:
                     else:
                         # This is the first VerifyWorld check, and serves as the canary in the coal mine
                         # If we get to this point in the code, the world itself is likely unstable from some combination of settings or bugs
-                        js.postMessage("Settings combination is likely unstable.")
+                        js.postMessage("Not all locations reached.")
                         ResetShuffledKasplatLocations(spoiler)
-                        raise Ex.SettingsIncompatibleException("Settings combination is likely unstable - report this to the devs!")
+                        raise Ex.LocationsFailureException("Unexpected failure to reach all locations - report this to the devs!")
                 return
             except Ex.KasplatPlacementException:
                 retries += 1

--- a/randomizer/Lists/DoorLocations.py
+++ b/randomizer/Lists/DoorLocations.py
@@ -373,6 +373,7 @@ door_locations = {
             location=[1475.0, 160.0, 1605.0, 351.0],
             group=5,
             moveless=False,
+            door_type=[DoorType.boss, DoorType.wrinkly],
             logic=lambda l: l.swim,
         ),
         DoorData(
@@ -382,6 +383,7 @@ door_locations = {
             location=[2151.0, 160.0, 1587.0, 350.0],
             group=5,
             moveless=False,
+            door_type=[DoorType.boss, DoorType.wrinkly],
             logic=lambda l: l.swim,
         ),
         DoorData(

--- a/randomizer/Lists/Exceptions.py
+++ b/randomizer/Lists/Exceptions.py
@@ -79,3 +79,7 @@ class SettingsIncompatibleException(FillException):
 
 class PlandoIncompatibleException(FillException):
     """Exception triggered when plando settings conflict with base settings."""
+
+
+class LocationsFailureException(FillException):
+    """Exception triggered when not all locations are reachable after placing random locations."""

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -834,7 +834,7 @@ class Settings:
         self.points_list_active_moves = 5
         self.points_list_bean = 3
         # Progressive hints
-        self.progressive_hint_item = None
+        self.progressive_hint_item = ProgressiveHintItem.off
         self.enable_progressive_hints = False  # Deprecated
         self.progressive_hint_text = 0  # Deprecated
         self.progressive_hint_count = 0

--- a/randomizer/ShuffleBosses.py
+++ b/randomizer/ShuffleBosses.py
@@ -399,15 +399,10 @@ def PlandoBosses(spoiler):
         filledBosses = []
         filledLevels = []
         for level in range(7):
-            level_order = -1
-            for order in spoiler.settings.level_order:
-                if level == spoiler.settings.level_order[order]:
-                    level_order = order - 1  # Classic off-by-one here: the UI goes 0-6 and the level order goes 1-7
-                    break
             # If we intend to plando this boss, send it in there
-            if spoiler.settings.plandomizer_dict["plando_boss_order_" + str(level_order)] != -1:
-                bossMap = Maps(spoiler.settings.plandomizer_dict["plando_boss_order_" + str(level_order)])
-                plannedKong = spoiler.settings.plandomizer_dict["plando_boss_kong_" + str(level_order)]
+            if spoiler.settings.plandomizer_dict["plando_boss_order_" + str(level)] != -1:
+                bossMap = Maps(spoiler.settings.plandomizer_dict["plando_boss_order_" + str(level)])
+                plannedKong = spoiler.settings.plandomizer_dict["plando_boss_kong_" + str(level)]
                 eligibleKongs = GetKongOptionsForBoss(bossMap, HardBossesEnabled(spoiler.settings, HardBossesSelected.alternative_mad_jack_kongs))
                 if plannedKong != -1:
                     # If the planned Kong is incompatible with this boss, ship it back

--- a/templates/plandomizer/plandomizer_general.html
+++ b/templates/plandomizer/plandomizer_general.html
@@ -333,7 +333,7 @@
                 {% for i in range(0, 7) %}
                     <label id="plando_boss_order_div_{{i}}"
                         class="flex-container select-order">
-                        <span class="order-label">Level {{i+1}}:</span>
+                        <span class="order-label">{{cb_rando_levels[i].name}}:</span>
                         <div id="plando_boss_order_{{i}}_wrapper"
                              data-toggle="tooltip"
                              title>

--- a/wiki/article_markdown/custom_locations/CustomLocationsDoors.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsDoors.MD
@@ -22,8 +22,8 @@
 | Jungle Japes | Behind Rambi Door - watery room - right | Boss, Dk_Portal, Wrinkly |  | 
 | Jungle Japes | Top of Lanky's Useless Slope - left | Wrinkly, Dk_Portal | `(l.islanky and l.handstand) or l.CanPhase()` | 
 | Jungle Japes | Top of Lanky's Useless Slope - right | Wrinkly, Dk_Portal | `(l.islanky and l.handstand) or l.CanPhase()` | 
-| Jungle Japes | Underwater by Warp 2 | Boss, Dk_Portal, Wrinkly | `l.swim` | 
-| Jungle Japes | Underwater by Chunky's underground | Boss, Dk_Portal, Wrinkly | `l.swim` | 
+| Jungle Japes | Underwater by Warp 2 | Boss, Wrinkly | `l.swim` | 
+| Jungle Japes | Underwater by Chunky's underground | Boss, Wrinkly | `l.swim` | 
 | Jungle Japes | Next to Funky - right | Boss, Dk_Portal, Wrinkly |  | 
 | Jungle Japes | Next to Lanky's Painting Room - left | Boss, Dk_Portal, Wrinkly | `(l.handstand and l.islanky) or (l.twirl and l.istiny)` | 
 | Jungle Japes | Next to Lanky's Painting Room - right | Boss, Dk_Portal, Wrinkly | `(l.handstand and l.islanky) or (l.twirl and l.istiny)` | 


### PR DESCRIPTION
- Fixed an issue where boss plando would fail if Helm wasn't level 8
- Reworded the exception thrown when not all locations are reached on the first attempt to be less confusing (again)
- Climbing is now a "training move" in advanced item hinting
- Prevented a few more underwater doors from being DK Portals