### PR TITLE
Allow safety toggles

### DIFF
--- a/ap_version.py
+++ b/ap_version.py
@@ -1,3 +1,3 @@
 """Holds the version for Archipelago."""
 
-version = "1.0.31"
+version = "1.0.32"

--- a/archipelago/DK64Client.py
+++ b/archipelago/DK64Client.py
@@ -601,6 +601,36 @@ class DK64CommandProcessor(ClientCommandProcessor):
                 create_task_log_exception(self.ctx.update_death_link(True))
                 logger.info("Deathlink enabled")
 
+    def _cmd_taglink(self):
+        """Toggle taglink from client. Overrides default setting."""
+        if isinstance(self.ctx, DK64Context):
+            if self.ctx.ENABLE_TAGLINK:
+                self.ctx.ENABLE_TAGLINK = False
+                self.ctx.client.ENABLE_TAGLINK = False
+                self.ctx.tags.discard("TagLink")
+                logger.info("Taglink disabled")
+            else:
+                self.ctx.ENABLE_TAGLINK = True
+                self.ctx.client.ENABLE_TAGLINK = True
+                logger.info("Taglink enabled")
+                self.ctx.tags.add("TagLink")
+            create_task_log_exception(self.ctx.send_msgs([{"cmd": "ConnectUpdate", "tags": self.ctx.tags}]))
+
+    def _cmd_ringlink(self):
+        """Toggle ringlink from client. Overrides default setting."""
+        if isinstance(self.ctx, DK64Context):
+            if self.ctx.ENABLE_RINGLINK:
+                self.ctx.ENABLE_RINGLINK = False
+                self.ctx.client.ENABLE_RINGLINK = False
+                self.ctx.tags.discard("RingLink")
+                logger.info("Ringlink disabled")
+            else:
+                self.ctx.ENABLE_RINGLINK = True
+                self.ctx.client.ENABLE_RINGLINK = True
+                logger.info("Ringlink enabled")
+                self.ctx.tags.add("RingLink")
+            create_task_log_exception(self.ctx.send_msgs([{"cmd": "ConnectUpdate", "tags": self.ctx.tags}]))
+
 
 class DK64Context(CommonContext):
     """Context for Donkey Kong 64."""


### PR DESCRIPTION
This pull request introduces a version update for Archipelago and adds new functionality to the `DK64Client` for toggling additional features (`Taglink` and `Ringlink`). The changes enhance the client-side control over these features and improve the overall flexibility of the application.

### Version Update:
* [`ap_version.py`](diffhunk://#diff-eedb3380dcf36b1ddad17bb7adb36762f81b4a723b72988cbce995d65dcf1e0eL3-R3): Updated the version from `1.0.31` to `1.0.32` to reflect the new changes.

### Feature Enhancements:
* [`archipelago/DK64Client.py`](diffhunk://#diff-2e2a10dbf06e376df9f46c4a4b442ccd5d63b70ef1bbaa8eacf0c26e5eb727f0R604-R633): Added `_cmd_taglink` and `_cmd_ringlink` methods to enable or disable `Taglink` and `Ringlink` features from the client. These methods update the corresponding flags in the context, modify client tags, and send updates to the server.