### PR TITLE
Create safety functions for deathlink

### DIFF
--- a/ap_version.py
+++ b/ap_version.py
@@ -1,3 +1,3 @@
 """Holds the version for Archipelago."""
 
-version = "1.0.27"
+version = "1.0.28"

--- a/archipelago/DK64Client.py
+++ b/archipelago/DK64Client.py
@@ -19,7 +19,7 @@ from client.pj64 import PJ64Client
 from client.items import item_ids, item_names_to_id
 from client.check_flag_locations import location_flag_to_name, location_name_to_flag
 from client.ap_check_ids import check_id_to_name, check_names_to_id
-from CommonClient import CommonContext, get_base_parser, gui_enabled, logger, server_loop
+from CommonClient import CommonContext, get_base_parser, gui_enabled, logger, server_loop, ClientCommandProcessor
 from NetUtils import ClientStatus
 from ap_version import version as ap_version
 
@@ -560,6 +560,38 @@ class DK64Client:
                 self.send_message(item_name, sender, "to")
                 self.sent_checks.remove(item)
 
+    def safe_clear_death_events(self):
+        """Clear any death events that may be pending."""
+        self.n64_client.write_u8(self.memory_pointer + DK64MemoryMap.receive_death, 0)
+        self.n64_client.write_u8(self.memory_pointer + DK64MemoryMap.send_death, 0)
+        self.pending_deathlink = False
+        self.deathlink_debounce = True
+
+
+class DK64CommandProcessor(ClientCommandProcessor):
+    def __init__(self, ctx):
+        super().__init__(ctx)
+
+    def _cmd_reset_deathlink(self):
+        """Reset the deathlink state."""
+        if isinstance(self.ctx, DK64Context):
+            self.ctx.client.safe_clear_death_events()
+            logger.info("Deathlink state reset")
+
+    def _cmd_deathlink(self):
+        """Toggle deathlink from client. Overrides default setting."""
+        if isinstance(self.ctx, DK64Context):
+            if self.ctx.ENABLE_DEATHLINK:
+                self.ctx.ENABLE_DEATHLINK = False
+                self.ctx.client.ENABLE_DEATHLINK = False
+                create_task_log_exception(self.ctx.update_death_link(False))
+                logger.info("Deathlink disabled")
+            else:
+                self.ctx.ENABLE_DEATHLINK = True
+                self.ctx.client.ENABLE_DEATHLINK = True
+                create_task_log_exception(self.ctx.update_death_link(True))
+                logger.info("Deathlink enabled")
+
 
 class DK64Context(CommonContext):
     """Context for Donkey Kong 64."""
@@ -570,7 +602,7 @@ class DK64Context(CommonContext):
     found_checks = []
     last_resend = time.time()
     ENABLE_DEATHLINK = False
-
+    command_processor = DK64CommandProcessor
     won = False
 
     def reset_checks(self):

--- a/archipelago/DK64Client.py
+++ b/archipelago/DK64Client.py
@@ -569,7 +569,10 @@ class DK64Client:
 
 
 class DK64CommandProcessor(ClientCommandProcessor):
+    """Command processor for Donkey Kong 64 commands."""
+
     def __init__(self, ctx):
+        """Initialize the DK64 command processor."""
         super().__init__(ctx)
 
     def _cmd_reset_deathlink(self):


### PR DESCRIPTION
This pull request introduces enhancements to the Donkey Kong 64 client, including the addition of new command processing capabilities, a utility function for handling death events, and a version update. The most significant changes focus on improving the Deathlink feature by adding commands to toggle and reset its state.

### Deathlink feature enhancements:
* Added a `safe_clear_death_events` method to handle clearing pending death events, ensuring the Deathlink state is reset safely. (`archipelago/DK64Client.py`, [archipelago/DK64Client.pyR563-R594](diffhunk://#diff-2e2a10dbf06e376df9f46c4a4b442ccd5d63b70ef1bbaa8eacf0c26e5eb727f0R563-R594))
* Introduced the `DK64CommandProcessor` class, extending `ClientCommandProcessor` to include `_cmd_reset_deathlink` and `_cmd_deathlink` commands for resetting and toggling Deathlink functionality. (`archipelago/DK64Client.py`, [archipelago/DK64Client.pyR563-R594](diffhunk://#diff-2e2a10dbf06e376df9f46c4a4b442ccd5d63b70ef1bbaa8eacf0c26e5eb727f0R563-R594))

### Code structure improvements:
* Assigned `DK64CommandProcessor` as the `command_processor` for `DK64Context`, enabling the newly added commands. (`archipelago/DK64Client.py`, [archipelago/DK64Client.pyL573-R605](diffhunk://#diff-2e2a10dbf06e376df9f46c4a4b442ccd5d63b70ef1bbaa8eacf0c26e5eb727f0L573-R605))

### Version update:
* Updated the version of Archipelago from `1.0.27` to `1.0.28`. (`ap_version.py`, [ap_version.pyL3-R3](diffhunk://#diff-eedb3380dcf36b1ddad17bb7adb36762f81b4a723b72988cbce995d65dcf1e0eL3-R3))

### Dependency update:
* Added `ClientCommandProcessor` to the list of imports from `CommonClient`, supporting the new command processor functionality. (`archipelago/DK64Client.py`, [archipelago/DK64Client.pyL22-R22](diffhunk://#diff-2e2a10dbf06e376df9f46c4a4b442ccd5d63b70ef1bbaa8eacf0c26e5eb727f0L22-R22))