### PR TITLE
Add requirements.txt to files to copy

### DIFF
--- a/tools/package_apworld.py
+++ b/tools/package_apworld.py
@@ -12,7 +12,7 @@ vendor_folder = "dk64/vendor"
 requirements_file = "requirements.txt"
 
 # Files and folders to copy into dk64
-files_to_copy = ["__init__.py", "js.py", "version.py", "static/compiled.jsonc", "archipelago.json"]
+files_to_copy = ["__init__.py", "js.py", "version.py", "static/compiled.jsonc", "archipelago.json", "requirements.txt"]
 folders_to_copy = ["archipelago", "base-hack/assets/arcade_jetpac", "base-hack/assets/DKTV", "base-hack/assets/displays", "randomizer", "static/patches"]
 
 # Ensure dk64 directory exists


### PR DESCRIPTION
This pull request makes a minor update to the packaging script by including the `requirements.txt` file in the list of files to be copied into the `dk64` directory. This ensures that dependencies are properly included during packaging.