### PR TITLE
Filler rainbow coin fix

### DIFF
--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -2667,12 +2667,11 @@ class Settings:
             if Types.Snide in self.shuffled_location_types:
                 # Snide can't be placed in/after expected Helm Access. To help out fill, we'll ban Snide from any locations in Helm
                 self.valid_locations[Types.Snide] = [x for x in shuffledLocationsShopOwner.copy() if spoiler.LocationList[x].level != Levels.HideoutHelm]
-            if Types.RainbowCoin in self.shuffled_location_types:
-                self.valid_locations[Types.RainbowCoin] = [
-                    x for x in shuffledNonMoveLocations if spoiler.LocationList[x].type not in (Types.Shop, Types.TrainingBarrel, Types.Shockwave, Types.PreGivenMove, Types.Climbing)
-                ]
-            if Types.FillerRainbowCoin in self.shuffled_location_types:
-                self.valid_locations[Types.FillerRainbowCoin] = self.valid_locations[Types.RainbowCoin].copy()
+            for item in (Types.RainbowCoin, Types.FillerRainbowCoin):
+                if item in self.shuffled_location_types:
+                    self.valid_locations[item] = [
+                        x for x in shuffledNonMoveLocations if spoiler.LocationList[x].type not in (Types.Shop, Types.TrainingBarrel, Types.Shockwave, Types.PreGivenMove, Types.Climbing)
+                    ]
             if Types.FakeItem in self.shuffled_location_types:
                 bad_fake_locations = (
                     # Miscellaneous issues


### PR DESCRIPTION
* Fixes a bug where seeds would fail to gen if Rainbow Coins were unshuffled but filler Rainbow Coins were added.