### PR TITLE
Music selection: fix for custom music

### DIFF
--- a/static/js/initalize.js
+++ b/static/js/initalize.js
@@ -453,7 +453,8 @@ async function update_music_select_options(isInitialLoad, has_custom_music) {
     MinorItem: cosmetic_names.minoritems,
     Event: cosmetic_names.events,
   };
-  let cosmetic_truncated_names = {
+  // Reset the global object storing truncated names.
+  cosmetic_truncated_names = {
     bgm: [],
     majoritems: [],
     minoritems: [],


### PR DESCRIPTION
The added "let" keyword meant that we were creating and updating a local variable, but we needed to update the global cosmetic_truncated_names object instead. With that object empty, we were unable to find custom songs that corresponded to the user's selections in the dropdowns, so no custom music could be assigned.