### PR TITLE
Rare instance of LZR having clean fixes

### DIFF
--- a/randomizer/CollectibleLogicFiles/DKIsles.py
+++ b/randomizer/CollectibleLogicFiles/DKIsles.py
@@ -68,6 +68,9 @@ LogicRegions = {
     Regions.HideoutHelmLobby: [
 
     ],
+    Regions.HideoutHelmLobbyPastVines: [
+
+    ],
     Regions.Treehouse: [
 
     ],

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -1983,7 +1983,7 @@ def compileHints(spoiler: Spoiler) -> bool:
             Maps.FungiForestLobby: [Regions.FungiForestLobby],
             Maps.CrystalCavesLobby: [Regions.CrystalCavesLobby],
             Maps.CreepyCastleLobby: [Regions.CreepyCastleLobby],
-            Maps.HideoutHelmLobby: [Regions.HideoutHelmLobby],
+            Maps.HideoutHelmLobby: [Regions.HideoutHelmLobby, Regions.HideoutHelmLobbyPastVines],
             Maps.ForestMillFront: [Regions.GrinderRoom],  # The Mini entrance counts
             Maps.CastleMuseum: [Regions.MuseumBehindGlass],  # Weird, but technically a connector between MP and Mini entrances
             Maps.CastleBallroom: [Regions.Ballroom],  # Also weird, as one side is all-kong and the other side is a MP pad

--- a/randomizer/Enums/Events.jsonc
+++ b/randomizer/Enums/Events.jsonc
@@ -233,6 +233,8 @@
         
         // Misc Events
         "JapesAccessToCannon": 204,
-        "AirSpaceEntered": 205
+        "AirSpaceEntered": 205,
+        "HelmLobbyW1aTagged": 206,
+        "HelmLobbyW1bTagged": 207
     }
 }

--- a/randomizer/Enums/Regions.jsonc
+++ b/randomizer/Enums/Regions.jsonc
@@ -280,6 +280,8 @@
     "CrankyCastle": 256,
     "CrankyIsles": 257,
     "Snide": 258,
+
+    // Regions added after this organization
     "AlcoveBeyondHatch": 259,
     "MushroomBlastLevelExterior": 260,
     "MushroomLowerBetweenLadders": 261,
@@ -304,6 +306,7 @@
     "CryptChunkyRoom": 280,
     "CryptDonkeyRoom": 281,
     "CryptDiddyRoom": 282,
-    "ForestMillTopOfNightCage": 283
+    "ForestMillTopOfNightCage": 283,
+    "HideoutHelmLobbyPastVines": 284
   }
 }

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -123,15 +123,13 @@ def KasplatShuffle(spoiler: Spoiler, LogicVariables: LogicVarHolder) -> None:
                 js.postMessage("Kasplat placement failed. Retrying. Tries: " + str(retries))
 
 
-@lru_cache(maxsize=None)
+# @lru_cache(maxsize=None) - Cache is disabled for now, as it's causing issues with certain bits of logic in LZR
 def GetExitLevelExit(level, restart) -> Optional[Transitions]:
     """Get the exit that using the "Exit Level" button will take you to."""
     # If you have option to restart, means there is no Exit Level option
     if restart is not None:
         return None
-    # For now, restarts will not be randomized
-    # if settings.shuffle_loading_zones == ShuffleLoadingZones.all and region.restart is not None:
-    #     return ShuffleExits.ShufflableExits[region.restart].shuffledId
+    # Otherwise identify and return the exit that the "Exit Level" button will take you to
     if level == Levels.JungleJapes:
         return ShuffleExits.ShufflableExits[Transitions.JapesToIsles].shuffledId
     elif level == Levels.AngryAztec:

