### PR TITLE
Entrance hint fix, pickier warp location selection

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -18,6 +18,7 @@ from randomizer.Enums.Maps import Maps
 from randomizer.Enums.Regions import Regions
 from randomizer.Enums.HintRegion import HintRegion, MEDAL_REWARD_REGIONS, HINT_REGION_PAIRING
 from randomizer.Enums.Settings import (
+    BananaportRando,
     ClimbingStatus,
     ProgressiveHintItem,
     ActivateAllBananaports,
@@ -2061,9 +2062,11 @@ def compileHints(spoiler: Spoiler) -> bool:
                 Maps.CastleBaboonBlast,
             ):
                 continue
-            # The Mechfish is its own map but is still not shuffled
-            if woth_map == Maps.GalleonMechafish:
-                continue
+            # If warps are pre-activated and cross-map, you might enter the Castle Crypt or the Llama Temple via the warps, and those transitions aren't hintable.
+            if spoiler.settings.activate_all_bananaports == ActivateAllBananaports.all and spoiler.settings.bananaport_rando in (BananaportRando.crossmap_coupled, BananaportRando.crossmap_decoupled):
+                # Best to not entrance hint these maps in those worlds just in case.
+                if woth_map in (Maps.CastleCrypt, Maps.AztecLlamaTemple):
+                    continue
             # Avoid hinting the same map section twice
             if woth_map in tracked_maps and (region_id in tracked_regions or region_id not in region_exceptions.keys()):
                 continue

--- a/randomizer/Lists/CustomLocations.py
+++ b/randomizer/Lists/CustomLocations.py
@@ -68,10 +68,10 @@ class CustomLocation:
         self.placement_subindex = default_index
         self.tied_warp_event = tied_warp_event
         if logic is None:
-            self.warp_banned = False
+            self.has_access_logic = False
             self.logic = lambda l: True
         else:
-            self.warp_banned = True
+            self.has_access_logic = True
             self.logic = logic
 
     def setCustomLocation(self, value: bool) -> None:

--- a/randomizer/ShufflePorts.py
+++ b/randomizer/ShufflePorts.py
@@ -13,7 +13,7 @@ from randomizer.Enums.Levels import Levels
 from randomizer.Enums.Events import Events
 from randomizer.Enums.Maps import Maps
 from randomizer.Enums.Regions import Regions
-from randomizer.Enums.Settings import ShufflePortLocations
+from randomizer.Enums.Settings import ActivateAllBananaports, ShufflePortLocations
 from randomizer.Lists.CustomLocations import CustomLocation, CustomLocations, LocationTypes, getBannedWarps
 from randomizer.Lists.Warps import BananaportVanilla
 from randomizer.LogicClasses import Event
@@ -116,12 +116,15 @@ def ResetPorts():
 
 def isCustomLocationValid(spoiler, location: CustomLocation, map_id: Maps, level: Levels) -> bool:
     """Determine whether a custom location is valid for a warp pad."""
-    if location.warp_banned:
-        # Locations that have logic to access them are banned from being warp locations
-        return False
     if location.map != map_id:
         # Has to be in the right map
         return False
+    if location.has_access_logic:
+        # Locations that have logic to access them are banned from being warp locations when those warps are pre-activated
+        if spoiler.settings.activate_all_bananaports == ActivateAllBananaports.all:
+            return False
+        elif spoiler.settings.activate_all_bananaports != ActivateAllBananaports.none and map_id == Maps.Isles:
+            return False
     BANNED_PORT_SHUFFLE_EVENTS = getBannedWarps(spoiler)
     if location.tied_warp_event is not None:
         if location.tied_warp_event in BANNED_PORT_SHUFFLE_EVENTS:


### PR DESCRIPTION
- Fixed an issue where you might get a nonsense entrance hinted if your first access to a region was with a pre-activated warp
- Fixed an issue where the mechfish couldn't get entrance hinted
- Allowed more custom locations to be warp locations so long as those warps are not pre-activated