### PR TITLE
Plandomizer: Various boss fixes

### DIFF
--- a/randomizer/Lists/Plandomizer.py
+++ b/randomizer/Lists/Plandomizer.py
@@ -156,12 +156,12 @@ PlandomizerPanels = {
         "name": "Shops",
         "levels": createPlannableLevelObj(include_isles=True),
     },
-    "Snide": {
-        "name": "Snide HQ",
-        "locations": {
-            "All Kongs": [],
-        },
-    },
+    # "Snide": {
+    #     "name": "Snide HQ",
+    #     "locations": {
+    #         "All Kongs": [],
+    #     },
+    # },
     "Switches": {
         "name": "Switches",
         "locations": [],

--- a/static/js/rando_options.js
+++ b/static/js/rando_options.js
@@ -903,16 +903,65 @@ function plando_disable_krool_phases_as_bosses(evt) {
     for (let option of tnsBossOptions) {
       option.setAttribute("disabled", "disabled");
     }
+  }
+  if (kroolInBossPool !== "full_shuffle") {
     for (let i = 0; i < 5; i++) {
       const kroolPhase = document.getElementById(`plando_krool_order_${i}`);
       if (kroolPhase.value.includes("Boss")) {
         kroolPhase.value = "";
+      }
+      for (const kroolOpt of kroolPhase.options) {
+        if (kroolOpt.value && kroolOpt.value.includes("Boss")) {
+          kroolOpt.setAttribute("disabled", "disabled");
+        }
       }
     }
   }
 }
 
 document.getElementById("krool_in_boss_pool_v2").addEventListener("change", plando_disable_krool_phases_as_bosses);
+
+// Ensure Pufftoss cannot be the final boss.
+function plando_disable_pufftoss_as_final_boss(evt) {
+  const kroolInBossPool = document.getElementById("krool_in_boss_pool_v2").value;
+  // If TnS bosses aren't allowed on K. Rool, exit early.
+  if (kroolInBossPool !== "full_shuffle") {
+    return;
+  }
+  const kroolPhaseCount = parseInt(
+    document.getElementById("krool_phase_count").value
+  );
+  // If the number of K. Rool phases is random, we can't safely put
+  // Pufftoss anywhere.
+  const kroolRandom = document.getElementById("krool_random").checked;
+
+  for (let i = 0; i < 5; i++) {
+    const allowPufftoss = !kroolRandom && (i + 1 !== kroolPhaseCount);
+    const kroolPhase = document.getElementById(`plando_krool_order_${i}`);
+    if (!allowPufftoss && kroolPhase.value === "GalleonBoss") {
+      kroolPhase.value = "";
+    }
+    for (const kroolOpt of kroolPhase.options) {
+      if (kroolOpt.value === "GalleonBoss") {
+        if (allowPufftoss) {
+          kroolOpt.removeAttribute("disabled");
+        } else {
+          kroolOpt.setAttribute("disabled", "disabled");
+        }
+      }
+    }
+  }
+}
+
+document
+  .getElementById("krool_in_boss_pool_v2")
+  .addEventListener("change", plando_disable_pufftoss_as_final_boss);
+document
+  .getElementById("krool_random")
+  .addEventListener("click", plando_disable_pufftoss_as_final_boss);
+document
+  .getElementById("krool_phase_count")
+  .addEventListener("change", plando_disable_pufftoss_as_final_boss);
 
 // Make changes to the plando tab based on other settings
 document
@@ -936,6 +985,7 @@ document
     plando_disable_tns_custom_locations(evt);
     plando_disable_isles_medals(evt);
     plando_disable_krool_phases_as_bosses(evt);
+    plando_disable_pufftoss_as_final_boss(evt);
 });
 
 // Randomize all non-cosmetic settings.

