### PR TITLE
minor logic stuff

### DIFF
--- a/randomizer/Lists/EnemyTypes.py
+++ b/randomizer/Lists/EnemyTypes.py
@@ -895,7 +895,7 @@ enemy_location_list = {
     Locations.Caves5DIChunkyEnemy_Gauntlet03: EnemyLoc(Maps.CavesChunkyIgloo, Enemies.FireballGlasses, 5, [], False, False),
     Locations.Caves5DIChunkyEnemy_Gauntlet04: EnemyLoc(Maps.CavesChunkyIgloo, Enemies.FireballGlasses, 6, [], False, False),
     # Lanky 1DC
-    Locations.Caves1DCEnemy_Near: EnemyLoc(Maps.CavesLankyCabin, Enemies.Kosha, 2, [], True),
+    Locations.Caves1DCEnemy_Near: EnemyLoc(Maps.CavesLankyCabin, Enemies.Kosha, 2, [Enemies.KlaptrapRed, Enemies.KlaptrapPurple, Enemies.Klobber], True),
     Locations.Caves1DCEnemy_Far: EnemyLoc(Maps.CavesLankyCabin, Enemies.Kosha, 1, [], True),
     # DK 5DC
     Locations.Caves5DCDKEnemy_Gauntlet0: EnemyLoc(Maps.CavesDonkeyCabin, Enemies.ZingerLime, 1, enemies_nokill_gun + [Enemies.Bat], True, False),

--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -1046,7 +1046,7 @@ class LogicVarHolder:
         elif bossFight == Maps.KroolLankyPhase:
             hasRequiredMoves = self.barrels and self.trombone
         elif bossFight == Maps.KroolTinyPhase:
-            hasRequiredMoves = self.mini and self.feather and (self.climbing or self.twirl)
+            hasRequiredMoves = self.mini and self.feather
         elif bossFight == Maps.KroolChunkyPhase:
             hasRequiredMoves = self.punch and self.CanSlamChunkyPhaseSwitch() and self.hunkyChunky and self.gorillaGone
         # In simple level order, there are a couple very specific cases we have to account for in order to prevent boss fill failures

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -470,7 +470,7 @@ LogicRegions = {
         Event(Events.KRoolDonkey, lambda l: not l.settings.krool_donkey or ((l.blast or not l.settings.cannons_require_blast) and l.donkey and l.climbing)),
         Event(Events.KRoolDiddy, lambda l: not l.settings.krool_diddy or (l.jetpack and l.peanut and l.diddy)),
         Event(Events.KRoolLanky, lambda l: not l.settings.krool_lanky or l.CanBeatLankyPhase()),
-        Event(Events.KRoolTiny, lambda l: not l.settings.krool_tiny or (l.mini and l.feather and l.tiny and (l.climbing or l.twirl))),
+        Event(Events.KRoolTiny, lambda l: not l.settings.krool_tiny or (l.mini and l.feather and l.tiny)),
         Event(Events.KRoolChunky, lambda l: not l.settings.krool_chunky or (l.CanSlamChunkyPhaseSwitch() and l.gorillaGone and l.hunkyChunky and l.punch and l.chunky)),
         Event(Events.KRoolDillo1, lambda l: not l.settings.krool_dillo1 or l.barrels),
         Event(Events.KRoolDog1, lambda l: not l.settings.krool_dog1 or l.barrels),

--- a/randomizer/ShuffleBosses.py
+++ b/randomizer/ShuffleBosses.py
@@ -195,12 +195,7 @@ def ShuffleBossesBasedOnOwnedItems(spoiler, ownedKongs: dict, ownedMoves: dict):
             if Kongs.diddy in ownedKongs[level] and Items.RocketbarrelBoost in ownedMoves[level] and Items.Peanut in ownedMoves[level]:
                 bossOptions[level].append(Maps.KroolDiddyPhase)
             # Tiny Phase needs Mini and Feather (no Orange logic yet (or ever?))
-            if (
-                Kongs.tiny in ownedKongs[level]
-                and Items.MiniMonkey in ownedMoves[level]
-                and Items.Feather in ownedMoves[level]
-                and ((Items.PonyTailTwirl in ownedMoves[level]) or (Items.Climbing in ownedMoves[level]))
-            ):
+            if Kongs.tiny in ownedKongs[level] and Items.MiniMonkey in ownedMoves[level] and Items.Feather in ownedMoves[level]:
                 bossOptions[level].append(Maps.KroolTinyPhase)
             # Chunky Phase always needs Punch, Hunky, and Gorilla Gone
             if Kongs.chunky in ownedKongs[level] and Items.PrimatePunch in ownedMoves[level] and Items.HunkyChunky in ownedMoves[level] and Items.GorillaGone in ownedMoves[level]:


### PR DESCRIPTION
- Red/Purple Klaptraps and Klobbers can no longer spawn next to the Baboon Balloon pad in Sprint Cabin
- K. Rool Tiny Phase no longer logically requires Climbing or Twirl