### PR TITLE
AP: filter out events from hint generation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -816,7 +816,7 @@ if baseclasses_loaded:
                 ]
 
                 # Look through every location in the multiworld and find all the DK64 items that are progression
-                for loc in multiworld.get_locations():
+                for loc in [location for location in multiworld.get_locations() if not location.is_event]:
                     player = loc.item.player
                     autoworld = multiworld.worlds[player]
                     locworld = multiworld.worlds[loc.player]


### PR DESCRIPTION
A speed optimization for generating output, we can filter out all event locations since we'll never hint them.