### PR TITLE
Correct copyright year

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@
                 <br />
                 Randomizer by 2dos and Ballaam | Web Generator by Killklli
                 <br />
-                In-game characters, images and logos copyright © 1999 Nintendo or Rareware respectively.
+                In-game characters, images and logos copyright © 1999 Nintendo.
                 <br />
                 DK64Randomizer.com does not distribute copyright material.
                 <br />

--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@
                 <br />
                 Randomizer by 2dos and Ballaam | Web Generator by Killklli
                 <br />
-                In-game characters, images and logos copyright © 1999-2024 Nintendo or Rareware respectively.
+                In-game characters, images and logos copyright © 1999 Nintendo or Rareware respectively.
                 <br />
                 DK64Randomizer.com does not distribute copyright material.
                 <br />


### PR DESCRIPTION
I don't think the current year being listed is necessary. I also removed Rareware since Nintendo is the exclusive owner of the copyright.