### PR TITLE
Bug fixes

### DIFF
--- a/randomizer/CollectibleLogicFiles/CreepyCastle.py
+++ b/randomizer/CollectibleLogicFiles/CreepyCastle.py
@@ -106,7 +106,7 @@ LogicRegions = {
         Collectible(Collectibles.balloon, Kongs.donkey, lambda l: l.coconut, None, 1),  # In minecart room
     ],
     Regions.CryptDiddyRoom: [
-        Collectible(Collectibles.balloon, Kongs.diddy, lambda l: l.peanut, None, 1),  # In Diddy's room
+        Collectible(Collectibles.balloon, Kongs.diddy, lambda l: l.peanut and (l.charge or l.generalclips or l.CanPhase()), None, 1),  # In Diddy's room
 
         Collectible(Collectibles.coin, Kongs.diddy, lambda l: l.charge or l.CanPhase() or l.generalclips, None, 3),  # In Diddy's room
     ],

--- a/randomizer/Lists/DoorLocations.py
+++ b/randomizer/Lists/DoorLocations.py
@@ -695,6 +695,7 @@ door_locations = {
             location=[2433, 530, 1076.25, 333.5],
             group=11,
             moveless=False,
+            kong_lst=[Kongs.donkey, Kongs.diddy, Kongs.chunky],
         ),
         DoorData(
             name="Entrance door switch",

--- a/randomizer/LogicFiles/JungleJapes.py
+++ b/randomizer/LogicFiles/JungleJapes.py
@@ -51,7 +51,7 @@ LogicRegions = {
         TransitionFront(Regions.JapesBeyondCoconutGate1, lambda l: l.checkBarrier(RemovedBarriersSelected.japes_coconut_gates) or Events.JapesFreeKongOpenGates in l.Events or l.CanPhase() or l.CanPhaseswim() or l.CanSkew(True) or l.CanSkew(False) or l.generalclips),
         TransitionFront(Regions.JapesBeyondCoconutGate2, lambda l: l.checkBarrier(RemovedBarriersSelected.japes_coconut_gates) or Events.JapesFreeKongOpenGates in l.Events or l.CanPhase() or l.CanPhaseswim() or l.CanSkew(True) or l.CanSkew(False) or l.generalclips),
         TransitionFront(Regions.JapesCatacomb, lambda l: (l.Slam and l.chunky and l.barrels) or l.CanPhaseswim() or l.CanSkew(True) or l.CanSkew(False), Transitions.JapesMainToCatacomb),
-        TransitionFront(Regions.JapesBlastPadPlatform, lambda l: (l.can_use_vines or l.CanMoonkick()) and l.climbing),
+        TransitionFront(Regions.JapesBlastPadPlatform, lambda l: (l.can_use_vines or l.CanMoonkick()) and l.climbing and (l.isdonkey or l.isdiddy or l.ischunky)),
     ]),
 
     Regions.JapesBlastPadPlatform: Region("Japes Blast Pad Platform", HintRegion.Lowlands, Levels.JungleJapes, False, None, [], [], [

--- a/static/presets/weights/weights_files.json
+++ b/static/presets/weights/weights_files.json
@@ -85,6 +85,7 @@
     "dk_portal_location_rando_v2": {
       "off": 1.0
     },
+    "dos_door_rando": 0,
     "enable_plandomizer": 0,
     "enable_progressive_hints": 0.5,
     "enable_shop_hints": 1,
@@ -507,6 +508,7 @@
       "off": 0.9,
       "main_only": 0.1
     },
+    "dos_door_rando": 0.4,
     "enable_plandomizer": 0,
     "enable_progressive_hints": 0.5,
     "enable_shop_hints": 0.9,
@@ -949,6 +951,7 @@
       "main_only": 0.3,
       "on": 0.2
     },
+    "dos_door_rando": 0.6,
     "enable_plandomizer": 0,
     "enable_progressive_hints": 0.5,
     "enable_shop_hints": 0.5,
@@ -1435,6 +1438,7 @@
       "main_only": 0.3,
       "on": 0.2
     },
+    "dos_door_rando": 0.6,
     "enable_plandomizer": 0,
     "enable_progressive_hints": 0.5,
     "enable_shop_hints": 0.5,

--- a/wiki/article_markdown/custom_locations/RandomSettingsDifficult.MD
+++ b/wiki/article_markdown/custom_locations/RandomSettingsDifficult.MD
@@ -95,6 +95,7 @@ The generated settings will be of greater difficulty. Requirements for B. Locker
 	- Off: 50%
 	- Main Only: 30%
 	- On: 20%
+- Dos Door Rando: 60%
 - Enable Progressive Hints: 50%
 - Enable Shop Hints: 50%
 - Dropsanity: 60%

--- a/wiki/article_markdown/custom_locations/RandomSettingsDifficultWithQolShuffle.MD
+++ b/wiki/article_markdown/custom_locations/RandomSettingsDifficultWithQolShuffle.MD
@@ -89,6 +89,7 @@ The generated settings will be of greater difficulty. Requirements for B. Locker
 	- Off: 50%
 	- Main Only: 30%
 	- On: 20%
+- Dos Door Rando: 60%
 - Enable Progressive Hints: 50%
 - Enable Shop Hints: 50%
 - Enable Tag Anywhere: 90%

--- a/wiki/article_markdown/custom_locations/RandomSettingsEasy.MD
+++ b/wiki/article_markdown/custom_locations/RandomSettingsEasy.MD
@@ -31,6 +31,7 @@ The generated settings will be of lesser difficulty. Requirements for B. Locker,
 - DK Phase requires Baboon Blast
 - Chaos B. Lockers
 - Crown Placement Rando
+- Dos Door Rando
 - Enable Plandomizer
 - Dropsanity
 - Hard B. Lockers

--- a/wiki/article_markdown/custom_locations/RandomSettingsStandard.MD
+++ b/wiki/article_markdown/custom_locations/RandomSettingsStandard.MD
@@ -94,6 +94,7 @@ The generated settings will be of average difficulty. Requirements for B. Locker
 - Random DK Portal Locations: 
 	- Off: 90%
 	- Main Only: 10%
+- Dos Door Rando: 40%
 - Enable Progressive Hints: 50%
 - Enable Shop Hints: 90%
 - Dropsanity: 25%


### PR DESCRIPTION
- Diddy's balloon in Castle Crypt now correctly requires charge, even when colroed bananas are not shuffled
- Fixed logic for reaching the Japes Baboon Blast pad, to account for Lanky and Tiny's lower jump distance when jumping off a vine.
- The Dos Doors setting is now part of the Random Settings shuffle. (little thought has gone into the actual weight numbers)