### PR TITLE
Adjust Patcher to no longer use Global

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -455,7 +455,8 @@ if baseclasses_loaded:
                 patch_file = self.update_seed_results(patch_data, spoiler, self.player)
                 out_path = os.path.join(output_directory, f"{self.multiworld.get_out_file_name_base(self.player)}.lanky")
                 print(out_path)
-                with open("output/" + f"{self.multiworld.get_out_file_name_base(self.player)}.lanky", "w") as f:
+                # with open("output/" + f"{self.multiworld.get_out_file_name_base(self.player)}.lanky", "w") as f:
+                with open(out_path, "w") as f:
                     f.write(patch_file)
                 # Copy the patch file to the outpath
                 # shutil.copy("output/" + f"{self.multiworld.get_out_file_name_base(self.player)}.lanky", out_path)

--- a/ap_version.py
+++ b/ap_version.py
@@ -1,3 +1,3 @@
 """Holds the version for Archipelago."""
 
-version = "1.0.4"
+version = "1.0.5"

--- a/randomizer/Patching/Patcher.py
+++ b/randomizer/Patching/Patcher.py
@@ -128,34 +128,26 @@ class ROM:
 
 
 # Try except for when the browser is trying to load this file
-def load_base_rom(default_file: None = None) -> None:
+def load_base_rom() -> None:
     """Load the base ROM file for patching."""
     try:
-        global patchedRom
-        global og_patched_rom
-        if patchedRom is None and default_file is None:
-            print("Loading base rom")
-            from randomizer.Patching import BPS as bps
+        print("Loading base rom")
+        from randomizer.Patching import BPS as bps
 
+        try:
+            patch = open("./static/patches/shrink-dk64.bps", "rb")
+        except Exception:
             try:
-                patch = open("./static/patches/shrink-dk64.bps", "rb")
+                patch = BytesIO(js.getFile("static/patches/shrink-dk64.bps"))
             except Exception:
-                try:
-                    patch = BytesIO(js.getFile("static/patches/shrink-dk64.bps"))
-                except Exception:
-                    patch = open("./worlds/dk64/static/patches/shrink-dk64.bps", "rb")
+                patch = open("./worlds/dk64/static/patches/shrink-dk64.bps", "rb")
 
-            original = open("dk64.z64", "rb")
-            og_patched_rom = BytesIO(bps.patch(original, patch).read())
-            patchedRom = copy.deepcopy(og_patched_rom)
-        elif default_file is not None and patchedRom is None:
-            print("Using default file")
-            og_patched_rom = default_file
-            patchedRom = copy.deepcopy(og_patched_rom)
-        else:
-            patchedRom = copy.deepcopy(og_patched_rom)
+        original = open("dk64.z64", "rb")
+        og_patched_rom = BytesIO(bps.patch(original, patch).read())
+        return og_patched_rom
     except Exception as e:
         print(e)
+        raise Exception("Unable to load BPS.") from e
         pass
 
 
