### PR TITLE
Spoiler Hint B. Locker Info

### DIFF
--- a/archipelago/FillSettings.py
+++ b/archipelago/FillSettings.py
@@ -288,6 +288,7 @@ def get_default_settings() -> dict:
         "shuffle_shops": False,
         "smaller_shops": False,
         "spoiler_hints": SpoilerHints.off,
+        "spoiler_include_blocker_info": False,
         "spoiler_include_level_order": False,
         "spoiler_include_woth_count": False,
         "starting_keys_list_selected": [],

--- a/randomizer/CompileHints.py
+++ b/randomizer/CompileHints.py
@@ -99,6 +99,10 @@ class StartingSpoiler:
                 settings.level_order[7],
                 settings.level_order[8],
             ]
+        if settings.spoiler_include_blocker_info:
+            self.blocker_info = []
+            for level_index, cost in enumerate(settings.BLockerEntryCount):
+                self.blocker_info.append({"item": settings.BLockerEntryItems[level_index], "cost": cost})
 
     def toCleanJSON(self):
         """Convert this object to JSON for the purposes of the spoiler log."""
@@ -2395,6 +2399,41 @@ def compileSpoilerHints(spoiler):
     spoiler.level_spoiler_human_readable["Starting Info"] += " | K. Rool Order: " + ", ".join([boss_names[map_id] for map_id in starting_info.krool_order])
     if spoiler.settings.spoiler_include_level_order:
         spoiler.level_spoiler_human_readable["Starting Info"] += " | Level Order: " + ", ".join([level_list[level] for level in starting_info.level_order])
