### PR TITLE
CLO Helm B. Locker buffer, warp wombo connector fix

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -2003,6 +2003,9 @@ def compileHints(spoiler: Spoiler) -> bool:
             # Maps.CastleUpperCave: [Regions.UpperCave],
             # Maps.CastleLowerCave: [Regions.LowerCave],
         }
+        # If warps are pre-activated and cross-map, we can't treat the Castle Crypt as a connector because you are decently likely to just warp into it.
+        if spoiler.settings.activate_all_bananaports == ActivateAllBananaports.all and spoiler.settings.bananaport_rando in (BananaportRando.crossmap_coupled, BananaportRando.crossmap_decoupled):
+            del connector_maps[Maps.CastleCrypt]
         # First identify which maps contain WotH items - some maps are more interesting than others
         isolated_interesting_transitions = []
         # Lists to prevent duplicate entrance hints from existing

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -292,27 +292,28 @@ class Settings:
         self.BLockerEntryItems = [BarrierItems.GoldenBanana] * 8
         self.BLockerEntryCount = [0] * 8
 
+        self.blocker_limits = {
+            # Will give customization to this eventually, just need to get a proof of concept working
+            # BarrierItems.Nothing: 0,
+            # BarrierItems.Kong: 5,
+            # BarrierItems.Move: 41,
+            BarrierItems.GoldenBanana: 200,
+            BarrierItems.Blueprint: 40,
+            BarrierItems.Fairy: 20,
+            # BarrierItems.Key: 8,
+            BarrierItems.Crown: 10,
+            BarrierItems.CompanyCoin: 2,
+            BarrierItems.Medal: 40,
+            BarrierItems.Bean: 1,
+            BarrierItems.Pearl: 5,
+            BarrierItems.RainbowCoin: 16,
+            # BarrierItems.IceTrap: 10,
+            # BarrierItems.Percentage: 20,
+            # BarrierItems.ColoredBanana: 1000,
+        }
+
         if self.chaos_blockers:
             self.chaos_ratio = self.chaos_ratio / 100.0
-            self.blocker_limits = {
-                # Will give customization to this eventually, just need to get a proof of concept working
-                # BarrierItems.Nothing: 0,
-                # BarrierItems.Kong: 5,
-                # BarrierItems.Move: 41,
-                BarrierItems.GoldenBanana: 200,
-                BarrierItems.Blueprint: 40,
-                BarrierItems.Fairy: 20,
-                # BarrierItems.Key: 8,
-                BarrierItems.Crown: 10,
-                BarrierItems.CompanyCoin: 2,
-                BarrierItems.Medal: 40,
-                BarrierItems.Bean: 1,
-                BarrierItems.Pearl: 5,
-                BarrierItems.RainbowCoin: 16,
-                # BarrierItems.IceTrap: 10,
-                # BarrierItems.Percentage: 20,
-                # BarrierItems.ColoredBanana: 1000,
-            }
             locked_blocker_items = []
             for slot in range(8):
                 item = self.random.choice([key for key in self.blocker_limits.keys() if key not in locked_blocker_items])


### PR DESCRIPTION
- Added a buffer to the Helm B. Locker in CLO if Helm is your last level. It should respect a buffer on your maximum B. Locker in a similar manner to other B. Lockers.
- Fixed an issue where a self-contained set of Maps centered on the Castle Crypt could cause weird entrance hints if you could use a preactivated warp to reach it.