### PR TITLE
Moved Japes Dos Door

### DIFF
--- a/randomizer/Lists/DoorLocations.py
+++ b/randomizer/Lists/DoorLocations.py
@@ -608,7 +608,6 @@ door_locations = {
             location=[903.167, 280, 1044.455, 180],
             group=11,
             placed=DoorType.dk_portal,
-            dos_door=True,
         ),
         DoorData(
             name="Diddy Mountain - Next to the slam switch",
@@ -710,6 +709,7 @@ door_locations = {
             logicregion=Regions.JungleJapesStart,
             location=[714, 288, 830, 90],
             group=11,
+            dos_door=True,
         ),
         DoorData(
             name="Against the mountain",

--- a/randomizer/ShuffleDoors.py
+++ b/randomizer/ShuffleDoors.py
@@ -302,7 +302,7 @@ def ShuffleVanillaDoors(spoiler):
                 door.placed = DoorType.null
                 vanilla_door_indexes.append(door_index)
         random.shuffle(vanilla_door_indexes)
-        # One random vanilla T&S per level is locked to being a T&S - One non-vanilla location is eligible in Japes in Dos' Doors (hence that DoorType.null eligibility)
+        # One random vanilla T&S per level is locked to being a T&S - Two non-vanilla Japes locations are eligible in Dos' Doors (hence that DoorType.null eligibility)
         locked_tns_options = [
             idx for idx in vanilla_door_indexes if door_locations[level][idx].default_placed in (DoorType.boss, DoorType.null) and DoorType.boss in door_locations[level][idx].door_type
         ]

--- a/static/js/rando_options.js
+++ b/static/js/rando_options.js
@@ -484,20 +484,13 @@ document
 function toggle_dos_door_rando() {
   const dosDoorRando  = document.getElementById("dos_door_rando");
   const vanillaDoorShuffle = document.getElementById("vanilla_door_rando");
-  const dkPortalRandoSelect = document.getElementById("dk_portal_location_rando_v2");
-  const dkPortalRandoVanilla = document.querySelector("#dk_portal_location_rando_v2 option[id='off']");
 
   if (dosDoorRando.checked) {
     vanillaDoorShuffle.checked = true;
     vanillaDoorShuffle.setAttribute("disabled", "disabled");
-    if (dkPortalRandoSelect.value == "off") {
-      dkPortalRandoSelect.value = "main_only";
-    }
-    dkPortalRandoVanilla.setAttribute("disabled", "disabled");
     toggle_vanilla_door_rando();
   } else {
     vanillaDoorShuffle.removeAttribute("disabled");
-    dkPortalRandoVanilla.removeAttribute("disabled");
   }
 }
 


### PR DESCRIPTION
A custom location near the vanilla Japes level portal is now used instead of the vanilla level portal location for Dos' Doors. This has the benefit of no longer needing to force DK Portal Rando on with Dos' Doors enabled.