### PR TITLE
Quick LZR Fixes

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -21,6 +21,7 @@ from randomizer.Enums.Settings import (
     BananaportRando,
     BLockerSetting,
     ClimbingStatus,
+    FasterChecksSelected,
     ProgressiveHintItem,
     ActivateAllBananaports,
     LogicType,
@@ -1423,6 +1424,12 @@ def compileHints(spoiler: Spoiler) -> bool:
             # Forest Donkey Mill needs to find the Grinder Room rather than Forest Main
             Locations.ForestDonkeyMill: [Regions.GrinderRoom, Maps.ForestMillFront],
         }
+        # If the Arcade GB isn't on the blast course, it's in the Arcade region and can be entrance hinted
+        if not spoiler.LogicVariables.checkFastCheck(FasterChecksSelected.factory_arcade_round_1):
+            location_exceptions[Locations.FactoryDonkeyDKArcade] = [Regions.FactoryArcadeTunnel, Maps.FranticFactory]
+        # If it is on, then it's on the blast course - this exception will make it unhintable
+        else:
+            location_exceptions[Locations.FactoryDonkeyDKArcade] = [Regions.FactoryBaboonBlast, Maps.FactoryBaboonBlast]
         region_exceptions = {
             # Most Galleon ships share a Map but have segmented sections. We want to be sure we're looking for the correct transition for each check.
             Regions.TinyShip: [Transitions.GalleonTinyToShipyard],

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -219,14 +219,14 @@ LogicRegions = {
         TransitionFront(Regions.MushroomUpper, lambda _: True, Transitions.ForestUpperExteriorToUpperMushroom),
         TransitionFront(Regions.MushroomNightExterior, lambda l: (l.istiny and l.twirl) or not l.IsHardFallDamage()),
         TransitionFront(Regions.GiantMushroomArea, lambda _: True),
-        TransitionFront(Regions.MushroomVeryTopExterior, lambda l: (l.handstand and l.islanky) or (l.slope_resets and l.diddy)),
+        TransitionFront(Regions.MushroomVeryTopExterior, lambda l: (l.handstand and l.islanky) or (l.slope_resets and l.isdiddy)),
         TransitionFront(Regions.MushroomChunkyRoom, lambda l: (l.CanSlamSwitch(Levels.FungiForest, 2) and l.ischunky) or l.CanPhase() or l.CanOStandTBSNoclip(), Transitions.ForestExteriorToChunky),
         TransitionFront(Regions.MushroomLankyZingersRoom, lambda l: Events.LankyMushroomSlamSwitch in l.Events or l.CanOStandTBSNoclip(), Transitions.ForestExteriorToZingers),
         TransitionFront(Regions.MushroomLankyMushroomsRoom, lambda l: Events.LankyMushroomSlamSwitch in l.Events or l.CanPhase() or l.CanOStandTBSNoclip(), Transitions.ForestExteriorToMushrooms),
         TransitionFront(Regions.ForestBossLobby, lambda l: not l.settings.tns_location_rando),
     ]),
 
-    Regions.MushroomVeryTopExterior: Region("Very Top of Mushroom", HintRegion.MushroomExterior, Levels.FungiForest, True, -1, [
+    Regions.MushroomVeryTopExterior: Region("Very Top of Mushroom", HintRegion.MushroomExterior, Levels.FungiForest, False, -1, [
         LocationLogic(Locations.ForestMainEnemy_TopOfMushroom, lambda _: True),
         LocationLogic(Locations.KremKap_ForestMainEnemy_TopOfMushroom, lambda l: l.camera),
 


### PR DESCRIPTION
- Fixed an issue where the logic thought there was a tag barrel at the top of the mushroom
- Fixed an issue where Factory Blast GB could get entrance hinted as if it were in the Arcade and not on the blast course (where it is when the Faster Check setting is on)