### PR TITLE
Excess BP Reward Simplification

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -1694,7 +1694,11 @@ def compileHints(spoiler: Spoiler) -> bool:
             regions_in_region = [region for region in spoiler.RegionList.values() if region.hint_name == foolish_name]
             for region in regions_in_region:
                 foolish_location_score += len(
-                    [loc for loc in region.locations if not spoiler.LocationList[loc.id].inaccessible and spoiler.LocationList[loc.id].type in spoiler.settings.shuffled_location_types]
+                    [
+                        loc
+                        for loc in region.locations
+                        if not spoiler.LocationList[loc.id].inaccessible and spoiler.LocationList[loc.id].type in spoiler.settings.shuffled_location_types and not spoiler.LocationList[loc.id].constant
+                    ]
                 )
                 if region.level == Levels.Shops and region.hint_name != HintRegion.Jetpac:  # Jetpac isn't a "real" shop, it's in the Shops level for convenience
                     shops_in_region += 1

--- a/randomizer/ItemPool.py
+++ b/randomizer/ItemPool.py
@@ -124,6 +124,9 @@ def PlaceConstants(spoiler):
         if spoiler.LocationList[location].type == Types.Shop:
             spoiler.LocationList[location].inaccessible = spoiler.LocationList[location].smallerShopsInaccessible
             spoiler.LocationList[location].tooExpensiveInaccessible = False
+    if Types.BlueprintBanana in spoiler.settings.shuffled_location_types:
+        for location_id in spoiler.settings.excluded_bp_locations:
+            spoiler.LocationList[location_id].PlaceDefaultItem(spoiler)
     # Make extra sure the Helm Key is right
     if settings.key_8_helm:
         helm_key = getHelmKey(spoiler.settings)
@@ -570,6 +573,8 @@ def GoldenBananaItems(settings):
     for item_type, value in decrease_values.items():
         if item_type not in settings.shuffled_location_types:
             decrease += value
+    if Types.BlueprintBanana in settings.shuffled_location_types:
+        decrease += len(settings.excluded_bp_locations)
     itemPool.extend(itertools.repeat(Items.GoldenBanana, settings.total_gbs - decrease))
     return itemPool
 

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -2344,6 +2344,12 @@ class Settings:
             # Cap at prog max
             self.progressive_hint_count = prog_max
 
+        self.excluded_bp_locations = []
+        if Types.BlueprintBanana in self.shuffled_location_types and self.most_snide_rewards < 40:
+            self.excluded_bp_locations = [Locations.TurnInJungleJapesDonkeyBlueprint + x for x in range(35)] + [Locations.TurnInDKIslesDonkeyBlueprint + x for x in range(5)]
+            count_to_exclude = 40 - self.most_snide_rewards
+            self.excluded_bp_locations = self.excluded_bp_locations[-count_to_exclude:]
+
     def isBadIceTrapLocation(self, location: Locations):
         """Determine whether an ice trap is safe to house an ice trap outside of individual cases."""
         bad_fake_types = [Types.TrainingBarrel, Types.PreGivenMove]
@@ -2547,12 +2553,6 @@ class Settings:
                     has_banana = True
             if has_banana:
                 self.valid_locations[Types.Banana] = [location for location in shuffledNonMoveLocations]
-            excluded_bp_locations = []
-            if Types.BlueprintBanana in self.shuffled_location_types and self.most_snide_rewards < 40:
-                excluded_bp_locations = [Locations.TurnInJungleJapesDonkeyBlueprint + x for x in range(35)] + [Locations.TurnInDKIslesDonkeyBlueprint + x for x in range(5)]
-                count_to_exclude = 40 - self.most_snide_rewards
-                excluded_bp_locations = excluded_bp_locations[-count_to_exclude:]
-
             if Types.FillerBanana in self.shuffled_location_types:
                 self.valid_locations[Types.FillerBanana] = [location for location in shuffledNonMoveLocations]
             regular_items = (
@@ -2790,28 +2790,6 @@ class Settings:
                             self.valid_locations[item_type][kong] = [v for v in self.valid_locations[item_type][kong] if valid_locations_lambda(spoiler.LocationList[v], v)]
                     else:
                         self.valid_locations[item_type] = [v for v in self.valid_locations[item_type] if valid_locations_lambda(spoiler.LocationList[v], v)]
-            # Remove any locations where we're excluding BPs
-            if Types.Shop in self.valid_locations:
-                for kong in self.valid_locations[Types.Shop]:
-                    self.valid_locations[Types.Shop][kong] = [v for v in self.valid_locations[Types.Shop][kong] if v not in excluded_bp_locations]
-            exclude_bp_types = (
-                # These types tend to be pretty important. Lets make sure that if the user specifies they want useful items to stop at a certain BP amount, these don't appear after that amount
-                Types.Key,
-                Types.Shockwave,
-                Types.Bean,
-                Types.Pearl,
-                Types.Candy,
-                Types.Funky,
-                Types.Cranky,
-                Types.Snide,
-                Types.Climbing,
-                Types.RarewareCoin,
-                Types.NintendoCoin,
-                Types.Kong,
-            )
-            for item_type in exclude_bp_types:
-                if item_type in self.valid_locations:
-                    self.valid_locations[item_type] = [v for v in self.valid_locations[item_type] if v not in excluded_bp_locations]
 
     def GetValidLocationsForItem(self, item_id):
         """Return the valid locations the input item id can be placed in."""

--- a/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsColoredBananas.MD
@@ -1638,7 +1638,7 @@
 | ---- | ------ | ----- |
 | On crystal tower | 10 | `self.logic = lambda _: True` | 
 | Up the crystal tower (Lanky) | 5 | `l.balloon or l.monkey_maneuvers` | 
-| Upper balloon pad | 10 | `l.balloon or l.monkey_maneuvers` | 
+| Upper balloon pad | 5 | `l.balloon or l.monkey_maneuvers` | 
 | Around crystal tower (lower) | Balloon | `self.logic = lambda _: True` | 
 | In Lanky 5DI (Lanky) | Balloon | `self.logic = lambda _: True` | 
 ## Caves Tiny Igloo


### PR DESCRIPTION
- Blueprint rewards beyond the cap are now treated as unshuffled locations and are always given GBs accordingly
- Foolish hints for blueprint reward regions past your cap can no longer appear