### PR TITLE
AP v1.1.10: Bonus Barrels

### DIFF
--- a/ap_version.py
+++ b/ap_version.py
@@ -1,3 +1,3 @@
 """Holds the version for Archipelago."""
 
-version = "1.1.10"
+version = "1.1.11"

--- a/archipelago/Options.py
+++ b/archipelago/Options.py
@@ -591,6 +591,82 @@ class MicroHints(Choice):
     default = 2
 
 
+class ShuffledBonusBarrels(OptionList):
+    """Determines which minigames are shuffled into the barrel pool.
+
+    Valid Keys:
+    "batty_barrel_bandit"
+    "big_bug_bash"
+    "busy_barrel_barrage"
+    "mad_maze_maul"
+    "minecart_mayhem"
+    "beaver_bother"
+    "teetering_turtle_trouble"
+    "stealthy_snoop"
+    "stash_snatch"
+    "splish_splash_salvage"
+    "speedy_swing_sortie"
+    "krazy_kong_klamour"
+    "searchlight_seek"
+    "kremling_kosh"
+    "peril_path_panic"
+    "helm_minigames"
+    "arenas"
+    "training_minigames"
+    "arcade"
+    """
+
+    display_name = "Shuffled Bonus Barrels"
+
+    valid_keys = {
+        "batty_barrel_bandit",
+        "big_bug_bash",
+        "busy_barrel_barrage",
+        "mad_maze_maul",
+        "minecart_mayhem",
+        "beaver_bother",
+        "teetering_turtle_trouble",
+        "stealthy_snoop",
+        "stash_snatch",
+        "splish_splash_salvage",
+        "speedy_swing_sortie",
+        "krazy_kong_klamour",
+        "searchlight_seek",
+        "kremling_kosh",
+        "peril_path_panic",
+        "helm_minigames",
+        "arenas",
+        "training_minigames",
+        "arcade",
+    }
+
+
+class HardMinigames(Toggle):
+    """Determines if hard minigames are shuffled into the barrel pool."""
+
+    display_name = "Hard Minigames"
+
+
+class AutoCompleteBonusBarrels(Toggle):
+    """If turned on, bonus barrels will instantly spawn their reward instead of requiring a minigame to complete.
+
+    This option does NOT autocomplete Helm barrels! Use the helm_room_bonus_count option."""
+
+    display_name = "Auto Complete Bonus Barrels"
+
+
+class HelmRoomBonusCount(Range):
+    """Determines how many bonus barrels need to be done in each Helm room.
+
+    If set to 0, there will be no bonus barrels and Blast-O-Matic sections will turn off immediately upon playing the instrument pad to open the room."""
+
+    display_name = "Helm Room Bonus Count"
+
+    range_start = 0
+    range_end = 2
+    default = 0
+
+
 @dataclass
 class DK64Options(PerGameCommonOptions):
     """Options for DK64R."""
@@ -651,6 +727,10 @@ class DK64Options(PerGameCommonOptions):
     disable_z_trap_weight: DisableZWeight
     receive_notifications: ReceiveNotifications
     hint_style: HintStyle
