### PR TITLE
Rebalance Costs of Progressive Hints

### DIFF
--- a/randomizer/Enums/Settings.jsonc
+++ b/randomizer/Enums/Settings.jsonc
@@ -824,6 +824,19 @@
   },
 
   /*
+    ProgressiveHintAlgorithm:
+    - Determines how quickly progressive hints are unlocked.
+    - slow: Hints are granted at a slower pace.
+    - medium: Default hint pacing.
+    - fast: Hints are granted more quickly.
+  */
+  "ProgressiveHintAlgorithm": {
+    "slow": 0,
+    "medium": 1,
+    "fast": 2
+  },
+
+  /*
     PuzzleRando:
     - Determines the difficulty of puzzle rando.
     - off: Puzzle solutions are NOT randomized.
@@ -1428,7 +1441,8 @@
     "krool_in_boss_pool_v2": 294,
     "no_consumable_upgrades": 295,
     "bosses_selected": 296,
-    "ice_trap_model_v2": 297
+    "ice_trap_model_v2": 297,
+    "progressive_hint_algorithm": 298
   },
   /*
     SettingsStringDataType:
@@ -1538,6 +1552,7 @@
     "chunky_phase_slam_req": { "obj": "SlamRequirement" },
     "puzzle_rando_difficulty": { "obj": "PuzzleRando" },
     "progressive_hint_item": { "obj": "ProgressiveHintItem" },
+    "progressive_hint_algorithm": { "obj": "ProgressiveHintAlgorithm" },
     "starting_moves_list_1": { "obj": "Items" },
     "starting_moves_list_2": { "obj": "Items" },
     "starting_moves_list_3": { "obj": "Items" },
@@ -2071,6 +2086,7 @@
       "obj": "SettingsStringDataType.bool"
     },
     "SettingsStringEnum.progressive_hint_item": { "obj": "ProgressiveHintItem" },
+    "SettingsStringEnum.progressive_hint_algorithm": { "obj": "ProgressiveHintAlgorithm" },
     "SettingsStringEnum.starting_moves_list_1": {
       "obj": "SettingsStringDataType.list"
     },

--- a/randomizer/Patching/ApplyRandomizer.py
+++ b/randomizer/Patching/ApplyRandomizer.py
@@ -379,7 +379,7 @@ def patching_response(spoiler):
         ROM_COPY.write(getProgHintBarrierItem(spoiler.settings.progressive_hint_item))
         for x in range(10):
             ROM_COPY.seek(sav + 0x98 + (x * 2))
-            ROM_COPY.writeMultipleBytes(getHintRequirementBatch(x, count), 2)
+            ROM_COPY.writeMultipleBytes(getHintRequirementBatch(x, count, spoiler.settings.progressive_hint_algorithm), 2)
     ROM_COPY.seek(sav + 0x115)
     ROM_COPY.writeMultipleBytes(count, 1)
 

--- a/randomizer/Patching/Library/Generic.py
+++ b/randomizer/Patching/Library/Generic.py
@@ -23,6 +23,7 @@ from randomizer.Enums.Settings import (
     HelmDoorItem,
     IceTrapFrequency,
     ProgressiveHintItem,
+    ProgressiveHintAlgorithm,
     HelmSetting,
     HelmBonuses,
     ColorOptions,
@@ -666,32 +667,33 @@ MEDAL_PROGRESSIVE_RATIOS = [
 ]
 
 
-EXPONENT = 1.7
-OFFSET_DIVISOR = 15
-
-
-def getHintRequirement(slot: int, cap: int):
-    """Get the hint requirement for a slot index."""
+def getHintRequirement(slot: int, cap: int, algorithm: ProgressiveHintAlgorithm):
+    """Get the hint requirement for a slot index from a power-warped linear function."""
     if slot == 34:
         return cap
-    offset = cap / OFFSET_DIVISOR
     hint_slot = slot & 0xFC
-    multiplier = cap - offset
-    final_offset = (cap + offset) / 2
-    exp_result = 1 + (math.pow(hint_slot, EXPONENT) / math.pow(34, EXPONENT))
-    z = math.pi * exp_result
-    required_gb_count = int(multiplier * 0.5 * math.cos(z) + final_offset)
-    if required_gb_count == 0:
-        return 1
-    return required_gb_count
+    # Only thing to adjust here is the ramping factor, which determines how quickly it reaches linear scaling.
+    # A higher factor means it ramps slower, costing less for longer
+    # A lower factor means it becomes linear faster, becoming costlier sooner
+    if algorithm == ProgressiveHintAlgorithm.fast:
+        ramping_factor = 1.8
+    elif algorithm == ProgressiveHintAlgorithm.medium:
+        ramping_factor = 1.5
+    else:  # algorithm == ProgressiveHintAlgorithm.slow
+        ramping_factor = 1.25
+    g = lambda slot: math.log(1 + math.exp(ramping_factor * (slot - 1)))
+    # This calculation normalizes the function between 1 and 100 given the inputs will be 1 to 35
+    percent_of_cap = 1 + 99 * math.pow((hint_slot / 34.0), ramping_factor)
+    # The cost of the hint is simply that percentage times the cap, with a minimum of 1 and a maximum of the cap as guard rails
+    return min(cap, max(1, int((percent_of_cap / 100) * cap)))
 
 
-def getHintRequirementBatch(batch: int, cap: int):
+def getHintRequirementBatch(batch: int, cap: int, algorithm: ProgressiveHintAlgorithm):
     """Get the hint requirement for a batch index."""
     slot = 34
     if batch < 9:
         slot = batch * 4
-    return getHintRequirement(slot, cap)
+    return getHintRequirement(slot, cap, algorithm)
 
 
 def getProgHintBarrierItem(item: ProgressiveHintItem) -> BarrierItems:

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -1045,6 +1045,7 @@ class Settings:
         # self.enable_progressive_hints = False  # Deprecated
         # self.progressive_hint_text = 0  # Deprecated
         self.progressive_hint_count = 0
+        self.progressive_hint_algorithm = ProgressiveHintAlgorithm.medium
         # Misc
         self.archipelago = False
 

--- a/randomizer/ShuffleDoors.py
+++ b/randomizer/ShuffleDoors.py
@@ -357,7 +357,7 @@ def SetProgressiveHintDoorLogic(spoiler):
     hint_costs = []
     for i in range(hint_count):
         door_location = Locations.JapesDonkeyDoor + i  # Hint door locations are ordered in their unlocking
-        hint_costs.append(getHintRequirement(i, spoiler.settings.progressive_hint_count))
+        hint_costs.append(getHintRequirement(i, spoiler.settings.progressive_hint_count, spoiler.settings.progressive_hint_algorithm))
     # I probably hate this more than you do but lambda functions in python REALLY like to mutate apparently
     spoiler.RegionList[Regions.GameStart].locations.append(LocationLogic(Locations.ProgressiveHint_01, lambda l: l.canFulfillProgHint(hint_costs[0])))
     spoiler.RegionList[Regions.GameStart].locations.append(LocationLogic(Locations.ProgressiveHint_02, lambda l: l.canFulfillProgHint(hint_costs[1])))

--- a/templates/qualityoflife.html
+++ b/templates/qualityoflife.html
@@ -248,6 +248,26 @@
                                 default="1"
                                 placeholder="1"/>
                     </div>
+                    <div style="display: flex; align-items: center;">
+                        <div style="margin-right: 10px; font-weight: bold;">Pace:</div>
+                        <select name="progressive_hint_algorithm"
+                                id="progressive_hint_algorithm"
+                                display_name="Progressive Hint Algorithm"
+                                class="form-select center-div"
+                                aria-label="Progressive Hint Algorithm"
+                                data-toggle="tooltip"
+                                title="How quickly progressive hints are unlocked.">
+                            <option value="slow">
+                                Slow
+                            </option>
+                            <option selected value="medium">
+                                Medium
+                            </option>
+                            <option value="fast">
+                                Fast
+                            </option>
+                        </select>
+                    </div>
                 </div>
             </div>
             <div class="flex-container">

--- a/tests/test_spoiler.py
+++ b/tests/test_spoiler.py
@@ -15,7 +15,7 @@ from randomizer.Enums.Settings import (ActivateAllBananaports, BananaportRando, 
                                        FreeTradeSetting, HelmDoorItem, HelmBonuses,
                                        HelmSetting, KasplatRandoSetting,
                                        KrushaUi, LevelRandomization, LogicType,
-                                       MicrohintsEnabled, MoveRando,
+                                       MicrohintsEnabled, MoveRando, ProgressiveHintAlgorithm,
                                        RandomPrices, SettingsMap,
                                        ShockwaveStatus, SpoilerHints,
                                        TrainingBarrels, WinConditionComplex,
@@ -36,7 +36,7 @@ class TestSpoiler(unittest.TestCase):
     def test_settings_string(self):
         """Confirm that settings strings decryption is working and generate a spoiler log with it."""
         # The settings string is defined either here or in the string above, pick your poison
-        self.settings_string = "Px+YQAAEKA4WBwwDhoDDgGHgMQAYiAxICiYFFAKKgUWA4+ASAAkIBF8mMFEcFI2FRkQjQLHaF6AAS/AAdggACwwAAYoAAP9A0tAoCBgIDgYIBASCgoGBYODAiAJ1MhuABvABwABxAByABzAB0AC5ABMwEJw9AhQgMDDCCQkE1GArQLRLSLTLUTVTWbXbYtltp222426ndW83CXAW+HfXhXEHOXGHInK3MHQHSXVHWnY3bDRElNSZhcYBlqiUQISIUQKMFIClBTBIyQRcE9TZPlm2YBGyyH6fhkJZWxluESSRiMU0gQ5HZCkWakl6LELYvVOhUQsAhMwoZEiR0qqrKBTLDkyTvEUByvIFYzyWMDIAAFLVTPEN0FIQAAUKAAKGAAFDgACiAABVoAAokAAUUAAKLAAFGAACjQABVwAAE+EsqoMVgtj2Z4sgwRwwDOZJdgcjwpioWhjisDQVpOIY1hcJIQn8g5BkiXReDoNBwQCISCgVCwYDIaDgdDwgEIiEYkEomE4oFIsFouF4wXwMDBWMRoNVYwAQEAkFAthAYqGQzYgAdgB+gIpwMDEZDHStz5TToeJGis8TV5vfKAwIxZpvU8THy8zNzs8OkeMAh3XEGWsQgvXz+AbPHwwmjnd1K9lZmcU2dWxfCnCgHBEMiEqWxrnwifwBZAEFA2oUR4IhkKY6EqWxrnwjKdK2vjOt8755BKiUUN809Fj3CVY5ba05KsHmGhBmPUuNEsLHilPgQBbIgfdZuXRQOLNEGegA+QB6gD6AHsAPsA"
+        self.settings_string = "Px+YQAAEKA4WBwwDhoDDgGHgMQAYiAxICiYFFAKKgUWA4+AyABkIFKWL5MYKI4KRtGjIhGgWO0L0AA1+AAzBAAJhgAAxQAAf6BpkBQEDAQHAwQCAkFBQMCwcGBEATqljcADeADgADiADkADmADoAFyACZgITiiBChAYGGEGhIJrIBWgWiWkWmWomqms2u2xbNbUNttxt1O6t5uEuAt8O+vCuIOcuMOROVuYOgOkuqOtOxu2GiJKakyi4wDrVEqAQkQogUYKQFKCmCRkgi4J6myfLNsxCOTDLIfp/HoZCWVsZbhEkkYjFNIEOh8QpqSXosQti9U6FRCwCEzCiASJHaqqsoGMsOTJO8RQHK8gVjPJYysgAN1TPEN0EIQAC0KABaGAAlDgASiAAHVoADokABUUAAaLAAdGAAKjQADVwAFk+EsqoMVgtj2Z4sgwRwwDOZJdgcKYqFoY4rA0FaTiGIo1hcJIQn8g5LEGSJdF4RAgEgoFg0HBAIhIKBULBgMhoOB0PCAQiIRiQSiYTigUiwWi4XjAar4GBgrGI0L6sYAGXC6XmEBioZDNiAB2AH6AinAsMRkOlbHymnQ8SNFZ4mrze+UBgRizTep4mPl5mbnZ4dI8YBDuuIMtYhBevn8A2ePhhNHO7qV7KzM4ps6ti+FOFAPCIZDISpbGufCJ/AFkAQUDahRHgiGQpjoSpbGufCMp0ra+M63zvnkDqRXzT0WPcGVlgkqweYcEHCkY9S40wseKU+BEFt91NldFA4s0gS4a16AJL5Aq43qAPoAewA+wA"
         settings_dict = decrypt_settings_string_enum(self.settings_string)
         settings_dict["seed"] = random.randint(0, 100000000)  # Can be fixed if you want to test a specific seed repeatedly
 
@@ -45,6 +45,7 @@ class TestSpoiler(unittest.TestCase):
         # settings_dict["plandomizer_data"] = json.loads('{"plando_starting_exit": -1, "plando_starting_kongs_selected": [-1], "plando_kong_rescue_diddy": -1, "plando_kong_rescue_lanky": -1, "plando_kong_rescue_tiny": -1, "plando_kong_rescue_chunky": -1, "plando_level_order_0": -1, "plando_level_order_1": -1, "plando_level_order_2": -1, "plando_level_order_3": -1, "plando_level_order_4": -1, "plando_level_order_5": -1, "plando_level_order_6": -1, "plando_level_order_7": -1, "plando_krool_order_0": -1, "plando_krool_order_1": -1, "plando_krool_order_2": -1, "plando_helm_order_0": -1, "plando_helm_order_1": -1, "plando_place_fairies": false, "plando_place_arenas": false, "plando_place_patches": false, "plando_place_kasplats": false, "plando_place_crates": false, "plando_place_wrinkly": false, "plando_place_tns": false, "locations": {"156": 18}, "prices": {}, "plando_bonus_barrels": {"156": 60}, "plando_switchsanity": {}, "plando_battle_arenas": {}, "plando_dirt_patches": [], "plando_fairies": [], "plando_kasplats": {}, "plando_melon_crates": [], "plando_wrinkly_doors": {}, "plando_tns_portals": {}, "hints": {}}')
 
         settings = Settings(settings_dict)
+        settings.progressive_hint_algorithm = ProgressiveHintAlgorithm.medium
         # settings.extreme_debugging = True  # Greatly slows seed gen, use with caution
         spoiler = Spoiler(settings)
         Generate_Spoiler(spoiler)

--- a/typings/randomizer/Enums/Settings.d.ts
+++ b/typings/randomizer/Enums/Settings.d.ts
@@ -498,6 +498,12 @@ export enum ProgressiveHintItem {
     req_cb = 10,
 }
 
+export enum ProgressiveHintAlgorithm {
+    slow = 0,
+    medium = 1,
+    fast = 2,
+}
+
 export enum PuzzleRando {
     off = 0,
     easy = 1,
@@ -964,6 +970,7 @@ export enum SettingsStringEnum {
     no_consumable_upgrades = 295,
     bosses_selected = 296,
     ice_trap_model_v2 = 297,
+    progressive_hint_algorithm = 298,
 }
 
 export enum SettingsStringDataType {
@@ -1065,6 +1072,7 @@ export const SettingsMap = {
     'chunky_phase_slam_req': SlamRequirement,
     'puzzle_rando_difficulty': PuzzleRando,
     'progressive_hint_item': ProgressiveHintItem,
+    'progressive_hint_algorithm': ProgressiveHintAlgorithm,
     'starting_moves_list_1': Items,
     'starting_moves_list_2': Items,
     'starting_moves_list_3': Items,
@@ -1332,6 +1340,7 @@ export const SettingsStringTypeMap = {
     SettingsStringEnum.has_password: SettingsStringDataType.bool,
     SettingsStringEnum.randomize_enemy_sizes: SettingsStringDataType.bool,
     SettingsStringEnum.progressive_hint_item: ProgressiveHintItem,
+    SettingsStringEnum.progressive_hint_algorithm: ProgressiveHintAlgorithm,
     SettingsStringEnum.starting_moves_list_1: SettingsStringDataType.list,
     SettingsStringEnum.starting_moves_list_count_1: SettingsStringDataType.int16,
     SettingsStringEnum.starting_moves_list_2: SettingsStringDataType.list,

--- a/typings/randomizer/Enums/Settings.pyi
+++ b/typings/randomizer/Enums/Settings.pyi
@@ -449,6 +449,11 @@ class ProgressiveHintItem(IntEnum):
     req_pearl = 9
     req_cb = 10
 
+class ProgressiveHintAlgorithm(IntEnum):
+    slow = 0
+    medium = 1
+    fast = 2
+
 class PuzzleRando(IntEnum):
     off = 0
     easy = 1
@@ -897,6 +902,7 @@ class SettingsStringEnum(IntEnum):
     no_consumable_upgrades = 295
     bosses_selected = 296
     ice_trap_model_v2 = 297
+    progressive_hint_algorithm = 298
 
 class SettingsStringDataType(IntEnum):
     bool = 1
@@ -996,6 +1002,7 @@ SettingsMap: dict = {
     "chunky_phase_slam_req": SlamRequirement,
     "puzzle_rando_difficulty": PuzzleRando,
     "progressive_hint_item": ProgressiveHintItem,
+    "progressive_hint_algorithm": ProgressiveHintAlgorithm,
     "starting_moves_list_1": Items,
     "starting_moves_list_2": Items,
     "starting_moves_list_3": Items,
@@ -1263,6 +1270,7 @@ SettingsStringTypeMap: dict = {
     SettingsStringEnum.has_password: SettingsStringDataType.bool,
     SettingsStringEnum.randomize_enemy_sizes: SettingsStringDataType.bool,
     SettingsStringEnum.progressive_hint_item: ProgressiveHintItem,
+    SettingsStringEnum.progressive_hint_algorithm: ProgressiveHintAlgorithm,
     SettingsStringEnum.starting_moves_list_1: SettingsStringDataType.list,
     SettingsStringEnum.starting_moves_list_count_1: SettingsStringDataType.int16,
     SettingsStringEnum.starting_moves_list_2: SettingsStringDataType.list,


### PR DESCRIPTION
Progressive hint costs have been entirely rebalanced into three possible choices
- "Fast" is comparable to before, except with the first few hint packs coming sooner
- "Slow" very quickly becomes a linear path to your cap
All three have lower costs at the 7-9 pack range. This is a new setting, but settings strings have not been updated yet.