### PR TITLE
snide properly in isles spoiler hints

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -2276,7 +2276,7 @@ def compileSpoilerHints(spoiler):
     for location_id in spoiler.LocationList.keys():
         location = spoiler.LocationList[location_id]
         level_of_location = location.level
-        if level_of_location == Levels.Shops:  # Jetpac and BlueprintBananas - we want Jetpac in Isles now, but we probably won't want BlueprintBananas there too when those start shuffling
+        if level_of_location in (Levels.Shops, Levels.Snide):  # Jetpac and Blueprint Rewards - we put them in Isles for now, this may change later
             level_of_location = Levels.DKIsles
         if location.item in important_items:
             item_obj = ItemList[location.item]


### PR DESCRIPTION
- Fixed an issue where blueprint rewards weren't properly being assigned to Isles in spoiler hints