### PR TITLE
ZOOM ZOOM

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -494,6 +494,8 @@ if baseclasses_loaded:
         def write_spoiler(self, spoiler_handle: typing.TextIO):
             """Write the spoiler."""
             spoiler_handle.write("\n")
+            spoiler_handle.write("Additional Settings info for player: " + self.player_name)
+            spoiler_handle.write("\n")
             spoiler_handle.write("Level Order: " + ", ".join([level.name for order, level in self.logic_holder.settings.level_order.items()]))
             spoiler_handle.write("\n")
             spoiler_handle.write("Starting Kongs: " + ", ".join([kong.name for kong in self.logic_holder.settings.starting_kong_list]))
@@ -511,6 +513,7 @@ if baseclasses_loaded:
             spoiler_handle.write("B. Locker Requirements: " + ", ".join([str(count) for count in self.logic_holder.settings.BLockerEntryCount]))
             spoiler_handle.write("\n")
             spoiler_handle.write("Removed Barriers: " + ", ".join([barrier.name for barrier in self.logic_holder.settings.remove_barriers_selected]))
+            spoiler_handle.write("\n")
 
         def create_item(self, name: str, force_non_progression=False) -> Item:
             """Create an item."""

--- a/__init__.py
+++ b/__init__.py
@@ -94,7 +94,7 @@ if baseclasses_loaded:
     from archipelago.Regions import all_locations, create_regions, connect_regions
     from archipelago.Rules import set_rules
     from archipelago.client.common import check_version
-    from worlds.AutoWorld import WebWorld, World
+    from worlds.AutoWorld import WebWorld, World, AutoLogicRegister
     from archipelago.Logic import LogicVarHolder
     from randomizer.Spoiler import Spoiler
     from randomizer.Settings import Settings
@@ -107,6 +107,7 @@ if baseclasses_loaded:
     from randomizer.CompileHints import compileMicrohints
     from randomizer.Enums.Types import Types
     from randomizer.Enums.Kongs import Kongs
+    from randomizer.Enums.Locations import Locations as DK64RLocations
     from randomizer.Lists import Item as DK64RItem
     from worlds.LauncherComponents import Component, components, Type, icon_paths
     import randomizer.ShuffleExits as ShuffleExits
@@ -131,6 +132,21 @@ if baseclasses_loaded:
 
     components.append(Component("DK64 Client", "DK64Client", func=launch_client, component_type=Type.CLIENT, icon="dk64"))
     icon_paths["dk64"] = f"ap:{__name__}/static/img/dk.png"
+
+    class DK64CollectionState(metaclass=AutoLogicRegister):
+        def init_mixin(self, parent: MultiWorld):
+            """Reset the logic holder in all DK64 worlds. This is called on every CollectionState init."""
+            dk64_ids = parent.get_game_players(DK64World.game) + parent.get_game_groups(DK64World.game)
+            for player in dk64_ids:
+                if hasattr(parent.worlds[player], 'logic_holder'):
+                    parent.worlds[player].logic_holder.Reset()
+
+        def copy_mixin(self, ret) -> CollectionState:
+            dk64_ids = ret.multiworld.get_game_players(DK64World.game) + ret.multiworld.get_game_groups(DK64World.game)
+            for player in dk64_ids:
+                if hasattr(ret.multiworld.worlds[player], 'logic_holder'):
+                    ret.multiworld.worlds[player].logic_holder.UpdateFromArchipelagoItems(ret)
+            return ret
 
     class DK64Web(WebWorld):
         """WebWorld for DK64."""
@@ -511,11 +527,9 @@ if baseclasses_loaded:
 
             return created_item
 
-        # def collect(self, state: CollectionState, item: Item) -> bool:
-        #     """Collect the item."""
-        #     change = super().collect(state, item)
-        #     if item in self.multiworld.precollected_items[self.player]:
-        #         self.logic_holder.AddArchipelagoItem(item)
-        #     elif item.classification in (ItemClassification.progression, ItemClassification.progression_skip_balancing):
-        #         self.logic_holder.UpdateFromArchipelagoItems(state)
-        #     return change
+        def collect(self, state: CollectionState, item: Item) -> bool:
+            """Collect the item."""
+            change = super().collect(state, item)
+            if change:
+                self.logic_holder.UpdateFromArchipelagoItems(state)
+            return change

--- a/__init__.py
+++ b/__init__.py
@@ -134,18 +134,21 @@ if baseclasses_loaded:
     icon_paths["dk64"] = f"ap:{__name__}/static/img/dk.png"
 
     class DK64CollectionState(metaclass=AutoLogicRegister):
+        """Logic Mixin to handle some awkward situations when the CollectionState is copied."""
+
         def init_mixin(self, parent: MultiWorld):
             """Reset the logic holder in all DK64 worlds. This is called on every CollectionState init."""
             dk64_ids = parent.get_game_players(DK64World.game) + parent.get_game_groups(DK64World.game)
             for player in dk64_ids:
