### PR TITLE
Change default password protection to disabled

### DIFF
--- a/racetime_bot/randobot/handler.py
+++ b/racetime_bot/randobot/handler.py
@@ -43,7 +43,7 @@ class RandoHandler(RaceHandler):
                                 label="Preset",
                                 options={key: value["name"] for key, value in self.dk64.stable_presets.items()},
                             ),
-                            msg_actions.BoolInput(name="--password", label="Password Protect", default=True),
+                            msg_actions.BoolInput(name="--password", label="Password Protect", default=False),
                             msg_actions.BoolInput(name="--spoiler", label="Generate Spoiler Log", default=False),
                         ),
                     ),


### PR DESCRIPTION
This pull request makes a small change to the default behavior for creating races in the bot. The "Password Protect" option is now set to `False` by default instead of `True`.

* Changed the default value of the `--password` option in the `begin` method of `racetime_bot/randobot/handler.py` to `False`, so races will not be password protected unless specified.