@@ -172,7 +164,7 @@ class LocalROM:
         Args:
             file ([type], optional): [description]. Defaults to None.
         """
-        global patchedRom
+        patchedRom = None
         if "PYTEST_CURRENT_TEST" in os.environ:
             data_size = 32 * 1024  # 32KB = 32 * 1024 bytes
             data = bytes(range(256)) * (data_size // 256)  # Repeat values from 0 to 255 to fill 32KB
@@ -182,7 +174,7 @@ class LocalROM:
             if not os.path.exists("dk64.z64"):
                 raise Exception("No ROM was loaded, please make sure you have dk64.z64 in the root directory of the project.")
             elif patchedRom is None:
-                load_base_rom()
+                patchedRom = load_base_rom()
 
         self.rom = patchedRom
 

--- a/randomizer/Patching/Patcher.py
+++ b/randomizer/Patching/Patcher.py
@@ -16,9 +16,6 @@ if TYPE_CHECKING:
     from randomizer.Lists.MapsAndExits import Maps
     from randomizer.Patching.ItemRando import CustomActors
 
-patchedRom = None
-og_patched_rom = None
-
 
 class ROM:
     """Patcher for ROM files loaded via Rompatcherjs."""

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -14,7 +14,6 @@ from randomizer.Patching import BPS as bps
 from rq import get_current_job
 from randomizer.Enums.Settings import SettingsMap
 from randomizer.Fill import Generate_Spoiler
-from randomizer.Patching.Patcher import load_base_rom
 from randomizer.Settings import Settings
 from randomizer.Spoiler import Spoiler
 from version import version
@@ -31,9 +30,9 @@ def generate_seed(settings_dict):
         if isinstance(settings_dict, str):
             settings_dict = json.loads(settings_dict)
         delayed_timestamp = settings_dict.get("delayed_spoilerlog_release", 0)
-        patch = open("./static/patches/shrink-dk64.bps", "rb")
-        original = open("dk64.z64", "rb")
-        patched = BytesIO(bps.patch(original, patch).read())
+        # patch = open("./static/patches/shrink-dk64.bps", "rb")
+        # original = open("dk64.z64", "rb")
+        # patched = BytesIO(bps.patch(original, patch).read())
         if not settings_dict.get("seed"):
             settings_dict["seed"] = random.randint(0, 100000000)
         try:
@@ -47,7 +46,7 @@ def generate_seed(settings_dict):
                     settings_dict["seed"] = str(settings_dict["seed"]) + "-" + str(current_retries)
         except Exception as e:
             logger.info(e)
-        load_base_rom(default_file=patched)
+        # load_base_rom(default_file=patched)
         settings_obj = Settings(cleanup_settings(settings_dict))
         spoiler = Spoiler(settings_obj)
         patch, spoiler, password = Generate_Spoiler(spoiler)


### PR DESCRIPTION
This pull request includes several changes to improve file handling and simplify the codebase in the `randomizer` module. The most important changes include modifying file paths, removing unused parameters, and updating global variable usage.

File handling improvements:

* [`__init__.py`](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cL458-R459): Updated the file path in the `generate_output` method to use the `output_directory` parameter instead of a hardcoded path.

Codebase simplification:

* [`randomizer/Patching/Patcher.py`](diffhunk://#diff-282170d1bb253e272020d4f14dd1af1df2f5ff910b4d2de85d72c42523b1495dL131-L136): Removed the `default_file` parameter from the `load_base_rom` method and updated the method to return `og_patched_rom` directly. [[1]](diffhunk://#diff-282170d1bb253e272020d4f14dd1af1df2f5ff910b4d2de85d72c42523b1495dL131-L136) [[2]](diffhunk://#diff-282170d1bb253e272020d4f14dd1af1df2f5ff910b4d2de85d72c42523b1495dL150-R150)
* [`randomizer/Patching/Patcher.py`](diffhunk://#diff-282170d1bb253e272020d4f14dd1af1df2f5ff910b4d2de85d72c42523b1495dL175-R167): Removed the global `patchedRom` variable and updated the `__init__` method to set `patchedRom` to `None`. [[1]](diffhunk://#diff-282170d1bb253e272020d4f14dd1af1df2f5ff910b4d2de85d72c42523b1495dL175-R167) [[2]](diffhunk://#diff-282170d1bb253e272020d4f14dd1af1df2f5ff910b4d2de85d72c42523b1495dL185-R177)

Unused code removal:

* [`worker/tasks.py`](diffhunk://#diff-b2aa0be81dfc10bb28cd1f039c301d4436e336e9eaef746e7d2522788faf0883L34-R35): Commented out unused code related to patching in the `generate_seed` method. [[1]](diffhunk://#diff-b2aa0be81dfc10bb28cd1f039c301d4436e336e9eaef746e7d2522788faf0883L34-R35) [[2]](diffhunk://#diff-b2aa0be81dfc10bb28cd1f039c301d4436e336e9eaef746e7d2522788faf0883L50-R49)