### PR TITLE
Support version for AP

### DIFF
--- a/ap_version.py
+++ b/ap_version.py
@@ -1,0 +1,3 @@
+"""Holds the version for Archipelago."""
+
+version = "1.0.0"

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -27,7 +27,8 @@ RUN mv /app/static /app/controller/static && \
     mv /app/index.html /app/controller/index.html && \
     mv /app/randomizer.html /app/controller/randomizer.html && \
     mv /app/base-hack /app/controller/base-hack && \
-    mv /app/version.py /app/controller/version.py
+    mv /app/version.py /app/controller/version.py && \
+    mv /app/ap_version.py /app/controller/ap_version.py
 
 WORKDIR /app/controller
 

--- a/controller/app.py
+++ b/controller/app.py
@@ -46,6 +46,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from opentelemetry_instrumentation_rq import RQInstrumentor
 
 COOLDOWN_PERIOD = 300  # 5 minutes in seconds
+archipelago_version = environ.get("ARCHIPELAGO_VERSION", "1.0.0")
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -60,7 +61,6 @@ resource = Resource(
         "container.name": socket.gethostname(),
     }
 )
-
 app = Flask(__name__, static_folder="", template_folder="templates")
 app.wsgi_app = OpenTelemetryMiddleware(app.wsgi_app)
 flask_api_doc(app, config_path="./swagger.yaml", url_prefix="/api/doc", title="API doc")
@@ -333,6 +333,12 @@ def task_status(task_id):
 def get_version():
     """Get the version of the controller."""
     return set_response(json.dumps({"version": version}), 200)
+
+
+@api.route("/ap_version", methods=["GET"])
+def get_ap_version():
+    """Get the version of Archipelago for version updates."""
+    return set_response(json.dumps({"version": archipelago_version}), 200)
 
 
 @api.route("/get_presets", methods=["GET"])

--- a/controller/app.py
+++ b/controller/app.py
@@ -44,9 +44,9 @@ from functools import wraps
 from swagger_ui import flask_api_doc
 from werkzeug.middleware.proxy_fix import ProxyFix
 from opentelemetry_instrumentation_rq import RQInstrumentor
+from ap_version import version as archipelago_version
 
 COOLDOWN_PERIOD = 300  # 5 minutes in seconds
-archipelago_version = environ.get("ARCHIPELAGO_VERSION", "1.0.0")
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
This pull request introduces a new versioning system for the Archipelago project by adding a version file and updating the relevant Dockerfile and application code to incorporate this change.

### Versioning System Updates:

* [`ap_version.py`](diffhunk://#diff-eedb3380dcf36b1ddad17bb7adb36762f81b4a723b72988cbce995d65dcf1e0eR1-R3): Added a new file to hold the version for Archipelago.
* [`controller/Dockerfile`](diffhunk://#diff-df234eb86d676bd9233f232e9dc9af4895969477a6a9ff9161e32621f6ce76d1L30-R31): Updated the Dockerfile to move the new `ap_version.py` file to the appropriate directory.

### Application Code Updates:

* `controller/app.py`: 
  * Imported the Archipelago version from `ap_version.py`.
  * Added a new endpoint `/ap_version` to return the Archipelago version.
  * Minor formatting improvement by removing an unnecessary blank line.