### PR TITLE
AP misc fixes and opts

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -538,6 +538,8 @@ if baseclasses_loaded:
                     settings_dict["starting_keys_list_selected"].append(DK64RItems.CreepyCastleKey)
                 elif item == "Key 8":
                     settings_dict["starting_keys_list_selected"].append(DK64RItems.HideoutHelmKey)
+                if settings_dict["starting_keys_list_selected"]:
+                    settings_dict["select_keys"] = True
             if self.options.goal == Goal.option_all_keys:
                 settings_dict["win_condition_item"] = WinConditionComplex.req_key
                 settings_dict["win_condition_count"] = 8

--- a/__init__.py
+++ b/__init__.py
@@ -327,6 +327,7 @@ if baseclasses_loaded:
             # V1 LIMITATION: We are restricting settings pretty heavily. This string serves as the base for all seeds, with AP options overriding some options
             self.settings_string = "PxZlegAAvwAAYIAAMMAAGKAAD/QNPAKAgYCA4GCAQEgoKBgWDgwIgCdUsbgAbwAcAAcQAcgAcwAdAAuQATMBCcTAhQmBhhNBAmqAFaBaJaRaZaiaqaza7bNbUNutyt2u6t6uGuCt+u+vCuKueuOuSuWuauiumuquuuyu2pmJqEkXCAZaolQCCiBRgpAUoKYCCLgswCNllPwdDISytgLcBI0EKakl6LELYvVOBUQsAhMQoAkiR2qqrJlhyZJ3iKA5XkCsaBjyWMDIABVM8Q3QQhAALQoAFoYACUOABKIAAdWgAOiQAFRQABosAB0YAAqNAANXAAWT4S34KpsDQVgui2PZniyDBHDAM5kj0Ng+GaWAPl2KYqFoY4rA0FYhjEIo1hcTwkhCfxLEGSJdF4XBASFBYYGhwgIiQoKiwwMjQ4OjxAQkRGSEpMTlBSVFZYWlxeYGJkZmhquLq8v1i+AGAAMIAYgAdgA0gD9ASnABOh4kaKzxNXm94dI8YBDuuIMtYhBevn8A2ePhhNHO7qV7KzM4ps6ti+FOFATCIZCmOhKlsa58IymfwBZAEFBGVCiPBEMhTHQlS2Nc+EZTpW18Z1vnfPIEminhe4A8xAkMI8pZhIVp5Ryikx8CwIhZpxCCKaq7Lbr4w8EcktT0AHyAPUAfQA9gB9gA"
             settings_dict = decrypt_settings_string_enum(self.settings_string)
+            settings_dict["krool_access"] = True
             settings_dict["archipelago"] = True
             settings_dict["starting_kongs_count"] = self.options.starting_kong_count.value
             settings_dict["open_lobbies"] = self.options.open_lobbies.value
@@ -433,6 +434,30 @@ if baseclasses_loaded:
             elif self.options.switchsanity.value == SwitchSanity.option_helm_access:
                 settings_dict["switchsanity_switch_isles_to_kroc_top"] = SwitchsanityKong.random
                 settings_dict["switchsanity_switch_isles_helm_lobby"] = SwitchsanityGone.random
+                settings_dict["switchsanity_switch_isles_aztec_lobby_back_room"] = SwitchsanityKong.tiny
+                settings_dict["switchsanity_switch_isles_fungi_lobby_fairy"] = SwitchsanityKong.tiny
+                settings_dict["switchsanity_switch_isles_spawn_rocketbarrel"] = SwitchsanityKong.lanky
+                settings_dict["switchsanity_switch_japes_to_hive"] = SwitchsanityKong.tiny
+                settings_dict["switchsanity_switch_japes_to_rambi"] = SwitchsanityKong.donkey
+                settings_dict["switchsanity_switch_japes_to_painting_room"] = SwitchsanityKong.diddy
+                settings_dict["switchsanity_switch_japes_to_cavern"] = SwitchsanityKong.diddy
+                settings_dict["switchsanity_switch_japes_free_kong"] = SwitchsanityKong.donkey
+                settings_dict["switchsanity_switch_aztec_to_kasplat_room"] = SwitchsanityKong.donkey
+                settings_dict["switchsanity_switch_aztec_llama_front"] = SwitchsanityKong.donkey
+                settings_dict["switchsanity_switch_aztec_llama_side"] = SwitchsanityKong.lanky
+                settings_dict["switchsanity_switch_aztec_llama_back"] = SwitchsanityKong.tiny
+                settings_dict["switchsanity_switch_aztec_sand_tunnel"] = SwitchsanityKong.donkey
+                settings_dict["switchsanity_switch_aztec_to_connector_tunnel"] = SwitchsanityKong.diddy
+                settings_dict["switchsanity_switch_aztec_free_lanky"] = SwitchsanityKong.donkey
+                settings_dict["switchsanity_switch_aztec_free_tiny"] = SwitchsanityKong.diddy
+                settings_dict["switchsanity_switch_factory_free_kong"] = SwitchsanityKong.lanky
+                settings_dict["switchsanity_switch_galleon_to_lighthouse_side"] = SwitchsanityKong.donkey
+                settings_dict["switchsanity_switch_galleon_to_shipwreck_side"] = SwitchsanityKong.diddy
+                settings_dict["switchsanity_switch_galleon_to_cannon_game"] = SwitchsanityKong.chunky
+                settings_dict["switchsanity_switch_fungi_yellow_tunnel"] = SwitchsanityKong.lanky
+                settings_dict["switchsanity_switch_fungi_green_tunnel_near"] = SwitchsanityKong.tiny
+                settings_dict["switchsanity_switch_fungi_green_tunnel_far"] = SwitchsanityKong.chunky
+
             elif self.options.switchsanity.value == SwitchSanity.option_off:
                 settings_dict["switchsanity_enabled"] = False
             settings_dict["logic_type"] = self.options.logic_type.value

