### PR TITLE
AP item fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -723,6 +723,7 @@ if baseclasses_loaded:
                 spoiler.pregiven_items = []
                 # Initialize dictionary to store Archipelago location to item name mappings for textbox display
                 spoiler.archipelago_locations = {}
+                print(self.multiworld.precollected_items[self.player])
                 for item in self.multiworld.precollected_items[self.player]:
                     dk64_item = logic_item_name_to_id[item.name]
                     # Only moves can be pushed to the pregiven_items list

--- a/__init__.py
+++ b/__init__.py
@@ -723,7 +723,6 @@ if baseclasses_loaded:
                 spoiler.pregiven_items = []
                 # Initialize dictionary to store Archipelago location to item name mappings for textbox display
                 spoiler.archipelago_locations = {}
-                print(self.multiworld.precollected_items[self.player])
                 for item in self.multiworld.precollected_items[self.player]:
                     dk64_item = logic_item_name_to_id[item.name]
                     # Only moves can be pushed to the pregiven_items list

--- a/ap_version.py
+++ b/ap_version.py
@@ -1,3 +1,3 @@
 """Holds the version for Archipelago."""
 
-version = "1.2.18"
+version = "1.2.19"

--- a/archipelago/Items.py
+++ b/archipelago/Items.py
@@ -167,9 +167,9 @@ def setup_items(world: World) -> typing.List[DK64Item]:
                     item_table.append(copy.copy(ap_item))
             case DK64RTypes.Crown:
                 num_crowns = 10
-                if not (world.options.goal == Goal.option_crowns or world.options.enable_chaos_blockers):
+                if not (world.options.goal in {Goal.option_crowns, Goal.option_treasure_hurry} or world.options.enable_chaos_blockers):
                     ap_item.classification = ItemClassification.filler
-                elif world.options.goal == Goal.option_crowns and not world.options.enable_chaos_blockers:
+                elif world.options.goal in {Goal.option_crowns, Goal.option_treasure_hurry} and not world.options.enable_chaos_blockers:
                     ap_item.classification = ItemClassification.progression_skip_balancing
                 for _ in range(num_crowns):
                     item_table.append(copy.copy(ap_item))
@@ -195,9 +195,9 @@ def setup_items(world: World) -> typing.List[DK64Item]:
                     item_table.append(copy.copy(ap_item))
             case DK64RTypes.RainbowCoin:
                 num_coins = 16
-                if not (world.options.goal == Goal.option_rainbow_coins or world.options.enable_chaos_blockers):
+                if not (world.options.goal in {Goal.option_rainbow_coins, Goal.option_treasure_hurry} or world.options.enable_chaos_blockers):
                     ap_item.classification = ItemClassification.filler
-                elif world.options.goal == Goal.option_rainbow_coins and not world.options.enable_chaos_blockers:
+                elif world.options.goal in {Goal.option_rainbow_coins, Goal.option_treasure_hurry} and not world.options.enable_chaos_blockers:
                     ap_item.classification = ItemClassification.progression_skip_balancing
                 for _ in range(num_coins):
                     item_table.append(copy.copy(ap_item))
@@ -215,9 +215,9 @@ def setup_items(world: World) -> typing.List[DK64Item]:
                     ap_item.classification = ItemClassification.useful
                     item_table.append(copy.copy(ap_item))
             case DK64RTypes.NintendoCoin | DK64RTypes.RarewareCoin:
-                if world.options.goal != Goal.option_company_coins and not world.options.enable_chaos_blockers:
+                if not (world.options.goal in {Goal.option_company_coins, Goal.option_treasure_hurry} or world.options.enable_chaos_blockers):
                     ap_item.classification = ItemClassification.filler
-                elif world.options.goal == Goal.option_company_coins and not world.options.enable_chaos_blockers:
+                elif world.options.goal in {Goal.option_company_coins, Goal.option_treasure_hurry} and not world.options.enable_chaos_blockers:
                     ap_item.classification = ItemClassification.progression_skip_balancing
                 item_table.append(copy.copy(ap_item))
             case DK64RTypes.Cranky | DK64RTypes.Funky | DK64RTypes.Candy | DK64RTypes.Snide:

--- a/archipelago/Items.py
+++ b/archipelago/Items.py
@@ -73,7 +73,7 @@ full_item_table.update(event_table)  # Temp for generating goal item
 
 
 def random_starting_moves(world: World) -> typing.List[str]:
-    """Handle starting move alterations here"""
+    """Handle starting move alterations here."""
     starting_moves = []
 
     all_eligible_starting_moves = DK64RItemPoolUtility.AllKongMoves()
@@ -102,7 +102,7 @@ def random_starting_moves(world: World) -> typing.List[str]:
 
 
 def setup_items(world: World) -> typing.List[DK64Item]:
-    """Set up the item table for the world"""
+    """Set up the item table for the world."""
     item_table = []
     starting_moves = random_starting_moves(world)
 

--- a/archipelago/Items.py
+++ b/archipelago/Items.py
@@ -92,7 +92,7 @@ def random_starting_moves(world: World) -> typing.List[str]:
         move_id = all_eligible_starting_moves.pop()
         move = DK64RItem.ItemList[move_id]
         # We don't want to pick anything we're already starting with. As an aside, the starting inventory move name may or may not have spaces in it.
-        if move.name in world.options.start_inventory.options:
+        if move.name in world.options.start_inventory:
             # If we were to choose a move we're forcibly starting with, pick another
             i -= 1
             continue
@@ -127,9 +127,10 @@ def setup_items(world: World) -> typing.List[DK64Item]:
                     num_moves = 2
                 elif item_id == DK64RItems.ProgressiveInstrumentUpgrade or item_id == DK64RItems.ProgressiveSlam:
                     num_moves = 3
-
-                if name in world.options.start_inventory or name in starting_moves:
-                    for _ in range(world.options.start_inventory[name] + starting_moves.count(name)):
+                if name in world.options.start_inventory:
+                    num_moves -= world.options.start_inventory[name]
+                if name in starting_moves:
+                    for _ in range(starting_moves.count(name)):
                         world.multiworld.push_precollected(copy.copy(ap_item))
                         num_moves -= 1
                 for _ in range(num_moves):
@@ -201,8 +202,10 @@ def setup_items(world: World) -> typing.List[DK64Item]:
                 for _ in range(num_coins):
                     item_table.append(copy.copy(ap_item))
             case DK64RTypes.Climbing:
-                if name in world.options.start_inventory or not world.options.climbing_shuffle:
+                if name in starting_moves or not world.options.climbing_shuffle:
                     world.multiworld.push_precollected(copy.copy(ap_item))
+                elif name in world.options.start_inventory:
+                    continue
                 else:
                     item_table.append(copy.copy(ap_item))
             case DK64RTypes.Hint:
@@ -221,7 +224,7 @@ def setup_items(world: World) -> typing.List[DK64Item]:
                 if not world.options.shopowners_in_pool:
                     continue
                 if name in world.options.start_inventory:
-                    world.multiworld.push_precollected(copy.copy(ap_item))
+                    continue
                 else:
                     item_table.append(copy.copy(ap_item))
             case (


### PR DESCRIPTION
* Fixed an issue where we weren't detecting moves already in the start_inventory for the purpose of random moves
* Fixed Climbing not being pushed if it's randomly chosen for starting moves
* Fixed duplicate pushing from start_inventory
* Treasure hurry treasures are now progression (skip balancing) if they aren't already progression for some other reason.