### PR TITLE
Adjust scripts and hope it works

### DIFF
--- a/.github/workflows/release_pages_dev.yml
+++ b/.github/workflows/release_pages_dev.yml
@@ -52,3 +52,39 @@ jobs:
         DEST_BRANCH: main
         DEST_FOLDER: ./
         DEST_PREDEPLOY_CLEANUP: rm -rf ./*
+    
+    - name: Check if ap_version.py changed
+      id: check_version
+      run: |
+        if git diff --name-only HEAD~ HEAD | grep -q "ap_version.py"; then
+          echo "version_changed=true" >> $GITHUB_OUTPUT
+          echo "AP version file changed"
+        else
+          echo "version_changed=false" >> $GITHUB_OUTPUT
+          echo "AP version file not changed"
+        fi
+
+    - name: Get version from ap_version.py
+      if: steps.check_version.outputs.version_changed == 'true'
+      id: get_version
+      run: |
+        VERSION=$(python3 -c "exec(open('ap_version.py').read()); print(version)")
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Version: $VERSION"
+
+    - name: Create Release in Target Repo
+      if: steps.check_version.outputs.version_changed == 'true'
+      uses: ncipollo/release-action@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+        owner: 2dos
+        repo: DK64-Randomizer-Dev
+        tag: v${{ steps.get_version.outputs.version }}
+        name: DK64 Randomizer APWorld v${{ steps.get_version.outputs.version }}
+        body: |
+          DK64 Randomizer APWorld file for Archipelago version ${{ steps.get_version.outputs.version }}
+          
+          This release contains the dk64.apworld file that can be used with the Archipelago multiworld randomizer.
+        artifacts: ./deploy-directory/dk64.apworld
+        makeLatest: true
+

--- a/.github/workflows/release_pages_dev.yml
+++ b/.github/workflows/release_pages_dev.yml
@@ -65,7 +65,7 @@ jobs:
         fi
 
     - name: Get version from ap_version.py
-      if: steps.check_version.outputs.version_changed == 'true'
+      if: steps.check_version.outputs.version_changed != 'true'
       id: get_version
       run: |
         VERSION=$(python3 -c "exec(open('ap_version.py').read()); print(version)")
@@ -73,7 +73,7 @@ jobs:
         echo "Version: $VERSION"
 
     - name: Create Release in Target Repo
-      if: steps.check_version.outputs.version_changed == 'true'
+      if: steps.check_version.outputs.version_changed != 'true'
       uses: ncipollo/release-action@v1
       with:
         token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/release_pages_main.yml
+++ b/.github/workflows/release_pages_main.yml
@@ -49,3 +49,37 @@ jobs:
         DEST_FOLDER: ./
         DEST_PREDEPLOY_CLEANUP: rm -rf ./*
 
+    - name: Check if ap_version.py changed
+      id: check_version
+      run: |
+        if git diff --name-only HEAD~ HEAD | grep -q "ap_version.py"; then
+          echo "version_changed=true" >> $GITHUB_OUTPUT
+          echo "AP version file changed"
+        else
+          echo "version_changed=false" >> $GITHUB_OUTPUT
+          echo "AP version file not changed"
+        fi
+
+    - name: Get version from ap_version.py
+      if: steps.check_version.outputs.version_changed == 'true'
+      id: get_version
+      run: |
+        VERSION=$(python3 -c "exec(open('ap_version.py').read()); print(version)")
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Version: $VERSION"
+
+    - name: Create Release in Target Repo
+      if: steps.check_version.outputs.version_changed == 'true'
+      uses: ncipollo/release-action@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+        owner: 2dos
+        repo: DK64-Randomizer-Release
+        tag: v${{ steps.get_version.outputs.version }}
+        name: DK64 Randomizer APWorld v${{ steps.get_version.outputs.version }}
+        body: |
+          DK64 Randomizer APWorld file for Archipelago version ${{ steps.get_version.outputs.version }}
+          
+          This release contains the dk64.apworld file that can be used with the Archipelago multiworld randomizer.
+        artifacts: ./deploy-directory/dk64.apworld
+        makeLatest: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for both the development and main release pipelines to automate the creation of a new release in the target repository whenever the `ap_version.py` file changes. The workflow now checks for changes to the version file, extracts the new version, and creates a corresponding release with the updated artifact.

**Release automation improvements:**

* Added a step to check if `ap_version.py` has changed in the latest commit, and only proceed with creating a release if it has. [[1]](diffhunk://#diff-49efdbf9bdda6b7a434332fac9b55ca8472a4b6a84246f87b1aee6ae5615fd8cR55-R90) [[2]](diffhunk://#diff-60f37cd8ba2c537fe1cd5f74155b09d679a6179d4766e1c0f607762f543146d6R52-R85)
* Added a step to extract the version number from `ap_version.py` using Python, making it available for tagging and naming the release. [[1]](diffhunk://#diff-49efdbf9bdda6b7a434332fac9b55ca8472a4b6a84246f87b1aee6ae5615fd8cR55-R90) [[2]](diffhunk://#diff-60f37cd8ba2c537fe1cd5f74155b09d679a6179d4766e1c0f607762f543146d6R52-R85)
* Automated the creation of a GitHub release in the target repository (`DK64-Randomizer-Dev` for dev, `DK64-Randomizer-Release` for main) with the new version tag and artifact, triggered only when the version file changes. [[1]](diffhunk://#diff-49efdbf9bdda6b7a434332fac9b55ca8472a4b6a84246f87b1aee6ae5615fd8cR55-R90) [[2]](diffhunk://#diff-60f37cd8ba2c537fe1cd5f74155b09d679a6179d4766e1c0f607762f543146d6R52-R85)