### PR TITLE
Trap Link

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1349,6 +1349,7 @@ if baseclasses_loaded:
                 "death_link": self.options.death_link.value,
                 "ring_link": self.options.ring_link.value,
                 "tag_link": self.options.tag_link.value,
+                "trap_link": self.options.trap_link.value,
                 "receive_notifications": self.options.receive_notifications.value,
                 "LevelOrder": ", ".join([level.name for order, level in self.spoiler.settings.level_order.items()]),
                 "StartingKongs": ", ".join([kong.name for kong in self.spoiler.settings.starting_kong_list]),

--- a/ap_version.py
+++ b/ap_version.py
@@ -1,3 +1,3 @@
 """Holds the version for Archipelago."""
 
-version = "1.1.9"
+version = "1.1.10"

--- a/archipelago/DK64Client.py
+++ b/archipelago/DK64Client.py
@@ -32,7 +32,6 @@ class DK64Client:
     """Client for Donkey Kong 64."""
 
     n64_client = None
-    tracker = None
     game = None
     auth = None
     locations_scouted = {}
@@ -872,7 +871,6 @@ class DK64Context(CommonContext):
         class DK64Manager(GameManager):
             logging_pairs = [
                 ("Client", "Archipelago"),
-                ("Tracker", "Tracker"),
             ]
             base_title = f"Archipelago Donkey Kong 64 Client (Version {ap_version})"
 

--- a/archipelago/DK64Client.py
+++ b/archipelago/DK64Client.py
@@ -19,18 +19,20 @@ import time
 import typing
 from client.common import DK64MemoryMap, create_task_log_exception, check_version
 from client.pj64 import PJ64Client
-from client.items import item_ids, item_names_to_id
+from client.items import item_ids, item_names_to_id, trap_name_to_index, trap_index_to_name
 from client.check_flag_locations import location_flag_to_name, location_name_to_flag
 from client.ap_check_ids import check_id_to_name, check_names_to_id
 from CommonClient import CommonContext, get_base_parser, gui_enabled, logger, server_loop, ClientCommandProcessor
 from NetUtils import ClientStatus
 from ap_version import version as ap_version
+from randomizer.Patching.ItemRando import normalize_location_name
 
 
 class DK64Client:
     """Client for Donkey Kong 64."""
 
     n64_client = None
+    tracker = None
     game = None
     auth = None
     locations_scouted = {}
@@ -50,6 +52,7 @@ class DK64Client:
     ENABLE_DEATHLINK = False
     ENABLE_RINGLINK = False
     ENABLE_TAGLINK = False
+    ENABLE_TRAPLINK = False
     current_speed = 130
     current_map = 0
     read_half = 0
@@ -106,7 +109,8 @@ class DK64Client:
         """Send a message to the game."""
 
         def sanitize_and_trim(input_string, max_length=0x20):
-            sanitized = "".join(e for e in input_string if e.isalnum() or e == " ").strip()
+            normalized = normalize_location_name(input_string)
+            sanitized = "".join(e for e in normalized if e.isalnum() or e == " ").strip()
             return sanitized[:max_length]
 
         stripped_item_name = sanitize_and_trim(item_name)
@@ -662,7 +666,7 @@ class DK64Client:
                 return data
         return data
 
-    async def main_tick(self, item_get_cb, deathlink_cb, map_change_cb, ring_link, tag_link):
+    async def main_tick(self, item_get_cb, deathlink_cb, map_change_cb, ring_link, tag_link, trap_link):
         """Game loop tick."""
         await self.readChecks(item_get_cb)
         # await self.item_tracker.readItems()
@@ -697,6 +701,8 @@ class DK64Client:
             await ring_link()
         if self.ENABLE_TAGLINK:
             await tag_link()
+        if self.ENABLE_TRAPLINK:
+            await trap_link()
         current_deliver_count = self.get_current_deliver_count()
         # If current_deliver_count is None
         if current_deliver_count is None:
@@ -797,6 +803,21 @@ class DK64CommandProcessor(ClientCommandProcessor):
                 self.ctx.tags.add("RingLink")
             create_task_log_exception(self.ctx.send_msgs([{"cmd": "ConnectUpdate", "tags": self.ctx.tags}]))
 
