### PR TITLE
Random Slam Hint Location

### DIFF
--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -746,11 +746,13 @@ def compileHints(spoiler: Spoiler) -> bool:
     if hintset.expectedDistribution[HintType.RequiredSlamHint] > 0:
         # If we're using hint doors, put it on a random hint door
         hint_location = hintset.getRandomHintLocation(random=spoiler.settings.random)
-        # If we're using progressive hints, put it on the last hint
-        if spoiler.settings.progressive_hint_item != ProgressiveHintItem.off:
-            hint_location = [hint for hint in hintset.hints if hint.level == Levels.CreepyCastle and hint.kong == Kongs.chunky][0]
-            if hint_location.hint_type == HintType.Plando:
-                hint_location = hintset.getRandomHintLocation(random=spoiler.settings.random)
+
+        # # If we're using progressive hints, put it on the last hint -- DEPRECATED: Many settings need the slam hint sooner than the last hint
+        # if spoiler.settings.progressive_hint_item != ProgressiveHintItem.off:
+        #     hint_location = [hint for hint in hintset.hints if hint.level == Levels.CreepyCastle and hint.kong == Kongs.chunky][0]
+        #     if hint_location.hint_type == HintType.Plando:
+        #         hint_location = hintset.getRandomHintLocation(random=spoiler.settings.random)
+
         # If hint_location is none, then there's no room for the slam hint. This is very likely plando's fault and intentionally done.
         if hint_location is not None:
             # Loop through locations looking for the slams - from prior calculations we can guarantee there are at least two in non-starting move locations

--- a/wiki/article_markdown/custom_locations/RandomSettingsDifficult.MD
+++ b/wiki/article_markdown/custom_locations/RandomSettingsDifficult.MD
@@ -50,18 +50,18 @@ The generated settings will be of greater difficulty. Requirements for B. Locker
 - Bonus Barrel Rando: 70%
 - Boss Location Rando: 80%
 - Bosses Selected: 
-	- Japesboss: 80%
-	- Aztecboss: 80%
-	- Factoryboss: 80%
-	- Galleonboss: 80%
-	- Fungiboss: 80%
-	- Cavesboss: 80%
-	- Castleboss: 80%
-	- Krooldonkeyphase: 80%
-	- Krooldiddyphase: 80%
-	- Kroollankyphase: 80%
-	- Krooltinyphase: 80%
-	- Kroolchunkyphase: 80%
+	- Japesboss: 100%
+	- Aztecboss: 100%
+	- Factoryboss: 100%
+	- Galleonboss: 100%
+	- Fungiboss: 100%
+	- Cavesboss: 100%
+	- Castleboss: 100%
+	- Krooldonkeyphase: 100%
+	- Krooldiddyphase: 100%
+	- Kroollankyphase: 100%
+	- Krooltinyphase: 100%
+	- Kroolchunkyphase: 100%
 - Randomize CB Locations: 60%
 - Cb Rando List Selected: 
 	- Junglejapes: 90%

--- a/wiki/article_markdown/custom_locations/RandomSettingsDifficultWithQolShuffle.MD
+++ b/wiki/article_markdown/custom_locations/RandomSettingsDifficultWithQolShuffle.MD
@@ -44,18 +44,18 @@ The generated settings will be of greater difficulty. Requirements for B. Locker
 - Bonus Barrel Rando: 70%
 - Boss Location Rando: 80%
 - Bosses Selected: 
-	- Japesboss: 80%
-	- Aztecboss: 80%
-	- Factoryboss: 80%
-	- Galleonboss: 80%
-	- Fungiboss: 80%
-	- Cavesboss: 80%
-	- Castleboss: 80%
-	- Krooldonkeyphase: 80%
-	- Krooldiddyphase: 80%
-	- Kroollankyphase: 80%
-	- Krooltinyphase: 80%
-	- Kroolchunkyphase: 80%
+	- Japesboss: 100%
+	- Aztecboss: 100%
+	- Factoryboss: 100%
+	- Galleonboss: 100%
+	- Fungiboss: 100%
+	- Cavesboss: 100%
+	- Castleboss: 100%
+	- Krooldonkeyphase: 100%
+	- Krooldiddyphase: 100%
+	- Kroollankyphase: 100%
+	- Krooltinyphase: 100%
+	- Kroolchunkyphase: 100%
 - Randomize CB Locations: 60%
 - Cb Rando List Selected: 
 	- Junglejapes: 90%

--- a/wiki/article_markdown/custom_locations/RandomSettingsEasy.MD
+++ b/wiki/article_markdown/custom_locations/RandomSettingsEasy.MD
@@ -69,18 +69,18 @@ The generated settings will be of lesser difficulty. Requirements for B. Locker,
 - Bonus Barrel Rando: 70%
 - Boss Location Rando: 80%
 - Bosses Selected: 
-	- Japesboss: 80%
-	- Aztecboss: 80%
-	- Factoryboss: 80%
-	- Galleonboss: 80%
-	- Fungiboss: 80%
-	- Cavesboss: 80%
-	- Castleboss: 80%
-	- Krooldonkeyphase: 80%
-	- Krooldiddyphase: 80%
-	- Kroollankyphase: 80%
-	- Krooltinyphase: 80%
-	- Kroolchunkyphase: 80%
+	- Japesboss: 100%
+	- Aztecboss: 100%
+	- Factoryboss: 100%
+	- Galleonboss: 100%
+	- Fungiboss: 100%
+	- Cavesboss: 100%
+	- Castleboss: 100%
+	- Krooldonkeyphase: 100%
+	- Krooldiddyphase: 100%
+	- Kroollankyphase: 100%
+	- Krooltinyphase: 100%
+	- Kroolchunkyphase: 100%
 - Randomize CB Locations: 30%
 - Cb Rando List Selected: 
 	- Junglejapes: 50%

--- a/wiki/article_markdown/custom_locations/RandomSettingsStandard.MD
+++ b/wiki/article_markdown/custom_locations/RandomSettingsStandard.MD
@@ -49,18 +49,18 @@ The generated settings will be of average difficulty. Requirements for B. Locker
 - Bonus Barrel Rando: 70%
 - Boss Location Rando: 80%
 - Bosses Selected: 
-	- Japesboss: 80%
-	- Aztecboss: 80%
-	- Factoryboss: 80%
-	- Galleonboss: 80%
-	- Fungiboss: 80%
-	- Cavesboss: 80%
-	- Castleboss: 80%
-	- Krooldonkeyphase: 80%
-	- Krooldiddyphase: 80%
-	- Kroollankyphase: 80%
-	- Krooltinyphase: 80%
-	- Kroolchunkyphase: 80%
+	- Japesboss: 100%
+	- Aztecboss: 100%
+	- Factoryboss: 100%
+	- Galleonboss: 100%
+	- Fungiboss: 100%
+	- Cavesboss: 100%
+	- Castleboss: 100%
+	- Krooldonkeyphase: 100%
+	- Krooldiddyphase: 100%
+	- Kroollankyphase: 100%
+	- Krooltinyphase: 100%
+	- Kroolchunkyphase: 100%
 - DK Phase requires Baboon Blast: 50%
 - Randomize CB Locations: 50%
 - Cb Rando List Selected: 


### PR DESCRIPTION
- Moved the guaranteed slam hint (if it exists) off of the last hint in progressive hints. It is now on a random hint, comparable to being on a random hint door.