### PR TITLE
Fix starting training moves and shopkeepers

### DIFF
--- a/randomizer/Fill.py
+++ b/randomizer/Fill.py
@@ -2492,6 +2492,9 @@ def FillTrainingMoves(spoiler: Spoiler, preplacedMoves: List[Items]):
         # We can expect that all locations in this region are starting move locations, Training Barrels, or starting shopkeeper locations
         for locationLogic in spoiler.RegionList[Regions.GameStart].locations:
             location = spoiler.LocationList[locationLogic.id]
+            if location.type == Types.TrainingBarrel and spoiler.settings.training_barrels == TrainingBarrels.normal:
+                # Patching expects these locations to be empty to fill in all the training moves
+                continue
             if location.item is None and location.type not in (Types.Cranky, Types.Funky, Types.Candy, Types.Snide):  # Don't put moves in shopkeeper locations!
                 placedMove = movesToPlace.pop()
                 location.inaccessible = False

--- a/randomizer/Patching/ItemRando.py
+++ b/randomizer/Patching/ItemRando.py
@@ -5,7 +5,7 @@ from randomizer.Enums.Items import Items
 from randomizer.Enums.Kongs import Kongs
 from randomizer.Enums.Levels import Levels
 from randomizer.Enums.Locations import Locations
-from randomizer.Enums.Settings import MicrohintsEnabled, TrainingBarrels
+from randomizer.Enums.Settings import ItemRandoListSelected, MicrohintsEnabled, TrainingBarrels
 from randomizer.Enums.VendorType import VendorType
 from randomizer.Enums.Types import Types
 from randomizer.Lists.Item import ItemList
@@ -499,7 +499,7 @@ def calculateInitFileScreen(spoiler, ROM_COPY: LocalROM):
             if item.can_have_item:
                 if item.location in list(OTHER_STARTING_ITEMS.keys()):
                     OTHER_STARTING_ITEMS[item.location] = item.new_subitem
-    if not found_shopkeeper:
+    if not found_shopkeeper and ItemRandoListSelected.shopowners in spoiler.settings.item_rando_list_selected:
         OTHER_STARTING_ITEMS[Locations.ShopOwner_Location00] = Items.NoItem
         OTHER_STARTING_ITEMS[Locations.ShopOwner_Location01] = Items.NoItem
         OTHER_STARTING_ITEMS[Locations.ShopOwner_Location02] = Items.NoItem


### PR DESCRIPTION
* Training moves should now show up at the start. Correctly. In all cases. I swear.
* Shopkeepers should now visually show up on the file select screen if they're unshuffled.