+    def _cmd_traplink(self):
+        """Toggle traplink from client. Overrides default setting."""
+        if isinstance(self.ctx, DK64Context):
+            if self.ctx.ENABLE_TRAPLINK:
+                self.ctx.ENABLE_TRAPLINK = False
+                self.ctx.client.ENABLE_TRAPLINK = False
+                self.ctx.tags.discard("TrapLink")
+                logger.info("Traplink disabled")
+            else:
+                self.ctx.ENABLE_TRAPLINK = True
+                self.ctx.client.ENABLE_TRAPLINK = True
+                logger.info("Traplink enabled")
+                self.ctx.tags.add("TrapLink")
+            create_task_log_exception(self.ctx.send_msgs([{"cmd": "ConnectUpdate", "tags": self.ctx.tags}]))
+
 
 class DK64Context(CommonContext):
     """Context for Donkey Kong 64."""
@@ -809,6 +830,7 @@ class DK64Context(CommonContext):
     ENABLE_DEATHLINK = False
     ENABLE_RINGLINK = False
     ENABLE_TAGLINK = False
+    ENABLE_TRAPLINK = False
     command_processor = DK64CommandProcessor
     won = False
 
@@ -850,6 +872,7 @@ class DK64Context(CommonContext):
         class DK64Manager(GameManager):
             logging_pairs = [
                 ("Client", "Archipelago"),
+                ("Tracker", "Tracker"),
             ]
             base_title = f"Archipelago Donkey Kong 64 Client (Version {ap_version})"
 
@@ -934,6 +957,12 @@ class DK64Context(CommonContext):
                     self.ENABLE_TAGLINK = True
                     self.client.ENABLE_TAGLINK = True
                     asyncio.create_task(self.send_msgs([{"cmd": "ConnectUpdate", "tags": self.tags}]))
+            if self.slot_data.get("trap_link"):
+                if "TrapLink" not in self.tags:
+                    self.tags.add("TrapLink")
+                    self.ENABLE_TRAPLINK = True
+                    self.client.ENABLE_TRAPLINK = True
+                    asyncio.create_task(self.send_msgs([{"cmd": "ConnectUpdate", "tags": self.tags}]))
             if self.slot_data.get("receive_notifications"):
                 self.client.send_mode = self.slot_data.get("receive_notifications")
             self.client.players = self.player_names
@@ -969,6 +998,15 @@ class DK64Context(CommonContext):
                 except Exception:
                     kong = 5
                 self.pending_tag_link = True, kong
+            if "TrapLink" in self.tags and source_name != self.player_names.get(self.slot) and "TrapLink" in args.get("tags", []):
+                if not hasattr(self, "pending_trap_link"):
+                    self.pending_trap_link = 0
+
+                self.pending_trap_link = trap_name_to_index.get(args["data"]["trap_name"], 0)
+
+                if self.pending_trap_link != 0:
+                    self.pending_trap_original = args["data"]["trap_name"]
+                    self.pending_trap_source = source_name
 
     async def send_ring_link(self, amount: int):
         """Send a ring link message."""
@@ -1185,6 +1223,39 @@ class DK64Context(CommonContext):
                 self.previous_kong = current_kong
                 self.pending_tag_link = False, 0  # Reset pending tag link
 
+    async def send_trap_link(self, trap_name: str):
+        """Send a trap link message."""
+        if "TrapLink" not in self.tags or self.slot is None:
+            return
+        logger.info(f"Sending trap link: {trap_name}")
+
+        player_name = self.player_names.get(self.slot)
+
+        await self.send_msgs([{"cmd": "Bounce", "tags": ["TrapLink"], "data": {"time": time.time(), "source": player_name, "trap_name": trap_name}}])
+
+    async def handle_trap_link(self):
+        """Handle trap link functionality for DK64 items."""
+        if not self.client.ENABLE_TRAPLINK:
+            return
+
+        activated_trap = self.client.n64_client.read_u8(self.client.memory_pointer + DK64MemoryMap.is_trapped)
+        if activated_trap != 0:
+            trap_name = trap_index_to_name.get(activated_trap, "Bubble Trap")
+            await self.send_trap_link(trap_name)
+            self.client.n64_client.write_u8(self.client.memory_pointer + DK64MemoryMap.is_trapped, 0)
+
+        if not hasattr(self, "pending_trap_link"):
+            self.pending_trap_link = 0
+        if not hasattr(self, "pending_trap_original"):
+            self.pending_trap_original = ""
+        if not hasattr(self, "pending_trap_source"):
+            self.pending_trap_source = ""
+
+        if self.pending_trap_link != 0:
+            self.client.n64_client.write_u8(self.client.memory_pointer + DK64MemoryMap.sent_trap, self.pending_trap_link)
+            self.pending_trap_link = 0
+            logger.info(f"Received linked {self.pending_trap_original} from {self.pending_trap_source}")
+
     async def sync(self):
         """Sync the game."""
         sync_msg = [{"cmd": "Sync"}]