+    shuffled_bonus_barrels: ShuffledBonusBarrels
+    hard_minigames: HardMinigames
+    auto_complete_bonus_barrels: AutoCompleteBonusBarrels
+    helm_room_bonus_count: HelmRoomBonusCount
 
 
 dk64_option_groups: List[OptionGroup] = [
@@ -714,6 +794,15 @@ dk64_option_groups: List[OptionGroup] = [
             MermaidRequirement,
             RarewareGBRequirement,
             JetpacRequirement,
+        ],
+    ),
+    OptionGroup(
+        "Bonus Barrels",
+        [
+            ShuffledBonusBarrels,
+            HardMinigames,
+            AutoCompleteBonusBarrels,
+            HelmRoomBonusCount,
         ],
     ),
     OptionGroup(

--- a/archipelago/Regions.py
+++ b/archipelago/Regions.py
@@ -13,11 +13,14 @@ from randomizer.Enums.Items import Items
 from randomizer.Enums.Kongs import Kongs
 from randomizer.Enums.Levels import Levels
 from randomizer.Enums.Locations import Locations
+from randomizer.Enums.Minigames import Minigames
+from randomizer.Enums.MinigameType import MinigameType
 from randomizer.Enums.Regions import Regions
 from randomizer.Enums.Settings import HelmSetting, FungiTimeSetting, FasterChecksSelected, ShuffleLoadingZones, WinConditionComplex
 from randomizer.Enums.Transitions import Transitions
 from randomizer.Enums.Types import Types
 from randomizer.Lists import Location as DK64RLocation, Item as DK64RItem
+from randomizer.Lists.Minigame import MinigameRequirements
 from randomizer.LogicClasses import Collectible, Event, LocationLogic, TransitionFront, Region as DK64Region
 from randomizer.Patching.Library.Generic import IsItemSelected
 from archipelago.Items import DK64Item
@@ -198,19 +201,35 @@ def create_region(
             # Quickly test and see if we can reach this location with zero items
             quick_success = False
             try:
-                quick_success = location.logic(None)
+                quick_success = location.logic(None) and not location_logic.bonusBarrel
             except Exception:
                 pass
             # If we can, we can greatly simplify the logic at this location
             if quick_success:
                 set_rule(location, lambda state: True)
             # Otherwise we have to work our way through the logic proper
-            # V1 LIMITATION: this will ignore minigame logic, so bonus barrels and Helm barrels must be autocompleted
             else:
                 set_rule(location, lambda state, player=player, location_logic=location_logic: hasDK64RLocation(state, player, location_logic))
             # Our Fill checks for Shockwave independent of the location's logic, so we must do the same
             if location_obj.type == Types.RainbowCoin:
                 add_rule(location, lambda state: state.has("Shockwave", player))
+            # If this is a bonus barrel location, add logic to check that we can complete the bonus barrel.
+            match location_logic.bonusBarrel:
+                case MinigameType.BonusBarrel:
+                    if not logic_holder.settings.bonus_barrel_auto_complete:
+                        add_rule(
+                            location, lambda state, player=player, location_logic=location_logic: canDoBonusBarrel(state, player, location_logic)
+                        )
+                case MinigameType.HelmBarrelFirst:
+                    if logic_holder.settings.helm_room_bonus_count > 0:
+                        add_rule(
+                            location, lambda state, player=player, location_logic=location_logic: canDoBonusBarrel(state, player, location_logic)
+                        )
+                case MinigameType.HelmBarrelSecond:
+                    if logic_holder.settings.helm_room_bonus_count == 2:
+                        add_rule(
+                            location, lambda state, player=player, location_logic=location_logic: canDoBonusBarrel(state, player, location_logic)
+                        )
             # Item placement limitations! These only apply to items in your own world, as other worlds' items will be AP items, and those can be anywhere.
             # Fairy locations cannot have your own world's blueprints on them for technical reasons.
             if location_obj.type == Types.Fairy:
@@ -455,3 +474,7 @@ def hasDK64RCollectible(state: CollectionState, player: int, collectible: Collec
 def hasDK64REvent(state: CollectionState, player: int, event: Event):
     """Check if the given event is accessible in the given state."""
     return event.logic(state.dk64_logic_holder[player])
+
+
+def canDoBonusBarrel(state: CollectionState, player: int, location: LocationLogic):
+    return MinigameRequirements[state.dk64_logic_holder[player].spoiler.shuffled_barrel_data[location.id].minigame].logic(state.dk64_logic_holder[player])

--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -53,7 +53,7 @@ from randomizer.Lists.CustomLocations import resetCustomLocations
 from randomizer.Enums.Maps import Maps
 from randomizer.Lists.Item import ItemList
 from randomizer.Lists.Location import SharedMoveLocations, SharedShopLocations, ShopLocationReference
-from randomizer.Lists.Minigame import BarrelMetaData, MinigameRequirements
+from randomizer.Lists.Minigame import MinigameRequirements
 from randomizer.Lists.ShufflableExit import GetLevelShuffledToIndex
 from randomizer.LogicClasses import Sphere, TransitionFront
 from randomizer.Patching import ApplyRandomizer
@@ -202,7 +202,7 @@ def should_skip_location(location, location_obj, spoiler, settings, region):
             or (location.bonusBarrel is MinigameType.HelmBarrelSecond and (settings.helm_barrels == MinigameBarrels.skip or settings.helm_room_bonus_count != HelmBonuses.two))
             or (location.bonusBarrel is MinigameType.TrainingBarrel and settings.training_barrels_minigames == MinigameBarrels.skip)
         ):
-            if not MinigameRequirements[BarrelMetaData[location.id].minigame].logic(spoiler.LogicVariables):
+            if not MinigameRequirements[spoiler.shuffled_barrel_data[location.id].minigame].logic(spoiler.LogicVariables):
                 return True
 
     # Skip hint doors if the wrong Kong
@@ -3818,8 +3818,7 @@ def ShuffleMisc(spoiler: Spoiler) -> None:
         or spoiler.settings.helm_barrels == MinigameBarrels.random
         or spoiler.settings.training_barrels_minigames == MinigameBarrels.random
     ):
-        BarrelShuffle(spoiler.settings)
-        spoiler.UpdateBarrels()
+        spoiler.shuffled_barrel_data = BarrelShuffle(spoiler.settings)
     # CB Shuffle
     if spoiler.settings.cb_rando_enabled:
         ShuffleCBs(spoiler)

--- a/randomizer/Patching/BarrelRando.py
+++ b/randomizer/Patching/BarrelRando.py
@@ -10,14 +10,14 @@ def randomize_barrels(spoiler, ROM_COPY: LocalROM):
     barrels = [28, 107, 134]
     if len(spoiler.settings.minigames_list_selected) > 0:
         barrel_replacements = {}
-        for location, minigame in spoiler.shuffled_barrel_data.items():
-            container_map = int(BarrelMetaData[location].map)
+        for minigame_data in spoiler.shuffled_barrel_data.values():
+            container_map = int(minigame_data.map)
             if container_map not in barrel_replacements:
                 barrel_replacements[container_map] = []
             barrel_replacements[container_map].append(
                 {
-                    "instance_id": int(BarrelMetaData[location].barrel_id),
-                    "new_map": int(MinigameRequirements[minigame].map),
+                    "instance_id": int(minigame_data.barrel_id),
+                    "new_map": int(MinigameRequirements[minigame_data.minigame].map),
                 }
             )
         for cont_map_id in barrel_replacements:

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -725,7 +725,7 @@ class Spoiler:
             or self.settings.training_barrels_minigames == MinigameBarrels.random
         ):
             shuffled_barrels = OrderedDict()
-            for location, minigame in self.shuffled_barrel_data.items():
+            for location, minigame in [(location, value.minigame) for location, value in self.shuffled_barrel_data.items()]:
                 if location in HelmMinigameLocations and self.settings.helm_barrels == MinigameBarrels.skip:
                     continue
                 if location in TrainingMinigameLocations and self.settings.training_barrels_minigames == MinigameBarrels.skip:


### PR DESCRIPTION
Adds bonus barrels to AP, along with 4 new options to control them:

* `shuffled_bonus_barrels`: select what games are in the pool
* `hard_minigames`: enable/disable the hard difficulty minigames
* `auto_complete_bonus_barrels`
* `helm_room_bonus_count`: how many helm barrels per room

This PR also refactors the bonus barrel shuffle a bit so that it's not done to a mutable dict with global scope, which breaks the multiworld case. The bonus barrel shuffler now just returns the data in the function `BarrelShuffle`.