### PR TITLE
bug fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -295,6 +295,8 @@ if baseclasses_loaded:
             settings.tiny_freeing_kong = self.random.randint(0, 4)
             settings.chunky_freeing_kong = self.random.randint(0, 4)
             spoiler = Spoiler(settings)
+            # Undo any changes to this location's name, until we find a better way to prevent this from confusing the tracker and the AP code that is responsible for sending out items
+            spoiler.LocationList[DK64RLocations.FactoryDonkeyDKArcade].name = "Factory Donkey DK Arcade Round 1"
             spoiler.settings.shuffled_location_types.append(Types.ArchipelagoItem)
             self.logic_holder = LogicVarHolder(spoiler, self.player)
 

--- a/ap_version.py
+++ b/ap_version.py
@@ -1,3 +1,3 @@
 """Holds the version for Archipelago."""
 
-version = "1.0.17"
+version = "1.0.18"

--- a/archipelago/Items.py
+++ b/archipelago/Items.py
@@ -92,8 +92,10 @@ def setup_items(world: World) -> typing.List[DK64Item]:
             classification = ItemClassification.filler
         elif item.type in [DK64RItems.IceTrapBubble, DK64RItems.IceTrapReverse, DK64RItems.IceTrapSlow]:
             classification = ItemClassification.trap
+        elif item.type == DK64RTypes.Key:
+            classification = ItemClassification.progression
         # The playthrough tag doesn't quite 1-to-1 map to Archipelago's "progression" type - some items we don't consider "playthrough" can affect logic
-        elif item.playthrough is True or item.type in (DK64RTypes.Blueprint, DK64RTypes.Pearl, DK64RTypes.Bean, DK64RTypes.Key):
+        elif item.playthrough is True or item.type in (DK64RTypes.Blueprint, DK64RTypes.Pearl, DK64RTypes.Bean):
             classification = ItemClassification.progression_skip_balancing
         else:  # double check jetpac, eh?
             classification = ItemClassification.useful

--- a/archipelago/Items.py
+++ b/archipelago/Items.py
@@ -93,7 +93,7 @@ def setup_items(world: World) -> typing.List[DK64Item]:
         elif item.type in [DK64RItems.IceTrapBubble, DK64RItems.IceTrapReverse, DK64RItems.IceTrapSlow]:
             classification = ItemClassification.trap
         # The playthrough tag doesn't quite 1-to-1 map to Archipelago's "progression" type - some items we don't consider "playthrough" can affect logic
-        elif item.playthrough is True or item.type in (DK64RTypes.Blueprint, DK64RTypes.Pearl, DK64RTypes.Bean):
+        elif item.playthrough is True or item.type in (DK64RTypes.Blueprint, DK64RTypes.Pearl, DK64RTypes.Bean, DK64RTypes.Key):
             classification = ItemClassification.progression_skip_balancing
         else:  # double check jetpac, eh?
             classification = ItemClassification.useful

--- a/archipelago/Logic.py
+++ b/archipelago/Logic.py
@@ -937,8 +937,8 @@ class LogicVarHolder:
         # if caged_item_id == Items.NoItem:
         #     return True
         # If we can't free Diddy, then we can't access the item so we can't reach the item
-        if not self.CanFreeDiddy():
-            return False
+        # if not self.CanFreeDiddy():
+        #     return False
         # If we are the right kong, then we can always get the item
         if self.IsKong(self.settings.diddy_freeing_kong):
             return True


### PR DESCRIPTION
- Factory Donkey DK Arcade Round 1 should now work correctly in terms of Archipelago. That also will always be the check's name, due to technical limitations
- Seeds with different sets of starting keys should now generate
- Fixed logic for anything that requires you to open the Japes gates that you'd need to free Diddy for (they no longer require a gun to open when Diddy's cage starts open)