### PR TITLE
Apply kongless hint door logic

### DIFF
--- a/randomizer/Logic.py
+++ b/randomizer/Logic.py
@@ -943,7 +943,8 @@ class LogicVarHolder:
         # The only weird exception: vanilla Fungi Lobby hint doors only check for Chunky, not the current Kong, and all besides Chunky's needs grab
         if not self.settings.wrinkly_location_rando and not self.settings.remove_wrinkly_puzzles and region_id == RegionEnum.FungiForestLobby:
             return self.chunky and (location.kong == Kongs.chunky or (self.donkey and self.grab))
-        return self.HasKong(location.kong)
+        # Last step: either have the kong or have Kongless Hint Doors enabled
+        return self.HasKong(location.kong) or self.settings.wrinkly_available
 
     def CanBuy(self, location, buy_empty=False):
         """Check if there are enough coins to purchase this location."""


### PR DESCRIPTION
Apply the Kongless Hint Door setting to the logic so you don't have to have the Kong to logically access a hint door. This greatly increases hint door availability for early items.