--- a/archipelago/DK64Client.py
+++ b/archipelago/DK64Client.py
@@ -360,11 +360,8 @@ class DK64Client:
             self.n64_client.write_u8(address, current_value + 1)
 
         elif field == "rainbow_coins":
-            # Rainbow coins: 1 byte counter at offset 0x011
-            address = count_struct_address + 0x011
-            current_value = self.n64_client.read_u8(address)
-            self.n64_client.write_u8(address, current_value + 1)
-
+            await self.writeFedData(0x015)  # TRANSFER_ITEM_RAINBOWCOIN
+            
         elif field == "ice_traps":
             # Ice traps: 2 byte counter at offset 0x012
             # Also need to trigger the actual ice trap effect via fed system

--- a/archipelago/Items.py
+++ b/archipelago/Items.py
@@ -119,8 +119,8 @@ def setup_items(world: World) -> typing.List[DK64Item]:
         if barrier_type == BarrierItems.CompanyCoin:
             nintendo_item = DK64RItem.ItemList[DK64RItems.NintendoCoin]
             rareware_item = DK64RItem.ItemList[DK64RItems.RarewareCoin]
-            item_table.append(DK64Item(nintendo_item.name, ItemClassification.progression_skip_balancing, full_item_table[nintendo_item.name].code, world.player))
-            item_table.append(DK64Item(rareware_item.name, ItemClassification.progression_skip_balancing, full_item_table[rareware_item.name].code, world.player))
+            item_table.append(DK64Item(nintendo_item.name, ItemClassification.progression, full_item_table[nintendo_item.name].code, world.player))
+            item_table.append(DK64Item(rareware_item.name, ItemClassification.progression, full_item_table[rareware_item.name].code, world.player))
             types_handled_directly.extend([DK64RTypes.NintendoCoin, DK64RTypes.RarewareCoin])
             continue
 
@@ -144,7 +144,7 @@ def setup_items(world: World) -> typing.List[DK64Item]:
 
             # Add progression items
             for i in range(progression_count):
-                item_table.append(DK64Item(item_obj.name, ItemClassification.progression_skip_balancing, full_item_table[item_obj.name].code, world.player))
+                item_table.append(DK64Item(item_obj.name, ItemClassification.progression, full_item_table[item_obj.name].code, world.player))
 
             # Add remaining items as useful
             for i in range(max_quantity - progression_count):
@@ -203,7 +203,7 @@ def setup_items(world: World) -> typing.List[DK64Item]:
             classification = ItemClassification.progression
         # Only mark Bean/Pearl as progression if they weren't handled directly as barrier items
         elif item.type in (DK64RTypes.Pearl, DK64RTypes.Bean) and DK64RTypes.Bean not in types_handled_directly:
-            classification = ItemClassification.progression_skip_balancing
+            classification = ItemClassification.progression
         # The playthrough tag doesn't quite 1-to-1 map to Archipelago's "progression" type - some items we don't consider "playthrough" can affect logic
         elif item.playthrough is True or item.type == DK64RTypes.Blueprint:
             classification = ItemClassification.progression_skip_balancing


### PR DESCRIPTION
* More hint generation optimization
* Fix key 8 not being force-required
* Fix helm access switchsanity accidentally being all switches random
* Add progression balancing to barrier items
* Foreign rainbow coins now give coins correctly
* Starting keys now are actually shown in-game, not just in archipelago