### PR TITLE
No WotH Shop Keys, Admin Strings Reordering

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -2160,6 +2160,9 @@ def compileHints(spoiler: Spoiler) -> bool:
                 and location.type not in (Types.TrainingBarrel, Types.PreGivenMove, Types.Climbing)
                 and not (spoiler.settings.key_8_helm and location_id == Locations.HelmKey)
             ):
+                # WotH Keys that are in Shops and have nothing else on the path to them will already be entirely covered and solved with the guaranteed multipath hint
+                if ItemList[location.item].type == Types.Key and location.type == Types.Shop and location_id in spoiler.woth_paths.keys() and len(spoiler.woth_paths[location_id]) == 1:
+                    continue
                 hintable_location_ids.append(location_id)
         random.shuffle(hintable_location_ids)
         placed_woth_hints = 0

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -67,6 +67,10 @@
                                 <select class="form-select" id="presets" disabled>
                                     <option value="" disabled selected>Select a preset</option>
                                 </select>
+                                <div style="display: flex; justify-content: space-evenly; padding-top: 10px;">
+                                    <a id="raise_button" class="btn btn-neutral" disabled onClick="move_preset(true)"><i class="fa fa-arrow-up"></i></a>
+                                    <a id="lower_button" class="btn btn-neutral" disabled onClick="move_preset(false)"><i class="fa fa-arrow-down"></i></a>
+                                </div>
                             </div>
                             <div class="item-select">
                                 <label for="name" class="select-title">Name</label>
@@ -91,6 +95,8 @@
 
                             var branchSelect = document.getElementById("branch");
                             var presetsSelect = document.getElementById("presets");
+                            var raiseButton = document.getElementById("raise_button");
+                            var lowerButton = document.getElementById("lower_button");
 
                             branchSelect.addEventListener("change", function () {
                                 presetsSelect.innerHTML = '<option value="" disabled selected>Select a preset</option>';
@@ -114,6 +120,9 @@
                                 var selectedPreset = local_presets[selectedBranch].find(
                                     (preset) => preset.name == presetsSelect.value
                                 );
+
+                                raiseButton.disabled = false;
+                                lowerButton.disabled = false;
 
                                 document.getElementById("name").value = selectedPreset.name;
                                 document.getElementById("description").value = selectedPreset.description;
@@ -178,6 +187,36 @@
                                     },
                                     error: function () {
                                         alert("Error deleting preset");
+                                    },
+                                });
+                            }
+
+                            function move_preset(moving_up) {
+                                var branch = branchSelect.value;
+                                var name = document.getElementById("name").value;
+
+                                if (!branch) {
+                                    alert("Please select a branch");
+                                    return;
+                                }
+
+                                var data = {
+                                    branch: branch,
+                                    name: name,
+                                    moving_up: moving_up,
+                                };
+
+                                $.ajax({
+                                    url: "/api/admin/presets/move",
+                                    type: "PUT",
+                                    data: JSON.stringify(data),
+                                    contentType: "application/json",
+                                    success: function () {
+                                        alert("Preset moved successfully");
+                                        location.reload();
+                                    },
+                                    error: function () {
+                                        alert("Error moving preset");
                                     },
                                 });
                             }


### PR DESCRIPTION
- WotH Keys found in shops with nothing else on the path to them will no longer be eligible for WotH hints
- Added some buttons to the admin panel to let us reorder the settings string list