### PR TITLE
AP All Keys Win Con

### DIFF
--- a/ap_version.py
+++ b/ap_version.py
@@ -1,3 +1,3 @@
 """Holds the version for Archipelago."""
 
-version = "1.0.8"
+version = "1.0.9"

--- a/archipelago/Items.py
+++ b/archipelago/Items.py
@@ -115,6 +115,10 @@ def setup_items(world: World) -> typing.List[DK64Item]:
     # Handle starting Kong list here
     for kong in world.logic_holder.settings.starting_kong_list:
         kong_item = DK64RItemPoolUtility.ItemFromKong(kong)
+        if kong == world.logic_holder.settings.starting_kong:
+            world.multiworld.push_precollected(
+                DK64Item(kong_item.name, ItemClassification.progression, full_item_table[DK64RItem.ItemList[kong_item].name].code, world.player)
+            )
         for item in item_table:
             if item.name == kong_item.name:
                 # Conveniently, this guarantees we have at least one precollected item!

--- a/archipelago/Items.py
+++ b/archipelago/Items.py
@@ -116,9 +116,7 @@ def setup_items(world: World) -> typing.List[DK64Item]:
     for kong in world.logic_holder.settings.starting_kong_list:
         kong_item = DK64RItemPoolUtility.ItemFromKong(kong)
         if kong == world.logic_holder.settings.starting_kong:
-            world.multiworld.push_precollected(
-                DK64Item(kong_item.name, ItemClassification.progression, full_item_table[DK64RItem.ItemList[kong_item].name].code, world.player)
-            )
+            world.multiworld.push_precollected(DK64Item(kong_item.name, ItemClassification.progression, full_item_table[DK64RItem.ItemList[kong_item].name].code, world.player))
         for item in item_table:
             if item.name == kong_item.name:
                 # Conveniently, this guarantees we have at least one precollected item!

--- a/archipelago/Options.py
+++ b/archipelago/Options.py
@@ -19,6 +19,7 @@ class Goal(Choice):
 
     display_name = "Goal"
     option_krool = 0
+    option_all_keys = 1
     default = 0
 
 

--- a/archipelago/Regions.py
+++ b/archipelago/Regions.py
@@ -389,6 +389,11 @@ def connect_regions(world: World, logic_holder: LogicVarHolder):
                 # print("Connecting " + region_id.name + " to " + destination_name)
             except Exception:
                 pass
+
+    # V1 LIMITATION: We have pre-activated Isles warps, so we need to make two extra connections to make sure the logic is correct
+    connect(world, "IslesMain", "IslesMainUpper", lambda state: True)  # Pre-activated W2
+    connect(world, "IslesMain", "KremIsleBeyondLift", lambda state: True)  # Pre-activated W4
+
     pass
 
 


### PR DESCRIPTION
- Added All Keys win condition to the Goal options in AP yamls
- Fixed an issue where pre-activated Isles warps weren't considered in AP logic
- Cranky now considers progressive AP items to be major items when hinting what is on Jetpac
- The starting Kong is now in the AP spoiler log and AP start inventory