+    if spoiler.settings.spoiler_include_blocker_info:
+        spoiler.level_spoiler_human_readable["B. Locker Values"] = (
+            "Japes: "
+            + str(starting_info.blocker_info[0]["cost"])
+            + " "
+            + str(starting_info.blocker_info[0]["item"].name)
+            + " | Aztec: "
+            + str(starting_info.blocker_info[1]["cost"])
+            + " "
+            + str(starting_info.blocker_info[1]["item"].name)
+            + " | Factory: "
+            + str(starting_info.blocker_info[2]["cost"])
+            + " "
+            + str(starting_info.blocker_info[2]["item"].name)
+            + " | Galleon: "
+            + str(starting_info.blocker_info[3]["cost"])
+            + " "
+            + str(starting_info.blocker_info[3]["item"].name)
+            + " | Forest: "
+            + str(starting_info.blocker_info[4]["cost"])
+            + " "
+            + str(starting_info.blocker_info[4]["item"].name)
+            + " | Caves: "
+            + str(starting_info.blocker_info[5]["cost"])
+            + " "
+            + str(starting_info.blocker_info[5]["item"].name)
+            + " | Castle: "
+            + str(starting_info.blocker_info[6]["cost"])
+            + " "
+            + str(starting_info.blocker_info[6]["item"].name)
+            + " | Helm: "
+            + str(starting_info.blocker_info[7]["cost"])
+            + " "
+            + str(starting_info.blocker_info[7]["item"].name)
+        )
     if spoiler.settings.spoiler_hints == SpoilerHints.points:
         spoiler.level_spoiler["point_spread"] = {
             "kongs": spoiler.settings.points_list_kongs,

--- a/randomizer/Enums/Settings.jsonc
+++ b/randomizer/Enums/Settings.jsonc
@@ -1456,7 +1456,8 @@
     "pause_hints_setting": 299,
     "hint_door_item": 300,
     "hint_door_item_count": 301,
-    "pause_hints_lockout_timer": 302
+    "pause_hints_lockout_timer": 302,
+    "spoiler_include_blocker_info": 303
   },
   /*
     SettingsStringDataType:
@@ -2018,6 +2019,9 @@
       "obj": "SettingsStringDataType.bool"
     },
     "SettingsStringEnum.spoiler_include_level_order": {
+      "obj": "SettingsStringDataType.bool"
+    },
+    "SettingsStringEnum.spoiler_include_blocker_info": {
       "obj": "SettingsStringDataType.bool"
     },
     "SettingsStringEnum.enable_progressive_hints": {

--- a/randomizer/Settings.py
+++ b/randomizer/Settings.py
@@ -813,6 +813,7 @@ class Settings:
         self.dim_solved_hints = False
         self.spoiler_include_woth_count = False
         self.spoiler_include_level_order = False
+        self.spoiler_include_blocker_info = False
         self.serious_hints = False
         self.fast_warps = False
         self.dpad_display = DPadDisplays.off

--- a/randomizer/Spoiler.py
+++ b/randomizer/Spoiler.py
@@ -469,18 +469,18 @@ class Spoiler:
         settings["Crown Enemy Rando"] = self.settings.crown_enemy_difficulty.name
         if self.settings.helm_hurry:
             settings["Game Mode"] = "Helm Hurry"
-        humanspoiler["Settings"] = settings
-        humanspoiler["Randomizer Version"] = self.settings.version
-        humanspoiler["Generation Branch"] = self.settings.branch
-        humanspoiler["Cosmetics"] = {}
         if self.settings.spoiler_hints != SpoilerHints.off:
+            humanspoiler["Spoiler Hints"] = self.level_spoiler_human_readable
             humanspoiler["Spoiler Hints Data"] = {}
             for key in self.level_spoiler.keys():
                 if key == "point_spread":
                     humanspoiler["Spoiler Hints Data"][key] = json.dumps(self.level_spoiler[key])
                 else:
                     humanspoiler["Spoiler Hints Data"][key] = self.level_spoiler[key].toCleanJSON()
-            humanspoiler["Spoiler Hints"] = self.level_spoiler_human_readable
+        humanspoiler["Settings"] = settings
+        humanspoiler["Randomizer Version"] = self.settings.version
+        humanspoiler["Generation Branch"] = self.settings.branch
+        humanspoiler["Cosmetics"] = {}
         humanspoiler["Requirements"] = {}
         if self.settings.random_starting_region_new != RandomStartingRegion.off:
             humanspoiler["Game Start"] = {}

--- a/static/presets/weights/weight_files_raw.json
+++ b/static/presets/weights/weight_files_raw.json
@@ -1767,6 +1767,9 @@
         "spoiler_include_level_order": {
             "ignore": true
         },
+        "spoiler_include_blocker_info": {
+            "ignore": true
+        },
         "dim_solved_hints": {
             "setting_type": "bool",
             "options": {

--- a/templates/qualityoflife.html
+++ b/templates/qualityoflife.html
@@ -456,6 +456,18 @@
                             Include Level Order
                         </label>
                     </div>
+                    <div class="form-check form-switch" style="padding-top:10px;">
+                        <label data-toggle="tooltip"
+                                style="font-size:14px;"
+                                title="Spoiler hints will includes the B. Locker requirements.">
+                            <input class="form-check-input"
+                                    type="checkbox"
+                                    name="spoiler_include_blocker_info"
+                                    display_name="Include B. Locker Info in Spoiler Hints"
+                                    value="True"/>
+                            Include B. Locker Info
+                        </label>
+                    </div>
                 </div>
                 <div class="item-select">
                     <p class="select-title">Extra Hints</p>

--- a/typings/randomizer/Enums/Settings.d.ts
+++ b/typings/randomizer/Enums/Settings.d.ts
@@ -981,6 +981,7 @@ export enum SettingsStringEnum {
     hint_door_item = 300,
     hint_door_item_count = 301,
     pause_hints_lockout_timer = 302,
+    spoiler_include_blocker_info = 303,
 }
 
 export enum SettingsStringDataType {
@@ -1316,6 +1317,7 @@ export const SettingsStringTypeMap = {
     SettingsStringEnum.starting_move_list_selected: SettingsStringDataType.list,
     SettingsStringEnum.start_with_slam: SettingsStringDataType.bool,
     SettingsStringEnum.spoiler_include_level_order: SettingsStringDataType.bool,
+    SettingsStringEnum.spoiler_include_blocker_info: SettingsStringDataType.bool,
     SettingsStringEnum.enable_progressive_hints: SettingsStringDataType.bool,
     SettingsStringEnum.progressive_hint_text: SettingsStringDataType.u8,
     SettingsStringEnum.progressive_hint_count: SettingsStringDataType.u16,

--- a/typings/randomizer/Enums/Settings.pyi
+++ b/typings/randomizer/Enums/Settings.pyi
@@ -912,6 +912,7 @@ class SettingsStringEnum(IntEnum):
     hint_door_item = 300
     hint_door_item_count = 301
     pause_hints_lockout_timer = 302
+    spoiler_include_blocker_info = 303
 
 class SettingsStringDataType(IntEnum):
     bool = 1
@@ -1245,6 +1246,7 @@ SettingsStringTypeMap: dict = {
     SettingsStringEnum.starting_move_list_selected: SettingsStringDataType.list,
     SettingsStringEnum.start_with_slam: SettingsStringDataType.bool,
     SettingsStringEnum.spoiler_include_level_order: SettingsStringDataType.bool,
+    SettingsStringEnum.spoiler_include_blocker_info: SettingsStringDataType.bool,
     SettingsStringEnum.enable_progressive_hints: SettingsStringDataType.bool,
     SettingsStringEnum.progressive_hint_text: SettingsStringDataType.u8,
     SettingsStringEnum.progressive_hint_count: SettingsStringDataType.u16,


### PR DESCRIPTION
- Added option to include B. Locker info in spoiler hints. This will tell you what item/quantity you need for each B. Locker. *Trackers may not be up to date with this, just look at the top of your spoiler log to get this in the meantime.*
- Rearranged the spoiler log such that spoiler hints, when available, will be at the top