@@ -1216,6 +1287,10 @@ class DK64Context(CommonContext):
         async def tag_link():
             """Handle a tag link."""
             await self.handle_tag_link()
+
+        async def trap_link():
+            """Handle a trap link."""
+            await self.handle_trap_link()
 
         async def deathlink():
             """Handle a deathlink."""
@@ -1278,7 +1353,7 @@ class DK64Context(CommonContext):
                     if status is False:
                         await asyncio.sleep(0.5)
                         continue
-                    await self.client.main_tick(on_item_get, deathlink, map_change, ring_link, tag_link)
+                    await self.client.main_tick(on_item_get, deathlink, map_change, ring_link, tag_link, trap_link)
                     await asyncio.sleep(0.5)
                     now = time.time()
                     if self.last_resend + 0.5 < now:

--- a/archipelago/Items.py
+++ b/archipelago/Items.py
@@ -305,10 +305,10 @@ def setup_items(world: World) -> typing.List[DK64Item]:
     trap_weights += [DK64RItems.IceTrapBubble] * world.options.bubble_trap_weight.value
     trap_weights += [DK64RItems.IceTrapReverse] * world.options.reverse_trap_weight.value
     trap_weights += [DK64RItems.IceTrapSlow] * world.options.slow_trap_weight.value
-    trap_weights += [DK64RItems.IceTrapDisableA] * world.options.disable_a_trap.value
-    trap_weights += [DK64RItems.IceTrapDisableB] * world.options.disable_b_trap.value
-    trap_weights += [DK64RItems.IceTrapDisableZ] * world.options.disable_z_trap.value
-    trap_weights += [DK64RItems.IceTrapDisableCU] * world.options.disable_c_trap.value
+    trap_weights += [DK64RItems.IceTrapDisableA] * world.options.disable_a_trap_weight.value
+    trap_weights += [DK64RItems.IceTrapDisableB] * world.options.disable_b_trap_weight.value
+    trap_weights += [DK64RItems.IceTrapDisableZ] * world.options.disable_z_trap_weight.value
+    trap_weights += [DK64RItems.IceTrapDisableCU] * world.options.disable_c_trap_weight.value
 
     trap_count = 0 if (len(trap_weights) == 0) else math.ceil(filler_item_count * (world.options.trap_fill_percentage.value / 100.0))
     filler_item_count -= trap_count

--- a/archipelago/Options.py
+++ b/archipelago/Options.py
@@ -124,25 +124,25 @@ class SlowTrapWeight(BaseTrapWeight):
 class DisableAWeight(BaseTrapWeight):
     """Likelihood of receiving a trap which disables your A button."""
 
-    display_name = "Disable A Trap"
+    display_name = "Disable A Trap Weight"
 
 
 class DisableBWeight(BaseTrapWeight):
     """Likelihood of receiving a trap which disables your B button."""
 
-    display_name = "Disable B Trap"
+    display_name = "Disable B Trap Weight"
 
 
 class DisableZWeight(BaseTrapWeight):
     """Likelihood of receiving a trap which disables your Z button."""
 
-    display_name = "Disable Z Trap"
+    display_name = "Disable Z Trap Weight"
 
 
 class DisableCWeight(BaseTrapWeight):
     """Likelihood of receiving a trap which disables your C buttons."""
 
-    display_name = "Disable C Trap"
+    display_name = "Disable C Trap Weight"
 
 
 class KroolPhaseCount(Range):
