### PR TITLE
Move enemy location list to spoiler

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -164,7 +164,7 @@ if baseclasses_loaded:
     from randomizer.Enums.EnemySubtypes import EnemySubtype
     from randomizer.Lists import Item as DK64RItem
     from randomizer.Lists.Switches import SwitchInfo
-    from randomizer.Lists.EnemyTypes import EnemyLoc, EnemyMetaData, enemy_location_list
+    from randomizer.Lists.EnemyTypes import EnemyLoc, EnemyMetaData
     from worlds.LauncherComponents import Component, components, Type, icon_paths
     import randomizer.ShuffleExits as ShuffleExits
     from Utils import open_filename
@@ -617,7 +617,7 @@ if baseclasses_loaded:
                         passthrough = self.multiworld.re_gen_passthrough["Donkey Kong 64"]
                         if passthrough["EnemyData"]:
                             for location, data in passthrough["EnemyData"].items():
-                                enemy_location_list[DK64RLocations[location]] = EnemyLoc(Maps[data["map"]], Enemies[data["enemy"]], 0, [], False)
+                                self.spoiler.enemy_location_list[DK64RLocations[location]] = EnemyLoc(Maps[data["map"]], Enemies[data["enemy"]], 0, [], False)
 
             # Handle hint preparation by initiating some variables
             self.hint_data = {
@@ -1016,7 +1016,7 @@ if baseclasses_loaded:
                 "EnemyData": (
                     {
                         location_id.name: {"map": enemy_loc.map.name, "enemy": enemy_loc.enemy.name}
-                        for location_id, enemy_loc in enemy_location_list.items()
+                        for location_id, enemy_loc in self.spoiler.enemy_location_list.items()
                         if EnemyMetaData[enemy_loc.enemy].e_type == EnemySubtype.GroundBeefy
                     }
                     if self.options.dropsanity.value

--- a/randomizer/LogicClasses.py
+++ b/randomizer/LogicClasses.py
@@ -10,7 +10,6 @@ from randomizer.Enums.Regions import Regions
 from randomizer.Enums.Time import Time
 from randomizer.Enums.Locations import Locations
 from randomizer.Enums.HintRegion import HintRegion, HINT_REGION_PAIRING, MEDAL_REWARD_REGIONS, SHOP_REGIONS
-from randomizer.Lists.EnemyTypes import enemy_location_list
 
 if TYPE_CHECKING:
     from randomizer.Enums.Collectibles import Collectibles
@@ -36,7 +35,7 @@ class LocationLogic:
         self.logic = logic  # Lambda function for accessibility
         if id >= Locations.JapesMainEnemy_Start and id <= Locations.IslesMainEnemy_LowerFactoryPath1:
             # Handle enemy logic
-            self.logic = lambda l: logic(l) and enemy_location_list[id].canDropItem(l)
+            self.logic = lambda l: logic(l) and l.spoiler.enemy_location_list[id].canDropItem(l)
         self.bonusBarrel = bonusBarrel  # Uses MinigameType enum
         self.isAuxiliaryLocation = (
             isAuxiliary  # For when the Location needs to be in a region but not count as in the region (used for locations that need to be accessible in different regions depending on settings)

--- a/randomizer/Patching/EnemyRando.py
+++ b/randomizer/Patching/EnemyRando.py
@@ -608,15 +608,15 @@ def randomize_enemies_0(spoiler):
         Items.PhotoKasplatTiny,
         Items.PhotoKasplatChunky,
     ]
-    for loc in enemy_location_list:
-        if enemy_location_list[loc].enable_randomization:
+    for loc in spoiler.enemy_location_list:
+        if spoiler.enemy_location_list[loc].enable_randomization:
             sound_safeguard = False
-            map = enemy_location_list[loc].map
+            map = spoiler.enemy_location_list[loc].map
             if map not in data:
                 data[map] = []
                 noise_management_dict[map] = 0
             sound_safeguard = noise_management_dict[map] > 2
-            new_enemy = enemy_location_list[loc].placeNewEnemy(spoiler.settings.random, spoiler.settings.enemies_selected, True, sound_safeguard)
+            new_enemy = spoiler.enemy_location_list[loc].placeNewEnemy(spoiler.settings.random, spoiler.settings.enemies_selected, True, sound_safeguard)
             krem_kap_location = (loc - Locations.JapesMainEnemy_Start) + Locations.KremKap_JapesMainEnemy_Start
             if krem_kap_location in spoiler.LocationList:
                 item = krem_kap_mapping[new_enemy]
@@ -625,17 +625,17 @@ def randomize_enemies_0(spoiler):
                 if item not in spoiler.valid_photo_items:
                     spoiler.valid_photo_items.append(item)
                 setPkmnSnapEnemy(new_enemy)
-                if not enemy_location_list[loc].respawns:
+                if not spoiler.enemy_location_list[loc].respawns:
                     print(f"ALERT: INCORRECT ENEMY {loc.name}")
-            elif enemy_location_list[loc].respawns:
+            elif spoiler.enemy_location_list[loc].respawns:
                 print(f"ALERT: MISSING ENEMY {loc.name}")
-            if map == Maps.ForestAnthill or not enemy_location_list[loc].respawns and EnemyMetaData[new_enemy].audio_engine_burden:
+            if map == Maps.ForestAnthill or not spoiler.enemy_location_list[loc].respawns and EnemyMetaData[new_enemy].audio_engine_burden:
                 noise_management_dict[map] += 1
             data[map].append(
                 {
                     "enemy": new_enemy,
-                    "speeds": [enemy_location_list[loc].idle_speed, enemy_location_list[loc].aggro_speed],
-                    "id": enemy_location_list[loc].id,
+                    "speeds": [spoiler.enemy_location_list[loc].idle_speed, spoiler.enemy_location_list[loc].aggro_speed],
+                    "id": spoiler.enemy_location_list[loc].id,
                     "location": Locations(loc).name,
                 }
             )

--- a/randomizer/Patching/EnemyRando.py
+++ b/randomizer/Patching/EnemyRando.py
@@ -2,7 +2,7 @@
 
 from randomizer.Enums.EnemySubtypes import EnemySubtype
 from randomizer.Enums.Settings import CrownEnemyDifficulty, DamageAmount, WinConditionComplex
-from randomizer.Lists.EnemyTypes import EnemyMetaData, enemy_location_list
+from randomizer.Lists.EnemyTypes import EnemyMetaData
 from randomizer.Enums.Enemies import Enemies
 from randomizer.Enums.Items import Items
 from randomizer.Enums.Locations import Locations

--- a/randomizer/Patching/ItemRando.py
+++ b/randomizer/Patching/ItemRando.py
@@ -10,7 +10,6 @@ from randomizer.Enums.VendorType import VendorType
 from randomizer.Enums.Types import Types
 from randomizer.Lists.Item import ItemList
 from randomizer.Patching.Library.DataTypes import intf_to_float
-from randomizer.Lists.EnemyTypes import enemy_location_list
 from randomizer.Patching.Library.Generic import setItemReferenceName
 from randomizer.Patching.Library.ItemRando import getModelFromItem, getItemPreviewText, getPropFromItem, getModelMask, getItemDBEntry, item_shop_text_mapping, BuyText
 from randomizer.Patching.Library.Assets import getPointerLocation, TableNames, CompTextFiles, ItemPreview
@@ -845,8 +844,8 @@ def place_randomized_items(spoiler, ROM_COPY: LocalROM):
                     elif item.old_item == Types.Enemies:
                         index = item.location - Locations.JapesMainEnemy_Start
                         ROM_COPY.seek(POINTER_ROM_ENEMIES + (index * 4))
-                        ROM_COPY.writeMultipleBytes(enemy_location_list[item.location].map, 1)
-                        ROM_COPY.writeMultipleBytes(enemy_location_list[item.location].id, 1)
+                        ROM_COPY.writeMultipleBytes(spoiler.enemy_location_list[item.location].map, 1)
+                        ROM_COPY.writeMultipleBytes(spoiler.enemy_location_list[item.location].id, 1)
                         ROM_COPY.writeMultipleBytes(actor_index, 2)
                     elif item.old_item in (Types.Medal, Types.Hint):
                         offset = None

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -51,7 +51,7 @@ from randomizer.Lists.Minigame import (
     MinigameSelector,
 )
 from randomizer.Lists.Multiselectors import FasterCheckSelector, RemovedBarrierSelector, QoLSelector
-from randomizer.Lists.EnemyTypes import EnemySelector
+from randomizer.Lists.EnemyTypes import EnemySelector, enemy_location_list
 from randomizer.Logic import CollectibleRegionsOriginal, LogicVarHolder, RegionsOriginal
 from randomizer.Prices import ProgressiveMoves
 from randomizer.Settings import Settings
@@ -108,6 +108,7 @@ class Spoiler:
         self.RegionList = deepcopy(RegionsOriginal)
         self.CollectibleRegions = deepcopy(CollectibleRegionsOriginal)
         self.LocationList = deepcopy(LocationListOriginal)
+        self.enemy_location_list = deepcopy(enemy_location_list)
         self.item_assignment = []
 
         self.move_data = []


### PR DESCRIPTION
Having a global, mutable enemy_location_list was causing all seeds in one Archipelago multiworld to believe that they had the same enemies in them, causing logic errors for dropsanity.

This change puts a deep copy of the list into the spoiler object, so that each seed has its own distinct enemy_location_list that is safe to mutate.