### PR TITLE
fix forest shuffled shops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,6 +246,3 @@ base-hack/modelling/*.obj
 *.ia4
 *.i8
 *.ia8
-seed.textproto
-tools/dump_lanky.py
-tools/pack_lanky.py

--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,6 @@ base-hack/modelling/*.obj
 *.ia4
 *.i8
 *.ia8
+seed.textproto
+tools/dump_lanky.py
+tools/pack_lanky.py

--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,4 @@ base-hack/modelling/*.obj
 seed.textproto
 tools/dump_lanky.py
 tools/pack_lanky.py
+base-hack/src/minigames/rom_cache.txt

--- a/dumper.py
+++ b/dumper.py
@@ -682,4 +682,4 @@ for arg in args:
     arg_f = globals()[f"dump_{arg}"]
     arg_f(sys.argv[1])
     print("Dumping complete")
-subprocess.call(["python", "./update_wiki.py"])
+subprocess.call(["python3" if sys.platform.startswith("linux") else "python", "./update_wiki.py"])

--- a/randomizer/CollectibleLogicFiles/FungiForest.py
+++ b/randomizer/CollectibleLogicFiles/FungiForest.py
@@ -139,7 +139,6 @@ LogicRegions = {
     Regions.MillArea: [
         Collectible(Collectibles.banana, Kongs.lanky, lambda _: True, None, 1),  # Mill roof
         Collectible(Collectibles.balloon, Kongs.donkey, lambda l: l.coconut, None, 1),  # Behind Barn
-        Collectible(Collectibles.balloon, Kongs.diddy, lambda l: l.peanut and (l.TimeAccess(Regions.MillArea, Time.Day) or l.monkey_maneuvers), None, 1),  # Snide
         Collectible(Collectibles.banana, Kongs.diddy, lambda _: True, None, 3),  # Near Rafter Barn
         Collectible(Collectibles.bunch, Kongs.diddy, lambda l: l.spring or l.CanMoontail(), None, 1),  # Near Rafter Barn
         Collectible(Collectibles.banana, Kongs.tiny, lambda l: l.swim, None, 17),  # Underwater
@@ -148,6 +147,9 @@ LogicRegions = {
         Collectible(Collectibles.coin, Kongs.diddy, lambda l: l.climbing, None, 3),  # On mushroom near back Tag Barrel
         Collectible(Collectibles.coin, Kongs.lanky, lambda l: l.climbing, None, 3),  # On mushroom near rafters attic
         Collectible(Collectibles.coin, Kongs.chunky, lambda l: l.climbing, None, 3),  # On mushroom near Chunky minecart exit
+    ],
+    Regions.SnideArea:[
+        Collectible(Collectibles.balloon, Kongs.diddy, lambda l: l.peanut, None, 1) # Near Snide
     ],
     Regions.MillChunkyTinyArea: [
         Collectible(Collectibles.bunch, Kongs.chunky, lambda l: l.punch, None, 1),

--- a/randomizer/CollectibleLogicFiles/FungiForest.py
+++ b/randomizer/CollectibleLogicFiles/FungiForest.py
@@ -148,8 +148,8 @@ LogicRegions = {
         Collectible(Collectibles.coin, Kongs.lanky, lambda l: l.climbing, None, 3),  # On mushroom near rafters attic
         Collectible(Collectibles.coin, Kongs.chunky, lambda l: l.climbing, None, 3),  # On mushroom near Chunky minecart exit
     ],
-    Regions.SnideArea:[
-        Collectible(Collectibles.balloon, Kongs.diddy, lambda l: l.peanut, None, 1) # Near Snide
+    Regions.SnideArea: [
+        Collectible(Collectibles.balloon, Kongs.diddy, lambda l: l.peanut, None, 1)  # Near Snide
     ],
     Regions.MillChunkyTinyArea: [
         Collectible(Collectibles.bunch, Kongs.chunky, lambda l: l.punch, None, 1),

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -1939,6 +1939,7 @@ def compileHints(spoiler: Spoiler) -> bool:
                 Regions.MillArea,
                 Regions.ThornvineArea,
                 Regions.MushroomVeryTopExterior,
+                Regions.SnideArea,
             ],
             [Regions.CrystalCavesEntryHandler, Regions.CrystalCavesMain, Regions.IglooArea, Regions.CabinArea],
             [Regions.CreepyCastleEntryHandler, Regions.CreepyCastleMain, Regions.CastleWaterfall],

--- a/randomizer/Enums/Regions.jsonc
+++ b/randomizer/Enums/Regions.jsonc
@@ -315,6 +315,7 @@
     "SnideFourthGroup": 289,
     "SnideLastGroup": 290,
     "FactoryArcadePole": 291,
-    "MushroomVeryTopExterior": 292
+    "MushroomVeryTopExterior": 292,
+    "SnideArea": 293
   }
 }

--- a/randomizer/Lists/BananaCoinLocations.py
+++ b/randomizer/Lists/BananaCoinLocations.py
@@ -5400,14 +5400,13 @@ BananaCoinGroupList = {
             map_id=Maps.FungiForest,
             name="In the Snide's area",
             konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
-            region=Regions.MillArea,
+            region=Regions.SnideArea,
             locations=[
                 [1.0, 3337, 270, 3714],
                 [1.0, 3312, 243, 3603],
                 [1.0, 3287, 235, 3462],
                 [1.0, 3251, 268, 3363],
             ],
-            logic=lambda l: (l.TimeAccess(Regions.MillArea, Time.Day)),
         ),
         BananaCoinGroup(
             group=32,

--- a/randomizer/Lists/CBLocations/FungiForestCBLocations.py
+++ b/randomizer/Lists/CBLocations/FungiForestCBLocations.py
@@ -3207,7 +3207,7 @@ BalloonList = [
         name="In front of Snide (Diddy)",
         speed=9,
         konglist=[Kongs.donkey, Kongs.diddy, Kongs.lanky, Kongs.tiny, Kongs.chunky],
-        region=Regions.MillArea,
+        region=Regions.SnideArea,
         vanilla=True,
         points=[[3233, 349, 3638], [3242, 327, 3550], [3180, 345, 3477]],
     ),

--- a/randomizer/Lists/CustomLocations.py
+++ b/randomizer/Lists/CustomLocations.py
@@ -2957,9 +2957,8 @@ CustomLocations = {
             y=268,
             z=3682,
             max_size=56,
-            logic_region=Regions.MillArea,
+            logic_region=Regions.SnideArea,
             group=2,
-            logic=lambda l: (l.TimeAccess(Regions.MillArea, Time.Day)),
         ),
         CustomLocation(
             map=Maps.FungiForest,

--- a/randomizer/Lists/DoorLocations.py
+++ b/randomizer/Lists/DoorLocations.py
@@ -2656,11 +2656,9 @@ door_locations = {
         DoorData(
             name="Near Mills Shop",
             map=Maps.FungiForest,
-            logicregion=Regions.MillArea,
+            logicregion=Regions.SnideArea,
             location=[3240.033, 268.5, 3718.017, 178.0],
             group=4,
-            moveless=False,
-            logic=lambda l: Events.Day in l.Events,
             placed=DoorType.boss,
             door_type=[DoorType.boss, DoorType.wrinkly],
             dk_portal_logic=lambda s: s.settings.fungi_time_internal in (FungiTimeSetting.dusk, FungiTimeSetting.progressive),

--- a/randomizer/Lists/MapsAndExits.py
+++ b/randomizer/Lists/MapsAndExits.py
@@ -185,6 +185,7 @@ RegionMapList = {
     Regions.ForestTopOfMill: Maps.FungiForest,
     Regions.ForestVeryTopOfMill: Maps.FungiForest,
     Regions.ForestMillTopOfNightCage: Maps.FungiForest,
+    Regions.SnideArea: Maps.FungiForest,
     # Caves
     Regions.CrystalCavesEntryHandler: Maps.CrystalCaves,
     Regions.CrystalCavesMain: Maps.CrystalCaves,

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -347,12 +347,19 @@ LogicRegions = {
         TransitionFront(Regions.MillRafters, lambda l: (l.spring or l.CanMoontail()) and l.isdiddy, Transitions.ForestMainToRafters, time=Time.Night),
         TransitionFront(Regions.ThornvineArea, lambda _: True, time=Time.Night),
         TransitionFront(Regions.ThornvineArea, lambda l: l.CanPhaseswim()),
-        TransitionFront(Regions.Snide, lambda l: l.snideAccess, time=Time.Day),
-        TransitionFront(Regions.ForestBossLobby, lambda l: not l.settings.tns_location_rando, time=Time.Day),
+        TransitionFront(Regions.SnideArea, lambda _: True, time=Time.Day),
         TransitionFront(Regions.ThornvineBarn, lambda l: l.CanPhaseswim(), Transitions.ForestMainToBarn, isGlitchTransition=True),
         TransitionFront(Regions.ForestVeryTopOfMill, lambda l: l.climbing),
         TransitionFront(Regions.ForestTopOfMill, lambda l: l.balloon and l.islanky),
         TransitionFront(Regions.ForestMillTopOfNightCage, lambda l: l.isdiddy or l.istiny or l.ischunky),
+    ]),
+
+    Regions.SnideArea: Region("Snide Area", HintRegion.Mills, Levels.FungiForest, False, None, [], [],
+    [
+        TransitionFront(Regions.MillArea, lambda _: True, time=Time.Day),
+        TransitionFront(Regions.Snide, lambda _: True),
+        TransitionFront(Regions.ForestBossLobby, lambda l: not l.settings.tns_location_rando),
+
     ]),
 
     Regions.MillChunkyTinyArea: Region("Mill Back Room", HintRegion.Mills, Levels.FungiForest, False, -1, [

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -359,7 +359,6 @@ LogicRegions = {
         TransitionFront(Regions.MillArea, lambda _: True, time=Time.Day),
         TransitionFront(Regions.Snide, lambda _: True),
         TransitionFront(Regions.ForestBossLobby, lambda l: not l.settings.tns_location_rando),
-
     ]),
 
     Regions.MillChunkyTinyArea: Region("Mill Back Room", HintRegion.Mills, Levels.FungiForest, False, -1, [

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -354,8 +354,7 @@ LogicRegions = {
         TransitionFront(Regions.ForestMillTopOfNightCage, lambda l: l.isdiddy or l.istiny or l.ischunky),
     ]),
 
-    Regions.SnideArea: Region("Snide Area", HintRegion.Mills, Levels.FungiForest, False, None, [], [],
-    [
+    Regions.SnideArea: Region("Snide Area", HintRegion.Mills, Levels.FungiForest, False, None, [], [], [
         TransitionFront(Regions.MillArea, lambda _: True, time=Time.Day),
         TransitionFront(Regions.Snide, lambda _: True),
         TransitionFront(Regions.ForestBossLobby, lambda l: not l.settings.tns_location_rando),

--- a/randomizer/LogicFiles/FungiForest.py
+++ b/randomizer/LogicFiles/FungiForest.py
@@ -356,7 +356,7 @@ LogicRegions = {
 
     Regions.SnideArea: Region("Snide Area", HintRegion.Mills, Levels.FungiForest, False, None, [], [], [
         TransitionFront(Regions.MillArea, lambda _: True, time=Time.Day),
-        TransitionFront(Regions.Snide, lambda _: True),
+        TransitionFront(Regions.Snide, lambda l: l.snideAccess),
         TransitionFront(Regions.ForestBossLobby, lambda l: not l.settings.tns_location_rando),
     ]),
 

--- a/randomizer/ShufflePorts.py
+++ b/randomizer/ShufflePorts.py
@@ -174,7 +174,7 @@ REGION_KLUMPS = {
     Regions.Lighthouse: [Regions.LighthouseAboveLadder],
     Regions.MushroomUpperExterior: [Regions.MushroomNightExterior],
     Regions.MushroomLowerExterior: [Regions.MushroomUpperMidExterior, Regions.MushroomBlastLevelExterior, Regions.GiantMushroomArea],
-    Regions.MillArea: [Regions.ForestTopOfMill, Regions.ForestVeryTopOfMill, Regions.ForestMillTopOfNightCage],
+    Regions.MillArea: [Regions.ForestTopOfMill, Regions.ForestVeryTopOfMill, Regions.ForestMillTopOfNightCage, Regions.SnideArea],
     Regions.CrystalCavesMain: [Regions.CavesBlueprintPillar, Regions.CavesBananaportSpire, Regions.CavesBonusCave],
     Regions.CabinArea: [Regions.CavesGGRoom, Regions.CavesRotatingCabinRoof, Regions.CavesSprintCabinRoof],
     Regions.CastleTree: [Regions.CastleTreePastPunch],

--- a/randomizer/ShuffleShopLocations.py
+++ b/randomizer/ShuffleShopLocations.py
@@ -57,7 +57,7 @@ available_shops = {
     Levels.FungiForest: [
         ShopLocation(Regions.CrankyGeneric, Maps.FungiForest, Regions.GiantMushroomArea, Regions.CrankyForest),
         ShopLocation(Regions.FunkyGeneric, Maps.FungiForest, Regions.WormArea, Regions.FunkyForest),
-        ShopLocation(Regions.Snide, Maps.FungiForest, Regions.MillArea, Regions.Snide),
+        ShopLocation(Regions.Snide, Maps.FungiForest, Regions.SnideArea, Regions.Snide),
     ],
     Levels.CrystalCaves: [
         ShopLocation(Regions.CrankyGeneric, Maps.CrystalCaves, Regions.CrystalCavesMain, Regions.CrankyCaves),

--- a/randomizer/ShuffleShopLocations.py
+++ b/randomizer/ShuffleShopLocations.py
@@ -4,7 +4,6 @@ from randomizer.Enums.Levels import Levels
 from randomizer.Enums.Regions import Regions
 from randomizer.Enums.Settings import ShuffleLoadingZones
 from randomizer.Enums.Maps import Maps
-from randomizer.Enums.Time import Time
 from randomizer.LogicClasses import TransitionFront
 
 
@@ -91,18 +90,6 @@ def ShuffleShopLocations(spoiler):
         if level == Levels.DKIsles and (spoiler.settings.shuffle_loading_zones == ShuffleLoadingZones.all or not spoiler.settings.fast_start_beginning_of_game):
             continue
         shop_array = available_shops[level]
-        # Capture each slot's original time-of-day requirement before exits are stripped,
-        # so it can be re-applied to whichever shop ends up in this slot.
-        slot_times = {}
-        for slot in shop_array:
-            if slot.locked:
-                continue
-            containing = spoiler.RegionList[slot.containing_region]
-            for slot_exit in containing.exits:
-                if slot_exit.dest == slot.shop_exit:
-                    slot_times[slot.containing_region] = slot_exit.time
-                    break
-            slot_times.setdefault(slot.containing_region, Time.Both)
         # Get list of shops in level
         shops_in_levels = []
         if spoiler.settings.enable_plandomizer and spoiler.settings.plandomizer_dict["plando_shop_location_rando"] != -1:
@@ -156,15 +143,14 @@ def ShuffleShopLocations(spoiler):
                 placement_index += 1
                 # Add exit to new containing region for logical access
                 region = spoiler.RegionList[shop.containing_region]
-                slot_time = slot_times.get(shop.containing_region, Time.Both)
                 if shop.new_shop == Regions.CrankyGeneric:
-                    region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.crankyAccess, time=slot_time))
+                    region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.crankyAccess))
                 elif shop.new_shop == Regions.FunkyGeneric:
-                    region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.funkyAccess, time=slot_time))
+                    region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.funkyAccess))
                 elif shop.new_shop == Regions.CandyGeneric:
                     region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.candyAccess))
                 elif shop.new_shop == Regions.Snide:
-                    region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.snideAccess, time=slot_time))
+                    region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.snideAccess))
         assortment[level] = assortment_in_level
     # Write Assortment to spoiler
     spoiler.shuffled_shop_locations = assortment

--- a/randomizer/ShuffleShopLocations.py
+++ b/randomizer/ShuffleShopLocations.py
@@ -4,6 +4,7 @@ from randomizer.Enums.Levels import Levels
 from randomizer.Enums.Regions import Regions
 from randomizer.Enums.Settings import ShuffleLoadingZones
 from randomizer.Enums.Maps import Maps
+from randomizer.Enums.Time import Time
 from randomizer.LogicClasses import TransitionFront
 
 
@@ -90,6 +91,18 @@ def ShuffleShopLocations(spoiler):
         if level == Levels.DKIsles and (spoiler.settings.shuffle_loading_zones == ShuffleLoadingZones.all or not spoiler.settings.fast_start_beginning_of_game):
             continue
         shop_array = available_shops[level]
+        # Capture each slot's original time-of-day requirement before exits are stripped,
+        # so it can be re-applied to whichever shop ends up in this slot.
+        slot_times = {}
+        for slot in shop_array:
+            if slot.locked:
+                continue
+            containing = spoiler.RegionList[slot.containing_region]
+            for slot_exit in containing.exits:
+                if slot_exit.dest == slot.shop_exit:
+                    slot_times[slot.containing_region] = slot_exit.time
+                    break
+            slot_times.setdefault(slot.containing_region, Time.Both)
         # Get list of shops in level
         shops_in_levels = []
         if spoiler.settings.enable_plandomizer and spoiler.settings.plandomizer_dict["plando_shop_location_rando"] != -1:
@@ -143,14 +156,15 @@ def ShuffleShopLocations(spoiler):
                 placement_index += 1
                 # Add exit to new containing region for logical access
                 region = spoiler.RegionList[shop.containing_region]
+                slot_time = slot_times.get(shop.containing_region, Time.Both)
                 if shop.new_shop == Regions.CrankyGeneric:
-                    region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.crankyAccess))
+                    region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.crankyAccess, time=slot_time))
                 elif shop.new_shop == Regions.FunkyGeneric:
-                    region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.funkyAccess))
+                    region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.funkyAccess, time=slot_time))
                 elif shop.new_shop == Regions.CandyGeneric:
                     region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.candyAccess))
                 elif shop.new_shop == Regions.Snide:
-                    region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.snideAccess))
+                    region.exits.append(TransitionFront(shop.new_shop_exit, lambda l: l.snideAccess, time=slot_time))
         assortment[level] = assortment_in_level
     # Write Assortment to spoiler
     spoiler.shuffled_shop_locations = assortment

--- a/requirement_data.js
+++ b/requirement_data.js
@@ -196,8 +196,8 @@ const requirement_data = {
             new Requirement(5, [[Moves.ClimbingCheck, Moves.FactoryTesting]]), // 1 bunch in Testing
             new Requirement(20, [[Moves.ClimbingCheck, Moves.FactoryProduction]]), // 4 bunches in SpinningCore
             new Requirement(10, [[Moves.ClimbingCheck, Moves.Pineapple, Moves.FactoryTesting]]), // 1 balloon in Testing
-            new Requirement(10, [[Moves.ClimbingCheck, Moves.Triangle, Moves.Punch, Moves.FactoryTesting]]), // 10 bananas in RandDUpper
-            new Requirement(10, [[Moves.ClimbingCheck, Moves.Pineapple, Moves.Triangle, Moves.Punch, Moves.FactoryTesting]]), // 1 balloon in RandDUpper
+            new Requirement(10, [[Moves.ClimbingCheck, Moves.Triangle, Moves.FactoryTesting]]), // 10 bananas in RandDUpper
+            new Requirement(10, [[Moves.ClimbingCheck, Moves.Pineapple, Moves.Triangle, Moves.FactoryTesting]]), // 1 balloon in RandDUpper
         ],
     },
     "Galleon": {
@@ -237,7 +237,7 @@ const requirement_data = {
         ],
         "Tiny": [
             new Requirement(9, [[Moves.Moveless]]), // 4 bananas, 5 bananas in GloomyGalleonStart
-            new Requirement(8, [[Moves.Vines]]), // 1 bunch, 3 bananas in GalleonPastVines
+            new Requirement(8, [[Moves.Vines, Moves.CannonCheck]]), // 1 bunch, 3 bananas in GalleonPastVines
             new Requirement(15, [[Moves.Pineapple, Moves.RaisedWater]]), // 3 bunches in GalleonBeyondPineappleGate
             new Requirement(5, [[Moves.RaisedWater, Moves.GalleonLighthouse]]), // 1 bunch in LighthouseSnideAlcove
             new Requirement(10, [[Moves.Diving, Moves.LevelSlam, Moves.GalleonPeanut]]), // 2 bunches in TinyShip
@@ -249,7 +249,7 @@ const requirement_data = {
         ],
         "Chunky": [
             new Requirement(12, [[Moves.Moveless]]), // 1 bunch, 2 bananas, 5 bananas in GloomyGalleonStart
-            new Requirement(3, [[Moves.Vines]]), // 3 bananas in GalleonPastVines
+            new Requirement(3, [[Moves.Vines, Moves.CannonCheck]]), // 3 bananas in GalleonPastVines
             new Requirement(10, [[Moves.Diving, Moves.GalleonLighthouse]]), // 10 bananas in LighthouseUnderwater
             new Requirement(15, [[Moves.Diving, Moves.GalleonPeanut]]), // 3 bunches in ShipyardUnderwater
             new Requirement(10, [[Moves.Pineapple, Moves.RaisedWater]]), // 1 balloon in GalleonBeyondPineappleGate
@@ -282,7 +282,7 @@ const requirement_data = {
         ],
         "Diddy": [
             new Requirement(28, [[Moves.Moveless]]), // 1 bunch, 2 bunches in FungiForestStart; 2 bunches in GiantMushroomArea; 3 bananas in MillArea
-            new Requirement(10, [[Moves.Peanut]]), // 1 balloon in SnideArea
+            new Requirement(10, [[Moves.Peanut]]), // 1 balloon in MillArea
             new Requirement(5, [[Moves.Spring]]), // 1 bunch in MillArea
             new Requirement(15, [[Moves.ForestYellowTunnel]]), // 1 bunch, 10 bananas in HollowTreeArea
             new Requirement(5, [[Moves.Rocket, Moves.ForestYellowTunnel]]), // 1 bunch in HollowTreeArea

--- a/requirement_data.js
+++ b/requirement_data.js
@@ -196,8 +196,8 @@ const requirement_data = {
             new Requirement(5, [[Moves.ClimbingCheck, Moves.FactoryTesting]]), // 1 bunch in Testing
             new Requirement(20, [[Moves.ClimbingCheck, Moves.FactoryProduction]]), // 4 bunches in SpinningCore
             new Requirement(10, [[Moves.ClimbingCheck, Moves.Pineapple, Moves.FactoryTesting]]), // 1 balloon in Testing
-            new Requirement(10, [[Moves.ClimbingCheck, Moves.Triangle, Moves.FactoryTesting]]), // 10 bananas in RandDUpper
-            new Requirement(10, [[Moves.ClimbingCheck, Moves.Pineapple, Moves.Triangle, Moves.FactoryTesting]]), // 1 balloon in RandDUpper
+            new Requirement(10, [[Moves.ClimbingCheck, Moves.Triangle, Moves.Punch, Moves.FactoryTesting]]), // 10 bananas in RandDUpper
+            new Requirement(10, [[Moves.ClimbingCheck, Moves.Pineapple, Moves.Triangle, Moves.Punch, Moves.FactoryTesting]]), // 1 balloon in RandDUpper
         ],
     },
     "Galleon": {
@@ -237,7 +237,7 @@ const requirement_data = {
         ],
         "Tiny": [
             new Requirement(9, [[Moves.Moveless]]), // 4 bananas, 5 bananas in GloomyGalleonStart
-            new Requirement(8, [[Moves.Vines, Moves.CannonCheck]]), // 1 bunch, 3 bananas in GalleonPastVines
+            new Requirement(8, [[Moves.Vines]]), // 1 bunch, 3 bananas in GalleonPastVines
             new Requirement(15, [[Moves.Pineapple, Moves.RaisedWater]]), // 3 bunches in GalleonBeyondPineappleGate
             new Requirement(5, [[Moves.RaisedWater, Moves.GalleonLighthouse]]), // 1 bunch in LighthouseSnideAlcove
             new Requirement(10, [[Moves.Diving, Moves.LevelSlam, Moves.GalleonPeanut]]), // 2 bunches in TinyShip
@@ -249,7 +249,7 @@ const requirement_data = {
         ],
         "Chunky": [
             new Requirement(12, [[Moves.Moveless]]), // 1 bunch, 2 bananas, 5 bananas in GloomyGalleonStart
-            new Requirement(3, [[Moves.Vines, Moves.CannonCheck]]), // 3 bananas in GalleonPastVines
+            new Requirement(3, [[Moves.Vines]]), // 3 bananas in GalleonPastVines
             new Requirement(10, [[Moves.Diving, Moves.GalleonLighthouse]]), // 10 bananas in LighthouseUnderwater
             new Requirement(15, [[Moves.Diving, Moves.GalleonPeanut]]), // 3 bunches in ShipyardUnderwater
             new Requirement(10, [[Moves.Pineapple, Moves.RaisedWater]]), // 1 balloon in GalleonBeyondPineappleGate
@@ -282,7 +282,7 @@ const requirement_data = {
         ],
         "Diddy": [
             new Requirement(28, [[Moves.Moveless]]), // 1 bunch, 2 bunches in FungiForestStart; 2 bunches in GiantMushroomArea; 3 bananas in MillArea
-            new Requirement(10, [[Moves.Peanut]]), // 1 balloon in MillArea
+            new Requirement(10, [[Moves.Peanut]]), // 1 balloon in SnideArea
             new Requirement(5, [[Moves.Spring]]), // 1 bunch in MillArea
             new Requirement(15, [[Moves.ForestYellowTunnel]]), // 1 bunch, 10 bananas in HollowTreeArea
             new Requirement(5, [[Moves.Rocket, Moves.ForestYellowTunnel]]), // 1 bunch in HollowTreeArea

--- a/requirement_data.js
+++ b/requirement_data.js
@@ -282,7 +282,7 @@ const requirement_data = {
         ],
         "Diddy": [
             new Requirement(28, [[Moves.Moveless]]), // 1 bunch, 2 bunches in FungiForestStart; 2 bunches in GiantMushroomArea; 3 bananas in MillArea
-            new Requirement(10, [[Moves.Peanut]]), // 1 balloon in MillArea
+            new Requirement(10, [[Moves.Peanut]]), // 1 balloon in SnideArea
             new Requirement(5, [[Moves.Spring]]), // 1 bunch in MillArea
             new Requirement(15, [[Moves.ForestYellowTunnel]]), // 1 bunch, 10 bananas in HollowTreeArea
             new Requirement(5, [[Moves.Rocket, Moves.ForestYellowTunnel]]), // 1 bunch in HollowTreeArea

--- a/typings/randomizer/Enums/Regions.d.ts
+++ b/typings/randomizer/Enums/Regions.d.ts
@@ -291,4 +291,5 @@ export enum Regions {
     SnideLastGroup = 290,
     FactoryArcadePole = 291,
     MushroomVeryTopExterior = 292,
+    SnideArea = 293,
 }

--- a/typings/randomizer/Enums/Regions.pyi
+++ b/typings/randomizer/Enums/Regions.pyi
@@ -293,3 +293,4 @@ class Regions(IntEnum):
     SnideLastGroup = 290
     FactoryArcadePole = 291
     MushroomVeryTopExterior = 292
+    SnideArea = 293

--- a/wiki/article_markdown/custom_locations/CustomLocationsCoins.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsCoins.MD
@@ -565,7 +565,7 @@
 | On the Green Tunnel Roof | 3 | `l.twirl and l.istiny` | 
 | On a mushroom in the Worm Area | 4 | `self.logic = lambda _: True` | 
 | On the waterwheel | 5 | `self.logic = lambda _: True` | 
-| In the Snide's area | 4 | `(l.TimeAccess(Regions.MillArea, Time.Day))` | 
+| In the Snide's area | 4 | `self.logic = lambda _: True` | 
 | Near the entrance to the Dark Rafters | 4 | `self.logic = lambda _: True` | 
 | Hanging off the mill roof | 3 | `self.logic = lambda _: True` | 
 | In front of the mill in the air | 3 | `l.balloon and l.islanky` | 

--- a/wiki/article_markdown/custom_locations/CustomLocationsDoors.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsDoors.MD
@@ -266,7 +266,7 @@
 | Fungi Forest Lobby | Forest Lobby - Near Entrance | Wrinkly | `self.logic = lambda _: True` | 
 | Fungi Forest | Behind Thornvine Barn | Boss, Wrinkly | `self.logic = lambda _: True` | 
 | Fungi Forest | Beanstalk Area Alcove | Boss, Wrinkly | `Events.Night in l.Events` | 
-| Fungi Forest | Near Mills Shop | Boss, Wrinkly | `Events.Day in l.Events` | 
+| Fungi Forest | Near Mills Shop | Boss, Wrinkly | `self.logic = lambda _: True` | 
 | Fungi Forest | Top of Giant Mushroom | Boss, Dk_Portal, Wrinkly | `self.logic = lambda _: True` | 
 | Fungi Forest | Owl Area Clearing | Boss, Wrinkly | `self.logic = lambda _: True` | 
 | Fungi Forest | On top of Mill Crusher Output | Boss, Dk_Portal, Wrinkly | `self.logic = lambda _: True` | 

--- a/wiki/article_markdown/custom_locations/CustomLocationsMiscellaneous.MD
+++ b/wiki/article_markdown/custom_locations/CustomLocationsMiscellaneous.MD
@@ -251,7 +251,7 @@
 | Fungi Forest | Behind Clock |  | `self.logic = lambda _: True` | 
 | Fungi Forest | In front of Clock |  | `self.logic = lambda _: True` | 
 | Fungi Forest | Near Blue Tunnel |  | `self.logic = lambda _: True` | 
-| Fungi Forest | Near Mills shop |  | `(l.TimeAccess(Regions.MillArea, Time.Day))` | 
+| Fungi Forest | Near Mills shop |  | `self.logic = lambda _: True` | 
 | Fungi Forest | Behind rafters barn |  | `self.logic = lambda _: True` | 
 | Fungi Forest | Left of rafters barn |  | `self.logic = lambda _: True` | 
 | Fungi Forest | Next to Diddy Pad |  | `self.logic = lambda _: True` | 

--- a/wiki/articles.json
+++ b/wiki/articles.json
@@ -134,12 +134,20 @@
         "link": "WikiEditing"
     },
     {
+        "name": "Random Settings: Easy",
+        "link": "RandomSettingsEasy"
+    },
+    {
         "name": "Custom Locations: Coins",
         "link": "CustomLocationsCoins"
     },
     {
         "name": "Custom Locations: Colored Bananas",
         "link": "CustomLocationsColoredBananas"
+    },
+    {
+        "name": "Custom Locations: Kasplats",
+        "link": "CustomLocationsKasplats"
     },
     {
         "name": "Custom Locations: Doors",
@@ -150,31 +158,23 @@
         "link": "CustomLocationsFairies"
     },
     {
-        "name": "Custom Locations: Kasplats",
-        "link": "CustomLocationsKasplats"
-    },
-    {
-        "name": "Custom Locations: Miscellaneous",
-        "link": "CustomLocationsMiscellaneous"
-    },
-    {
-        "name": "Plando Colors",
-        "link": "PlandoColors"
+        "name": "Random Settings: Standard",
+        "link": "RandomSettingsStandard"
     },
     {
         "name": "Random Settings: Difficult",
         "link": "RandomSettingsDifficult"
     },
     {
+        "name": "Plando Colors",
+        "link": "PlandoColors"
+    },
+    {
+        "name": "Custom Locations: Miscellaneous",
+        "link": "CustomLocationsMiscellaneous"
+    },
+    {
         "name": "Random Settings: Difficult With Qol Shuffle",
         "link": "RandomSettingsDifficultWithQolShuffle"
-    },
-    {
-        "name": "Random Settings: Easy",
-        "link": "RandomSettingsEasy"
-    },
-    {
-        "name": "Random Settings: Standard",
-        "link": "RandomSettingsStandard"
     }
 ]


### PR DESCRIPTION
Fixed an issue where if shuffled shops are enabled, the new MillArea -> Snide TransitionFront didnt pass the time kwarg thus defaulting to Time.Both

Thanks Spike for being the brave soldier to make a preset with shuffle shop locations