### PR TITLE
Fix AP gen bug

### DIFF
--- a/ap_version.py
+++ b/ap_version.py
@@ -1,3 +1,3 @@
 """Holds the version for Archipelago."""
 
-version = "1.0.25"
+version = "1.0.26"

--- a/randomizer/ShuffleBosses.py
+++ b/randomizer/ShuffleBosses.py
@@ -112,7 +112,7 @@ def GetKongOptionsForBoss(boss_map: Maps, alt_mj_kongs: bool):
         # Not possible right now to make any other kong beat another's phase, however, if we were to do so:
         # DK Phase - Make all kongs enter cannon barrels
         # Other phases - ????????
-        possibleKongs = [Kongs.donkey + (boss_map - Maps.KroolDonkeyPhase)]
+        possibleKongs = [Kongs(Kongs.donkey + (boss_map - Maps.KroolDonkeyPhase))]
     return possibleKongs
 
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "__startup__.py", line 121, in run
  File "console.py", line 25, in run
  File "Generate.py", line 552, in <module>
  File "Main.py", line 359, in main
  File "concurrent\futures\_base.py", line 449, in result
  File "concurrent\futures\_base.py", line 401, in __get_result
  File "concurrent\futures\thread.py", line 59, in run
  File "Main.py", line 269, in write_multidata
  File "C:\ProgramData\Archipelago\custom_worlds\dk64.apworld\dk64\__init__.py", line 591, in fill_slot_data
  File "C:\ProgramData\Archipelago\custom_worlds\dk64.apworld\dk64\__init__.py", line 591, in <genexpr>
AttributeError: 'int' object has no attribute 'name'
```

KRool kongs are stored as ints instead of Kong enums is the reason this happens. Slot data expects the Kong enum.