@@ -303,6 +303,15 @@ class TagLink(Toggle):
     """
 
     display_name = "Tag Link"
+
+
+class TrapLink(Toggle):
+    """Determines if the Trap Link is enabled.
+
+    If enabled, your received Traps will link to other players with Trap Link enabled, and their received traps will link to you
+    """
+
+    display_name = "Trap Link"
 
 
 class MirrorMode(Toggle):
@@ -589,6 +598,7 @@ class DK64Options(PerGameCommonOptions):
     death_link: DeathLink
     ring_link: RingLink
     tag_link: TagLink
+    trap_link: TrapLink
     goal: Goal
     krool_key_count: KeysRequiredToBeatKrool
     key8_lock: Key8Helm
@@ -635,10 +645,10 @@ class DK64Options(PerGameCommonOptions):
     bubble_trap_weight: BubbleTrapWeight
     reverse_trap_weight: ReverseTrapWeight
     slow_trap_weight: SlowTrapWeight
-    disable_a_trap: DisableAWeight
-    disable_b_trap: DisableBWeight
-    disable_c_trap: DisableCWeight
-    disable_z_trap: DisableZWeight
+    disable_a_trap_weight: DisableAWeight
+    disable_b_trap_weight: DisableBWeight
+    disable_c_trap_weight: DisableCWeight
+    disable_z_trap_weight: DisableZWeight
     receive_notifications: ReceiveNotifications
     hint_style: HintStyle
 
@@ -740,6 +750,7 @@ dk64_option_groups: List[OptionGroup] = [
         [
             TagLink,
             RingLink,
+            TrapLink,
             DeathLink,
         ],
     ),

--- a/archipelago/client/common.py
+++ b/archipelago/client/common.py
@@ -47,6 +47,8 @@ class DK64MemoryMap:
     # 5 = Random
 
     can_tag = 0x061
+    is_trapped = 0x062
+    sent_trap = 0x063
     current_kong = 0x8074E77C
     count_struct_pointer = 0x807FFFB8  # Pointer to CountStruct containing item counts
 

--- a/archipelago/client/items.py
+++ b/archipelago/client/items.py
@@ -221,39 +221,38 @@ item_names_to_id = {item_ids[key]["name"]: key for key in item_ids}
 # For TrapLink
 trap_name_to_index: dict[str, int] = {
     # Our native Traps
-    "Bubble Trap":       1,
-    "Reverse Trap":      2,
-    "Slow Trap":         3,
-    "Disable A Trap":    5,
-    "Disable B Trap":    6,
-    "Disable Z Trap":    7,
+    "Bubble Trap": 1,
+    "Reverse Trap": 2,
+    "Slow Trap": 3,
+    "Disable A Trap": 5,
+    "Disable B Trap": 6,
+    "Disable Z Trap": 7,
     "Disable C Up Trap": 8,
-
     # Common other trap names
-    "Bee Trap":           6,  # Disable B Trap
-    "Blue Balls Curse":   1,  # Bubble Trap
+    "Bee Trap": 6,  # Disable B Trap
+    "Blue Balls Curse": 1,  # Bubble Trap
     "Chaos Control Trap": 1,  # Bubble Trap
-    "Confound Trap":      2,  # Reverse Trap
-    "Confuse Trap":       2,  # Reverse Trap
-    "Confusion Trap":     2,  # Reverse Trap
-    "Fear Trap":          3,  # Slow Trap
-    "Freeze Trap":        1,  # Bubble Trap
-    "Frozen Trap":        1,  # Bubble Trap
-    "Fuzzy Trap":         2,  # Reverse Trap
-    "Honey Trap":         5,  # Disable A Trap
-    "Ice Trap":           1,  # Bubble Trap
-    "Iron Boots Trap":    5,  # Disable A Trap
-    "Jump Trap":          5,  # Disable A Trap
-    "No Vac Trap":        7,  # Disable Z Trap
-    "Paralyze Trap":      1,  # Bubble Trap
-    "Poison Mushroom":    3,  # Slow Trap
-    "Poison Trap":        3,  # Slow Trap
-    "Reversal Trap":      2,  # Reverse Trap
-    "Screen Flip Trap":   2,  # Screen Flip Trap
-    "Slowness Trap":      3,  # Slow Trap
-    "Sticky Floor Trap":  5,  # Disable A Trap
-    "Stun Trap":          1,  # Bubble Trap
-    "Timer Trap":         3,  # Slow Trap
+    "Confound Trap": 2,  # Reverse Trap
+    "Confuse Trap": 2,  # Reverse Trap
+    "Confusion Trap": 2,  # Reverse Trap
+    "Fear Trap": 3,  # Slow Trap
+    "Freeze Trap": 1,  # Bubble Trap
+    "Frozen Trap": 1,  # Bubble Trap
+    "Fuzzy Trap": 2,  # Reverse Trap
+    "Honey Trap": 5,  # Disable A Trap
+    "Ice Trap": 1,  # Bubble Trap
+    "Iron Boots Trap": 5,  # Disable A Trap
+    "Jump Trap": 5,  # Disable A Trap
+    "No Vac Trap": 7,  # Disable Z Trap
+    "Paralyze Trap": 1,  # Bubble Trap
+    "Poison Mushroom": 3,  # Slow Trap
+    "Poison Trap": 3,  # Slow Trap
+    "Reversal Trap": 2,  # Reverse Trap
+    "Screen Flip Trap": 2,  # Screen Flip Trap
+    "Slowness Trap": 3,  # Slow Trap
+    "Sticky Floor Trap": 5,  # Disable A Trap
+    "Stun Trap": 1,  # Bubble Trap
+    "Timer Trap": 3,  # Slow Trap
 }
 
 trap_index_to_name: dict[int, str] = {

--- a/archipelago/client/items.py
+++ b/archipelago/client/items.py
@@ -217,3 +217,51 @@ item_ids = {
 
 # Automatically create another table that is the Name to the key
 item_names_to_id = {item_ids[key]["name"]: key for key in item_ids}
+
+# For TrapLink
+trap_name_to_index: dict[str, int] = {
+    # Our native Traps
+    "Bubble Trap":       1,
+    "Reverse Trap":      2,
+    "Slow Trap":         3,
+    "Disable A Trap":    5,
+    "Disable B Trap":    6,
+    "Disable Z Trap":    7,
+    "Disable C Up Trap": 8,
+
+    # Common other trap names
+    "Bee Trap":           6,  # Disable B Trap
+    "Blue Balls Curse":   1,  # Bubble Trap
+    "Chaos Control Trap": 1,  # Bubble Trap
+    "Confound Trap":      2,  # Reverse Trap
+    "Confuse Trap":       2,  # Reverse Trap
+    "Confusion Trap":     2,  # Reverse Trap
+    "Fear Trap":          3,  # Slow Trap
+    "Freeze Trap":        1,  # Bubble Trap
+    "Frozen Trap":        1,  # Bubble Trap
+    "Fuzzy Trap":         2,  # Reverse Trap
+    "Honey Trap":         5,  # Disable A Trap
+    "Ice Trap":           1,  # Bubble Trap
+    "Iron Boots Trap":    5,  # Disable A Trap
+    "Jump Trap":          5,  # Disable A Trap
+    "No Vac Trap":        7,  # Disable Z Trap
+    "Paralyze Trap":      1,  # Bubble Trap
+    "Poison Mushroom":    3,  # Slow Trap
+    "Poison Trap":        3,  # Slow Trap
+    "Reversal Trap":      2,  # Reverse Trap
+    "Screen Flip Trap":   2,  # Screen Flip Trap
+    "Slowness Trap":      3,  # Slow Trap
+    "Sticky Floor Trap":  5,  # Disable A Trap
+    "Stun Trap":          1,  # Bubble Trap
+    "Timer Trap":         3,  # Slow Trap
+}
+
+trap_index_to_name: dict[int, str] = {
+    1: "Bubble Trap",
+    2: "Reverse Trap",
+    3: "Slow Trap",
+    5: "Disable A Trap",
+    6: "Disable B Trap",
+    7: "Disable Z Trap",
+    8: "Disable C Up Trap",
+}


### PR DESCRIPTION
This PR adds support for the Trap Link protocol, linking received traps by name to any other players with Trap Link enabled, across games.

A list of Trap Names is handled by converting them to similar, comparable traps which DK64 currently supports.