### PR TITLE
Door Fixes, UI Fix

### DIFF
--- a/randomizer/Lists/DoorLocations.py
+++ b/randomizer/Lists/DoorLocations.py
@@ -106,11 +106,7 @@ class DoorData:
         self.default_placed = placed  # info about what door_type a door location is in vanilla
         self.dos_door = dos_door  # We need extra doors in Japes to make Dos' Doors work - this flag is for specifically that
         self.door_type = door_type.copy()  # denotes what types it can be
-        # If we do not explicitly bar this door from being a DK portal, assume that it is allowed to be
-        if dk_portal_logic is None:
-            self.dk_portal_logic = lambda s: True
-        else:
-            self.dk_portal_logic = dk_portal_logic
+        self.dk_portal_logic = dk_portal_logic
         if True:  # Disable if we figure it's not necessary
             if DoorType.dk_portal in self.door_type and self.logicregion in UNDERWATER_LOGIC_REGIONS:
                 # Disable portals in underwater regions
@@ -141,12 +137,14 @@ class DoorData:
 
     def updateDoorTypeLogic(self, spoiler):
         """Update door type list depending on enabled settings."""
-        if self.dk_portal_logic(spoiler):
-            if self.logicregion not in UNDERWATER_LOGIC_REGIONS and DoorType.dk_portal not in self.door_type:
-                self.door_type.append(DoorType.dk_portal)
-        else:
-            if DoorType.dk_portal in self.door_type:
-                self.door_type.remove(DoorType.dk_portal)
+        # If the door has logic that affects whether or not it can be a DK Portal
+        if self.dk_portal_logic is not None:
+            if self.dk_portal_logic(spoiler):
+                if self.logicregion not in UNDERWATER_LOGIC_REGIONS and DoorType.dk_portal not in self.door_type:
+                    self.door_type.append(DoorType.dk_portal)
+            else:
+                if DoorType.dk_portal in self.door_type:
+                    self.door_type.remove(DoorType.dk_portal)
         if spoiler.settings.dk_portal_location_rando_v2 == DKPortalRando.main_only:
             if self.map not in LEVEL_MAIN_MAPS and DoorType.dk_portal in self.door_type:
                 self.door_type = [x for x in self.door_type if x != DoorType.dk_portal]

--- a/randomizer/Lists/DoorLocations.py
+++ b/randomizer/Lists/DoorLocations.py
@@ -106,8 +106,9 @@ class DoorData:
         self.default_placed = placed  # info about what door_type a door location is in vanilla
         self.dos_door = dos_door  # We need extra doors in Japes to make Dos' Doors work - this flag is for specifically that
         self.door_type = door_type.copy()  # denotes what types it can be
+        # If we do not explicitly bar this door from being a DK portal, assume that it is allowed to be
         if dk_portal_logic is None:
-            self.dk_portal_logic = lambda s: False
+            self.dk_portal_logic = lambda s: True
         else:
             self.dk_portal_logic = dk_portal_logic
         if True:  # Disable if we figure it's not necessary
@@ -140,9 +141,12 @@ class DoorData:
 
     def updateDoorTypeLogic(self, spoiler):
         """Update door type list depending on enabled settings."""
-        if self.dk_portal_logic(spoiler) and self.logicregion not in UNDERWATER_LOGIC_REGIONS:
-            if DoorType.dk_portal not in self.door_type:
+        if self.dk_portal_logic(spoiler):
+            if self.logicregion not in UNDERWATER_LOGIC_REGIONS and DoorType.dk_portal not in self.door_type:
                 self.door_type.append(DoorType.dk_portal)
+        else:
+            if DoorType.dk_portal in self.door_type:
+                self.door_type.remove(DoorType.dk_portal)
         if spoiler.settings.dk_portal_location_rando_v2 == DKPortalRando.main_only:
             if self.map not in LEVEL_MAIN_MAPS and DoorType.dk_portal in self.door_type:
                 self.door_type = [x for x in self.door_type if x != DoorType.dk_portal]

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -958,12 +958,9 @@ class Settings:
             ]
             ItemPool.JunkSharedMoves = [Items.ProgressiveAmmoBelt, Items.ProgressiveAmmoBelt]
 
