### PR TITLE
Archipelago: Blueprints item group

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -245,6 +245,17 @@ if baseclasses_loaded:
         item_name_to_id = {name: data.code for name, data in full_item_table.items()}
         location_name_to_id = all_locations
 
+        def blueprint_item_group() -> str:
+            res = set()
+            for name, _ in full_item_table.items():
+                if "Blueprint" in name:
+                    res.add(name)
+            return res
+
+        item_name_groups = {
+            "Blueprints": blueprint_item_group(),
+        }
+
         # with open("donklocations.txt", "w") as f:
         #     print(location_name_to_id, file=f)
 


### PR DESCRIPTION
Putting "Blueprints" somewhere in your yaml expands it during generation to mean all of the individual blueprints.

This basically only matters for itemlink, but it's nice quality of life for those who like to share GBs :)