### PR TITLE
Revert "Fix bug with Archipelago 0.6.1 client for linux where apworld root path is not added to syspath"

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -111,12 +111,10 @@ if baseclasses_loaded:
     else:
         raise Exception(f"Unsupported platform: {platform_type}")
 
-    cwd = os.path.dirname(__file__)
-    sys.path.append(cwd)
-    sys.path.append(cwd + "/" + "worlds/dk64/")
-    sys.path.append(cwd + "/" + "worlds/dk64/archipelago/")
-    sys.path.append(cwd + "/" + "custom_worlds/dk64.apworld/dk64/")
-    sys.path.append(cwd + "/" + "custom_worlds/dk64.apworld/dk64/archipelago/")
+    sys.path.append("worlds/dk64/")
+    sys.path.append("worlds/dk64/archipelago/")
+    sys.path.append("custom_worlds/dk64.apworld/dk64/")
+    sys.path.append("custom_worlds/dk64.apworld/dk64/archipelago/")
 
     import randomizer.ItemPool as DK64RItemPool
 


### PR DESCRIPTION
Reverts 2dos/DK64-Randomizer#2661