### PR TITLE
Prevent bad warp location logic

### DIFF
--- a/randomizer/Lists/CustomLocations.py
+++ b/randomizer/Lists/CustomLocations.py
@@ -68,8 +68,10 @@ class CustomLocation:
         self.placement_subindex = default_index
         self.tied_warp_event = tied_warp_event
         if logic is None:
+            self.warp_banned = False
             self.logic = lambda l: True
         else:
+            self.warp_banned = True
             self.logic = logic
 
     def setCustomLocation(self, value: bool) -> None:

--- a/randomizer/ShufflePorts.py
+++ b/randomizer/ShufflePorts.py
@@ -116,6 +116,9 @@ def ResetPorts():
 
 def isCustomLocationValid(spoiler, location: CustomLocation, map_id: Maps, level: Levels) -> bool:
     """Determine whether a custom location is valid for a warp pad."""
+    if location.warp_banned:
+        # Locations that have logic to access them are banned from being warp locations
+        return False
     if location.map != map_id:
         # Has to be in the right map
         return False


### PR DESCRIPTION
Banned all custom locations that have non-trivial access logic from being warps. This saves us a veritable mountain of logic headaches from accessing pre-activated warps in unexpected ways