### PR TITLE
Logic Changes

### DIFF
--- a/randomizer/LogicFiles/DKIsles.py
+++ b/randomizer/LogicFiles/DKIsles.py
@@ -201,7 +201,7 @@ LogicRegions = {
         TransitionFront(Regions.IslesHill, lambda l: True),
         TransitionFront(Regions.AztecLobbyRoof, lambda l: l.CanMoonkick()),
         TransitionFront(Regions.AngryAztecLobby, lambda l: l.settings.open_lobbies or Events.JapesKeyTurnedIn in l.Events or l.CanPhase(), Transitions.IslesMainToAztecLobby),
-        TransitionFront(Regions.IslesEar, lambda l: (l.settings.open_lobbies or Events.ForestKeyTurnedIn in l.Events) and ((l.istiny and l.twirl) or (l.isdonkey or l.ischunky or ((l.isdiddy or l.islanky) and l.advanced_platforming) and not l.isKrushaAdjacent(l.kong)) or l.CanMoonkick())),
+        TransitionFront(Regions.IslesEar, lambda l: (l.settings.open_lobbies or Events.ForestKeyTurnedIn in l.Events) and ((l.istiny and l.twirl) or (l.isdonkey or l.ischunky or ((l.isdiddy or l.islanky) and l.advanced_platforming) and not l.isKrushaAdjacent(l.kong))) or l.CanMoonkick()),
     ]),
 
     Regions.IslesEar: Region("Isles Ear", HintRegion.MainIsles, Levels.DKIsles, False, None, [], [], [

--- a/randomizer/LogicFiles/FranticFactory.py
+++ b/randomizer/LogicFiles/FranticFactory.py
@@ -143,6 +143,7 @@ LogicRegions = {
     ], [
         TransitionFront(Regions.FactoryArcadeTunnel, lambda l: l.climbing),
         TransitionFront(Regions.LowerCore, lambda l: True),
+        TransitionFront(Regions.ChunkyRoomPlatform, lambda l : l.CanMoonkick() or (l.twirl and l.istiny and l.advanced_platforming) or (l.isdiddy and l.advanced_platforming)),
         TransitionFront(Regions.CrankyFactory, lambda l: l.crankyAccess),
         TransitionFront(Regions.CandyFactory, lambda l: l.candyAccess),
         TransitionFront(Regions.FactoryStoragePipe, lambda l: l.islanky and l.handstand),

--- a/randomizer/LogicFiles/FranticFactory.py
+++ b/randomizer/LogicFiles/FranticFactory.py
@@ -143,7 +143,7 @@ LogicRegions = {
     ], [
         TransitionFront(Regions.FactoryArcadeTunnel, lambda l: l.climbing),
         TransitionFront(Regions.LowerCore, lambda l: True),
-        TransitionFront(Regions.ChunkyRoomPlatform, lambda l : l.CanMoonkick() or (l.twirl and l.istiny and l.advanced_platforming) or (l.isdiddy and l.advanced_platforming)),
+        TransitionFront(Regions.ChunkyRoomPlatform, lambda l: l.CanMoonkick() or (l.twirl and l.istiny and l.advanced_platforming) or (l.isdiddy and l.advanced_platforming)),
         TransitionFront(Regions.CrankyFactory, lambda l: l.crankyAccess),
         TransitionFront(Regions.CandyFactory, lambda l: l.candyAccess),
         TransitionFront(Regions.FactoryStoragePipe, lambda l: l.islanky and l.handstand),


### PR DESCRIPTION
- Lobby 6 Moonkick is now in logic without opening the lobby
- New Transition logic to get to Power Hut platform