--- a/randomizer/Lists/CBLocations/DKIslesCBLocations.py
+++ b/randomizer/Lists/CBLocations/DKIslesCBLocations.py
@@ -2676,8 +2676,7 @@ ColoredBananaGroupList = [
         map_id=Maps.HideoutHelmLobby,
         name="Far W1",
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
-        region=Regions.HideoutHelmLobby,
-        logic=lambda l: l.hasMoveSwitchsanity(Switches.IslesHelmLobbyGone, False) and l.can_use_vines,
+        region=Regions.HideoutHelmLobbyPastVines,
         locations=[
             [5, 1.0, 454, 216, 1013],
         ],

--- a/randomizer/Lists/MapsAndExits.py
+++ b/randomizer/Lists/MapsAndExits.py
@@ -43,6 +43,7 @@ RegionMapList = {
     Regions.CrystalCavesLobby: Maps.CrystalCavesLobby,
     Regions.CreepyCastleLobby: Maps.CreepyCastleLobby,
     Regions.HideoutHelmLobby: Maps.HideoutHelmLobby,
+    Regions.HideoutHelmLobbyPastVines: Maps.HideoutHelmLobby,
     # Japes
     Regions.JungleJapesEntryHandler: Maps.JungleJapes,
     Regions.JungleJapesStart: Maps.JungleJapes,

--- a/randomizer/Lists/ShufflableExit.py
+++ b/randomizer/Lists/ShufflableExit.py
@@ -52,8 +52,8 @@ ShufflableExits = {
     Transitions.CavesToIsles: ShufflableExit("Crystal Caves to Caves Lobby", Regions.CrystalCavesEntryHandler, TransitionBack(Regions.CrystalCavesLobby, "From Caves", "Caves Lobby from Crystal Caves", Transitions.IslesToCaves), ExitCategories.CavesExterior),
     Transitions.IslesToCastle: ShufflableExit("Castle Lobby to Creepy Castle", Regions.CreepyCastleLobby, TransitionBack(Regions.CreepyCastleEntryHandler, "From Castle Lobby", "Creepy Castle from Castle Lobby", Transitions.CastleToIsles), ExitCategories.CastleLobby),
     Transitions.CastleToIsles: ShufflableExit("Creepy Castle to Castle Lobby", Regions.CreepyCastleEntryHandler, TransitionBack(Regions.CreepyCastleLobby, "From Castle", "Castle Lobby from Creepy Castle", Transitions.IslesToCastle), ExitCategories.CastleExterior),
-    Transitions.IslesToHelm: ShufflableExit("Helm Lobby to Hideout Helm", Regions.HideoutHelmLobby, TransitionBack(Regions.HideoutHelmEntry, "From Helm Lobby", "Hideout Helm from Helm Lobby", Transitions.HelmToIsles), ExitCategories.HelmLobby),
-    Transitions.HelmToIsles: ShufflableExit("Hideout Helm to Helm Lobby", Regions.HideoutHelmEntry, TransitionBack(Regions.HideoutHelmLobby, "From Helm", "Helm Lobby from Hideout Helm", Transitions.IslesToHelm), ExitCategories.HideoutHelm),
+    Transitions.IslesToHelm: ShufflableExit("Helm Lobby to Hideout Helm", Regions.HideoutHelmLobbyPastVines, TransitionBack(Regions.HideoutHelmEntry, "From Helm Lobby", "Hideout Helm from Helm Lobby", Transitions.HelmToIsles), ExitCategories.HelmLobby),
+    Transitions.HelmToIsles: ShufflableExit("Hideout Helm to Helm Lobby", Regions.HideoutHelmEntry, TransitionBack(Regions.HideoutHelmLobbyPastVines, "From Helm", "Helm Lobby from Hideout Helm", Transitions.IslesToHelm), ExitCategories.HideoutHelm),
 
     # DK Isles Exits
     Transitions.IslesTreehouseToStart: ShufflableExit("DK's Treehouse to Training Grounds", Regions.Treehouse, TransitionBack(Regions.TrainingGrounds, "From Treehouse", "Training Grounds from DK's Treehouse", Transitions.IslesStartToTreehouse)),

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -463,7 +463,14 @@ LogicRegions = {
         Event(Events.HelmLobbyTraversable, lambda l: ((l.hasMoveSwitchsanity(Switches.IslesHelmLobbyGone) and l.can_use_vines) or (l.CanMoonkick() and l.donkey))),
     ], [
         TransitionFront(Regions.KremIsleMouth, lambda l: True, Transitions.IslesHelmLobbyToMain),
-        TransitionFront(Regions.HideoutHelmEntry, lambda l: Events.HelmLobbyTraversable in l.Events and l.IsLevelEnterable(Levels.HideoutHelm), Transitions.IslesToHelm),
+        TransitionFront(Regions.HideoutHelmLobbyPastVines, lambda l: Events.HelmLobbyTraversable in l.Events or Events.HelmLobbyW1bTagged in l.Events),
+    ]),
+
+    Regions.HideoutHelmLobbyPastVines: Region("Hideout Helm Lobby Past Vines", HintRegion.LateLobbies, Levels.DKIsles, False, Regions.HideoutHelmLobby, [], [
+        Event(Events.HelmLobbyW1bTagged, lambda l: True),
+    ], [
+        TransitionFront(Regions.HideoutHelmLobby, lambda l: Events.HelmLobbyW1aTagged in l.Events),
+        TransitionFront(Regions.HideoutHelmEntry, lambda l: l.IsLevelEnterable(Levels.HideoutHelm), Transitions.IslesToHelm),
     ]),
 
     Regions.KRool: Region("K. Rool", HintRegion.KRool, Levels.DKIsles, True, None, [], [

--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -460,6 +460,7 @@ LogicRegions = {
         LocationLogic(Locations.IslesKasplatHelmLobby, lambda l: not l.settings.kasplat_rando and ((l.scope and l.coconut) or (l.twirl and l.tiny and l.advanced_platforming))),
     ], [
         Event(Events.HelmLobbyAccessed, lambda l: True),
+        Event(Events.HelmLobbyW1aTagged, lambda l: True),
         Event(Events.HelmLobbyTraversable, lambda l: ((l.hasMoveSwitchsanity(Switches.IslesHelmLobbyGone) and l.can_use_vines) or (l.CanMoonkick() and l.donkey))),
     ], [
         TransitionFront(Regions.KremIsleMouth, lambda l: True, Transitions.IslesHelmLobbyToMain),

--- a/randomizer/LogicFiles/HideoutHelm.py
+++ b/randomizer/LogicFiles/HideoutHelm.py
@@ -42,7 +42,7 @@ LogicRegions = {
         LocationLogic(Locations.HelmMainEnemy_Start0, lambda l: True),
         LocationLogic(Locations.HelmMainEnemy_Start1, lambda l: True),
     ], [], [
-        TransitionFront(Regions.HideoutHelmLobby, lambda l: Events.HelmFinished in l.Events, Transitions.HelmToIsles),
+        TransitionFront(Regions.HideoutHelmLobbyPastVines, lambda l: Events.HelmFinished in l.Events, Transitions.HelmToIsles),
         TransitionFront(Regions.HideoutHelmSwitchRoom, lambda l: (l.handstand and l.islanky) or l.advanced_platforming),
         TransitionFront(Regions.HideoutHelmAfterBoM, lambda l: l.settings.helm_setting == HelmSetting.skip_all or Events.HelmFinished in l.Events),  # W1
     ]),

--- a/typings/randomizer/Enums/Events.d.ts
+++ b/typings/randomizer/Enums/Events.d.ts
@@ -204,4 +204,6 @@ export enum Events {
     HelmLobbyTraversable = 203,
     JapesAccessToCannon = 204,
     AirSpaceEntered = 205,
+    HelmLobbyW1aTagged = 206,
+    HelmLobbyW1bTagged = 207,
 }

--- a/typings/randomizer/Enums/Events.pyi
+++ b/typings/randomizer/Enums/Events.pyi
@@ -206,3 +206,5 @@ class Events(IntEnum):
     HelmLobbyTraversable = 203
     JapesAccessToCannon = 204
     AirSpaceEntered = 205
+    HelmLobbyW1aTagged = 206
+    HelmLobbyW1bTagged = 207

--- a/typings/randomizer/Enums/Regions.d.ts
+++ b/typings/randomizer/Enums/Regions.d.ts
@@ -282,4 +282,5 @@ export enum Regions {
     CryptDonkeyRoom = 281,
     CryptDiddyRoom = 282,
     ForestMillTopOfNightCage = 283,
+    HideoutHelmLobbyPastVines = 284,
 }

--- a/typings/randomizer/Enums/Regions.pyi
+++ b/typings/randomizer/Enums/Regions.pyi
@@ -284,3 +284,4 @@ class Regions(IntEnum):
     CryptDonkeyRoom = 281
     CryptDiddyRoom = 282
     ForestMillTopOfNightCage = 283
+    HideoutHelmLobbyPastVines = 284

--- a/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
@@ -1787,7 +1787,7 @@
 | Kasplat island | 5 | `l.scope and l.coconut` | 
 | Right side | 5 |  | 
 | Left side | 5 |  | 
-| Far W1 | 5 | `l.hasMoveSwitchsanity(Switches.IslesHelmLobbyGone, False) and l.can_use_vines` | 
+| Far W1 | 5 |  | 
 | Around Kasplat island | Balloon |  | 
 | Left side | Balloon |  | 
 ## Banana Fairy Room


### PR DESCRIPTION
- Split Helm Lobby into 2 regions to account for being able to warp between sides once you have found each side
- Fixed an issue where Exit Level transitions weren't properly being utilized in some circumstances (by deleting the cache)