### PR TITLE
Sort Slam Hint

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -1243,6 +1243,7 @@ def compileHints(spoiler: Spoiler) -> bool:
                 if location.item == Items.ProgressiveSlam and id not in PreGivenLocations and id not in TrainingBarrelLocations:  # Ignore anything pre-given
                     if location.level not in slam_levels:
                         slam_levels.append(location.level)
+            slam_levels.sort(key=lambda level: level.value)  # Sort the slam levels by vanilla level order so as to disguise any information from the traversal
             # Assemble a hint that resembles the microhint - only hint the levels the slams are in
             slam_text_entries = [f"{level_colors[x]}{level_list[x]}{level_colors[x]}" for x in slam_levels]
             slam_text = " or ".join(slam_text_entries)
@@ -2804,6 +2805,7 @@ def compileMicrohints(spoiler: Spoiler) -> None:
                             hint_text = hint_text.replace(colorless_kong_list[location.kong].upper(), "KRUSHA")
                 spoiler.microhints[item.name] = hint_text
     if len(slam_levels) > 0:
+        slam_levels.sort(key=lambda level: level.value)  # Sort the slam levels so they are in order
         slam_text_entries = [f"{level_colors[x]}{level_list[x]}{level_colors[x]}" for x in slam_levels]
         slam_text = " or ".join(slam_text_entries)
         spoiler.microhints[ItemList[Items.ProgressiveSlam].name] = (


### PR DESCRIPTION
Sorting the slam hint guarantees there's no arcane rules you can use to further decipher the location of the slams based on the world traversal mechanism used to build the hint.