-                if hasattr(parent.worlds[player], 'logic_holder'):
-                    parent.worlds[player].logic_holder.Reset()
+                if hasattr(parent.worlds[player], "logic_holder"):
+                    parent.worlds[player].logic_holder.Reset()  # If we don't reset here, we double-collect the starting inventory
 
         def copy_mixin(self, ret) -> CollectionState:
+            """Update the current logic holder in all DK64 worlds with the current CollectionState. This is called after the CollectionState init inside the copy() method, so this essentially undoes the above method."""
             dk64_ids = ret.multiworld.get_game_players(DK64World.game) + ret.multiworld.get_game_groups(DK64World.game)
             for player in dk64_ids:
-                if hasattr(ret.multiworld.worlds[player], 'logic_holder'):
-                    ret.multiworld.worlds[player].logic_holder.UpdateFromArchipelagoItems(ret)
+                if hasattr(ret.multiworld.worlds[player], "logic_holder"):
+                    ret.multiworld.worlds[player].logic_holder.UpdateFromArchipelagoItems(ret)  # If we don't update here, every copy wipes the logic holder's knowledge
             return ret
 
     class DK64Web(WebWorld):

--- a/ap_version.py
+++ b/ap_version.py
@@ -1,3 +1,3 @@
 """Holds the version for Archipelago."""
 
-version = "1.0.0"
+version = "1.0.1"

--- a/archipelago/Items.py
+++ b/archipelago/Items.py
@@ -117,7 +117,8 @@ def setup_items(world: World) -> typing.List[DK64Item]:
         kong_item = DK64RItemPoolUtility.ItemFromKong(kong)
         for item in item_table:
             if item.name == kong_item.name:
-                # We don't need to precollect Kong items, as they'll patch in to the main menu properly
+                # Conveniently, this guarantees we have at least one precollected item!
+                world.multiworld.push_precollected(DK64Item(item.name, ItemClassification.progression, full_item_table[DK64RItem.ItemList[kong_item].name].code, world.player))
                 item_table.remove(item)
                 break
 

--- a/archipelago/Regions.py
+++ b/archipelago/Regions.py
@@ -223,8 +223,8 @@ def create_region(
             quantity *= 5
         elif collectible.type == Collectibles.balloon:
             quantity *= 10
-            add_rule(location, lambda state: state.has(gun_for_kong[collectible.kong], player))  # We need to be sure we check for gun access for this balloon
-        add_rule(location, lambda state: logic_holder.HasKong(collectible.kong))  # There's no FTA for collectibles - you *must* own the right kong to collect it
+            add_rule(location, lambda state, collectible_kong=collectible.kong: state.has(gun_for_kong[collectible_kong], player))  # We need to be sure we check for gun access for this balloon
+        add_rule(location, lambda state, collectible_kong=collectible.kong: logic_holder.HasKong(collectible_kong))  # There's no FTA for collectibles - you *must* own the right kong to collect it
         location.place_locked_item(DK64Item("Collectible CBs, " + collectible.kong.name + ", " + level.name + ", " + str(quantity), ItemClassification.progression_skip_balancing, None, player))
         # print("Collectible CBs, " + collectible.kong.name + ", " + level.name + ", " + str(quantity))
         new_region.locations.append(location)

--- a/archipelago/Regions.py
+++ b/archipelago/Regions.py
@@ -409,23 +409,19 @@ def connect(world: World, source: str, target: str, rule: typing.Optional[typing
 
 def hasDK64RTransition(state: CollectionState, logic: LogicVarHolder, exit: TransitionFront):
     """Check if the given transition is accessible in the given state."""
-    logic.UpdateFromArchipelagoItems(state)
     return exit.logic(logic)
 
 
 def hasDK64RLocation(state: CollectionState, logic: LogicVarHolder, location: LocationLogic):
     """Check if the given location is accessible in the given state."""
-    logic.UpdateFromArchipelagoItems(state)
     return location.logic(logic)
 
 
 def hasDK64RCollectible(state: CollectionState, logic: LogicVarHolder, collectible: Collectible):
     """Check if the given collectible is accessible in the given state."""
-    logic.UpdateFromArchipelagoItems(state)
     return collectible.logic(logic)
 
 
 def hasDK64REvent(state: CollectionState, logic: LogicVarHolder, event: Event):
     """Check if the given event is accessible in the given state."""
-    logic.UpdateFromArchipelagoItems(state)
     return event.logic(logic)


### PR DESCRIPTION
First pass on zoom zoom here:
- Only calling updates on item pickup dramatically reduces the amount of updates required, and thus speeds things up a BOATLOAD. At least 2x-3x faster, possibly more depending on the size of the multiworld.
Logic fix:
- Fixed an issue where you may be picking up collectibles with incorrect Kongs
Others:
- Added a bit at the top of the spoiler to better distinguish which seed each pile of settings belongs to