### PR TITLE
adjust events

### DIFF
--- a/.github/workflows/release_pages_dev.yml
+++ b/.github/workflows/release_pages_dev.yml
@@ -9,6 +9,19 @@ jobs:
     if: contains(github.actor, '[bot]')
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+
+    - name: Check if ap_version.py changed
+      id: check_version
+      run: |
+        if git diff --name-only HEAD~ HEAD | grep -q "ap_version.py"; then
+          echo "version_changed=true" >> $GITHUB_OUTPUT
+          echo "AP version file changed"
+        else
+          echo "version_changed=false" >> $GITHUB_OUTPUT
+          echo "AP version file not changed"
+        fi
 
     - name: Setup python
       uses: actions/setup-python@v4.1.0
@@ -53,17 +66,6 @@ jobs:
         DEST_FOLDER: ./
         DEST_PREDEPLOY_CLEANUP: rm -rf ./*
     
-    - name: Check if ap_version.py changed
-      id: check_version
-      run: |
-        if git diff --name-only HEAD~ HEAD | grep -q "ap_version.py"; then
-          echo "version_changed=true" >> $GITHUB_OUTPUT
-          echo "AP version file changed"
-        else
-          echo "version_changed=false" >> $GITHUB_OUTPUT
-          echo "AP version file not changed"
-        fi
-
     - name: Get version from ap_version.py
       if: steps.check_version.outputs.version_changed == 'true'
       id: get_version

--- a/.github/workflows/release_pages_main.yml
+++ b/.github/workflows/release_pages_main.yml
@@ -8,6 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+
+    - name: Check if ap_version.py changed
+      id: check_version
+      run: |
+        if git diff --name-only HEAD~ HEAD | grep -q "ap_version.py"; then
+          echo "version_changed=true" >> $GITHUB_OUTPUT
+          echo "AP version file changed"
+        else
+          echo "version_changed=false" >> $GITHUB_OUTPUT
+          echo "AP version file not changed"
+        fi
 
     - name: Setup python
       uses: actions/setup-python@v4.1.0
@@ -48,17 +61,6 @@ jobs:
         DEST_BRANCH: main
         DEST_FOLDER: ./
         DEST_PREDEPLOY_CLEANUP: rm -rf ./*
-
-    - name: Check if ap_version.py changed
-      id: check_version
-      run: |
-        if git diff --name-only HEAD~ HEAD | grep -q "ap_version.py"; then
-          echo "version_changed=true" >> $GITHUB_OUTPUT
-          echo "AP version file changed"
-        else
-          echo "version_changed=false" >> $GITHUB_OUTPUT
-          echo "AP version file not changed"
-        fi
 
     - name: Get version from ap_version.py
       if: steps.check_version.outputs.version_changed == 'true'


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflows for both the development and main release pipelines. The main change is moving the logic that checks if `ap_version.py` has changed to an earlier step, immediately after checking out the repository. This ensures the version check is always performed on the correct commit range and before any other steps that might modify the working directory. Additionally, the checkout action is updated to fetch two commits of history to enable the diff check.

Workflow improvements (applied to both `release_pages_dev.yml` and `release_pages_main.yml`):

* Moved the "Check if ap_version.py changed" step to immediately after the repository checkout, ensuring the diff is accurate and not affected by subsequent steps. [[1]](diffhunk://#diff-49efdbf9bdda6b7a434332fac9b55ca8472a4b6a84246f87b1aee6ae5615fd8cR12-R24) [[2]](diffhunk://#diff-60f37cd8ba2c537fe1cd5f74155b09d679a6179d4766e1c0f607762f543146d6R11-R23)
* Updated the `actions/checkout` step to use `fetch-depth: 2` so that the workflow can compare the last two commits for changes to `ap_version.py`. [[1]](diffhunk://#diff-49efdbf9bdda6b7a434332fac9b55ca8472a4b6a84246f87b1aee6ae5615fd8cR12-R24) [[2]](diffhunk://#diff-60f37cd8ba2c537fe1cd5f74155b09d679a6179d4766e1c0f607762f543146d6R11-R23)
* Removed the duplicate "Check if ap_version.py changed" step from later in the workflow to avoid redundancy. [[1]](diffhunk://#diff-49efdbf9bdda6b7a434332fac9b55ca8472a4b6a84246f87b1aee6ae5615fd8cL56-L66) [[2]](diffhunk://#diff-60f37cd8ba2c537fe1cd5f74155b09d679a6179d4766e1c0f607762f543146d6L52-L62)