--- a/ui/plando_settings.py
+++ b/ui/plando_settings.py
@@ -37,7 +37,6 @@ from ui.plando_validation import (
     validate_hint_count,
     validate_hint_text,
     validate_item_limits,
-    validate_krool_order_no_duplicates,
     validate_level_order_no_duplicates,
     validate_no_crate_items_with_shuffled_crates,
     validate_no_crown_items_with_shuffled_crowns,
@@ -233,6 +232,7 @@ async def import_plando_options(jsonString):
     js.plando_toggle_custom_locations_tab(None)
     js.plando_disable_isles_medals(None)
     js.plando_disable_krool_phases_as_bosses(None)
+    js.plando_disable_pufftoss_as_final_boss(None)
     lock_key_8_in_helm(None)
     validate_custom_arena_locations(None)
     validate_custom_crate_locations(None)
@@ -246,7 +246,6 @@ async def import_plando_options(jsonString):
     validate_shuffle_shops_no_conflict(None)
     validate_starting_kong_count(None)
     validate_level_order_no_duplicates(None)
-    validate_krool_order_no_duplicates(None)
     validate_helm_order_no_duplicates(None)
     validate_no_crate_items_with_shuffled_crates(None)
     validate_no_crown_items_with_shuffled_crowns(None)

--- a/ui/plando_validation.py
+++ b/ui/plando_validation.py
@@ -53,7 +53,6 @@ class ValidationError(IntEnum):
     invalid_shop_cost = auto()
     invalid_starting_kong_count = auto()
     level_order_duplicates = auto()
-    krool_order_duplicates = auto()
     helm_order_duplicates = auto()
     assigned_shop_when_shuffled = auto()
     assigned_dirt_patch_when_shuffled = auto()
@@ -550,41 +549,6 @@ def validate_level_order_no_duplicates(evt):
                 selectElem = js.document.getElementById(select)
                 errString = "The same level cannot be used twice in the level order."
                 mark_option_invalid(selectElem, ValidationError.level_order_duplicates, errString)
-
-
-@bind("change", "plando_krool_order_", 5)
-@bind("change", "plando_boss_order_", 7)
-def validate_krool_order_no_duplicates(evt):
-    """Raise an error if the same boss is chosen twice in the K. Rool or Boss order."""
-    battleDict = {}
-    # Count the instances of each boss battle.
-    for i in range(0, 5):
-        kroolElemName = f"plando_krool_order_{i}"
-        kroolOrderElem = js.document.getElementById(kroolElemName)
-        battle = kroolOrderElem.value
-        if battle in battleDict:
-            battleDict[battle].append(kroolElemName)
-        else:
-            battleDict[battle] = [kroolElemName]
-    for i in range(0, 7):
-        tnsElemName = f"plando_boss_order_{i}"
-        tnsOrderElem = js.document.getElementById(tnsElemName)
-        battle = tnsOrderElem.value
-        if battle in battleDict:
-            battleDict[battle].append(tnsElemName)
-        else:
-            battleDict[battle] = [tnsElemName]
-    # Invalidate any selects that re-use the same battle.
-    for battle, selects in battleDict.items():
-        if battle == "" or len(selects) == 1:
-            for select in selects:
-                selectElem = js.document.getElementById(select)
-                mark_option_valid(selectElem, ValidationError.krool_order_duplicates)
-        else:
-            for select in selects:
-                selectElem = js.document.getElementById(select)
-                errString = "The same boss battle cannot be used twice in the K. Rool order."
-                mark_option_invalid(selectElem, ValidationError.krool_order_duplicates, errString)
 
 
 @bind("change", "plando_helm_order_", 5)
@@ -1472,29 +1436,6 @@ def validate_plando_options(settings_dict: dict) -> list[str]:
             break
         else:
             levelOrderSet.add(level)
-
-    # Ensure that no boss battle was selected more than once in the K. Rool or boss order.
-    bossOrderSet = set()
-    for i in range(0, 5):
-        battle = plando_dict[f"plando_krool_order_{i}"]
-        if battle == PlandoItems.Randomize:
-            continue
-        if battle in bossOrderSet:
-            errString = "The same boss battle cannot be used twice."
-            errList.append(errString)
-            break
-        else:
-            bossOrderSet.add(battle)
-    for i in range(0, 7):
-        battle = plando_dict[f"plando_boss_order_{i}"]
-        if battle == PlandoItems.Randomize:
-            continue
-        if battle in bossOrderSet:
-            errString = "The same boss battle cannot be used twice."
-            errList.append(errString)
-            break
-        else:
-            bossOrderSet.add(battle)
 
     # Ensure that no Kong was selected more than once in the Helm order.
     helmOrderSet = set()


### PR DESCRIPTION
- Because duplicate bosses are now allowed, the plandomizer no longer requires that each boss only be placed once.
- A fix to prevent TnS bosses from being placed on K. Rool phases if K. Rool in Boss Pool is set to "K. Rool Only".
- Pufftoss cannot be placed on the final K. Rool phase (due to crashing issues). If the number of K. Rool phases is random, Pufftoss cannot be placed on any of them.

This also removes the "Snide HQ" tab for now, until we can do something with it.