### PR TITLE
Archipelago: Fall back to latin-1 encoding if utf-8 fails for the config file

### DIFF
--- a/ap_version.py
+++ b/ap_version.py
@@ -1,3 +1,3 @@
 """Holds the version for Archipelago."""
 
-version = "1.0.44"
+version = "1.0.45"

--- a/archipelago/client/pj64.py
+++ b/archipelago/client/pj64.py
@@ -142,11 +142,18 @@ class PJ64Client:
         def clean_config_file(file_path):
             """Read the config file and return cleaned lines."""
             cleaned_lines = []
-            with open(file_path, encoding="utf8") as f:
-                for line in f:
-                    stripped = line.strip()
-                    if stripped == "" or stripped.startswith("[") or "=" in stripped:
-                        cleaned_lines.append(line)
+            def read_and_clean_lines(file_path, encoding):
+                with open(file_path, encoding=encoding) as f:
+                    for line in f:
+                        stripped = line.strip()
+                        if stripped == "" or stripped.startswith("[") or "=" in stripped:
+                            cleaned_lines.append(line)
+
+            try:
+                read_and_clean_lines(file_path, "utf8")
+            except UnicodeDecodeError:
+                # Try one fallback encoding, just in case
+                read_and_clean_lines(file_path, "latin1")
             return cleaned_lines
 
         def sanitize_config(config):

--- a/archipelago/client/pj64.py
+++ b/archipelago/client/pj64.py
@@ -142,6 +142,7 @@ class PJ64Client:
         def clean_config_file(file_path):
             """Read the config file and return cleaned lines."""
             cleaned_lines = []
+
             def read_and_clean_lines(file_path, encoding):
                 with open(file_path, encoding=encoding) as f:
                     for line in f:


### PR DESCRIPTION
Sometimes, Windows likes to save file paths with non utf-8 characters (yay, ANSI!).  This can be a problem if someone ends up with file paths in their Project64.cfg with such a character.

We can solve this by at least trying latin-1 encoding, and only bail if that also fails. Tested using a config with é included.