-        # Dos' Doors require all of these to be on - it's a variant on vanilla door shuffle
+        # Dos' Doors requires this to be on - it's a variant on vanilla door shuffle
         if self.dos_door_rando:
             self.vanilla_door_rando = True
-            # The UI should force this, but DK Portal Rando must be at least somewhat enabled for Dos' Doors
-            if self.dk_portal_location_rando_v2 == DKPortalRando.off:
-                self.dk_portal_location_rando_v2 = DKPortalRando.main_only
         # If we're using the vanilla door shuffle, turn both wrinkly and tns rando on
         if self.vanilla_door_rando:
             self.wrinkly_location_rando = True

--- a/static/js/rando_options.js
+++ b/static/js/rando_options.js
@@ -448,6 +448,22 @@ document
   .getElementById("helm_hurry")
   .addEventListener("click", disable_helm_hurry);
 
+// Disable Points Selector when Spoiler Hints are not set to Points
+function disable_points() {
+  const selector = document.getElementById("points_list_modal");
+  const disabled = document.getElementById("spoiler_hints").value !== "points";
+
+  if (disabled) {
+    selector.setAttribute("disabled", "disabled");
+  } else {
+    selector.removeAttribute("disabled");
+  }
+}
+
+document
+  .getElementById("spoiler_hints")
+  .addEventListener("change", disable_points);
+
 // Disable Remove Barriers Selector when Remove Barriers is off
 function disable_remove_barriers() {
   const selector = document.getElementById("remove_barriers_modal");
@@ -2298,6 +2314,7 @@ function update_ui_states() {
   disable_misc_changes_modal(null);
   toggle_bananaport_selector(null);
   disable_helm_hurry(null);
+  disable_points(null);
   disable_remove_barriers(null);
   disable_faster_checks(null);
   toggle_logic_type(null);

--- a/static/js/rando_options.js
+++ b/static/js/rando_options.js
@@ -830,6 +830,32 @@ document
   .getElementById("music_filtering")
   .addEventListener("click", disable_music_filtering_modal);
 
+function disable_custom_cb_locations_modal() {
+  const selector = document.getElementById("cb_rando_list_modal");
+  if (document.getElementById("cb_rando_enabled").checked) {
+    selector.removeAttribute("disabled");
+  } else {
+    selector.setAttribute("disabled", "disabled");
+  }
+}
+
+document
+  .getElementById("cb_rando_enabled")
+  .addEventListener("click", disable_custom_cb_locations_modal);
+
+function disable_misc_changes_modal() {
+  const selector = document.getElementById("misc_changes_modal");
+  if (document.getElementById("misc_changes_toggle").checked) {
+    selector.removeAttribute("disabled");
+  } else {
+    selector.setAttribute("disabled", "disabled");
+  }
+}
+
+document
+  .getElementById("misc_changes_toggle")
+  .addEventListener("click", disable_misc_changes_modal);
+
 // Hide the plando options for certain Helm phases if they are disabled
 function plando_hide_helm_options(evt) {
   const helmPhaseCount = parseInt(
@@ -2268,6 +2294,8 @@ function update_ui_states() {
   disable_hard_bosses_modal(null);
   disable_excluded_songs_modal(null);
   disable_music_filtering_modal(null);
+  disable_custom_cb_locations_modal(null);
+  disable_misc_changes_modal(null);
   toggle_bananaport_selector(null);
   disable_helm_hurry(null);
   disable_remove_barriers(null);

--- a/templates/qualityoflife.html
+++ b/templates/qualityoflife.html
@@ -10,6 +10,7 @@
                         <input class="form-check-input"
                                type="checkbox"
                                name="quality_of_life"
+                               id="misc_changes_toggle"
                                display_name="Misc Changes"
                                value="True"
                                checked/>


### PR DESCRIPTION
- Fixed an issue where DK Portal Rando would still occasionally try to assign invalid doors (because the dk_portal_logic wasn't correctly filtering out doors)
- Fixed an issue where Dos' Doors silently forced DK Portal Rando to be on (woops!)
- Fixed some cogs on the UI to properly disable when the corresponding setting is disabled