### PR TITLE
New AP stuff/fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1571,6 +1571,7 @@ if baseclasses_loaded:
                 ),
                 "Shopkeepers": self.options.shopowners_in_pool.value,
                 "HalfMedals": self.options.half_medals_in_pool.value,
+                "HalfMedalPercentage": self.spoiler.settings.half_medal_percentage,
                 "MinigameData": ({location_id.name: minigame_data.minigame.name for location_id, minigame_data in self.spoiler.shuffled_barrel_data.items()}),
                 "Autocomplete": self.options.auto_complete_bonus_barrels.value,
                 "HelmBarrelCount": self.options.helm_room_bonus_count.value,
@@ -1947,6 +1948,7 @@ if baseclasses_loaded:
             relevant_data["StartingKongs"] = [Kongs[kong] for kong in starting_kongs]
             relevant_data["MedalCBRequirement"] = medal_cb_req
             relevant_data["MedalCBRequirementLevel"] = medal_cb_requirement_level
+            relevant_data["HalfMedalPercentage"] = slot_data.get("HalfMedalPercentage", 50)
             relevant_data["FairyRequirement"] = fairy_req
             relevant_data["MermaidPearls"] = pearl_req
             relevant_data["JetpacReq"] = jetpac_req

--- a/archipelago.json
+++ b/archipelago.json
@@ -1,6 +1,6 @@
 {
     "minimum_ap_version": "0.6.5",
-    "world_version": "1.5.7",
+    "world_version": "1.5.8",
     "authors": ["2dos", "AlmostSeagull", "Ballaam", "Green Bean", "Killklli", "Lrauq", "PoryGone", "Umed"],
     "version": 7,
     "compatible_version": 7,

--- a/archipelago/FillSettings.py
+++ b/archipelago/FillSettings.py
@@ -352,6 +352,7 @@ def apply_archipelago_settings(settings_dict: dict, options, multiworld) -> None
     settings_dict["shuffle_helm_location"] = options.shuffle_helm_level_order.value
     settings_dict["mermaid_gb_pearls"] = options.pearls_required_for_mermaid.value
     settings_dict["cb_medal_behavior_new"] = options.medal_distribution.value
+    settings_dict["half_medal_percentage"] = options.half_medal_percentage.value
     settings_dict["smaller_shops"] = options.smaller_shops.value and not hasattr(multiworld, "generation_is_fake")
     settings_dict["puzzle_rando_difficulty"] = options.puzzle_rando.value
     if options.enable_cutscenes.value:
@@ -832,6 +833,7 @@ def handle_fake_generation_settings(settings: Settings, multiworld) -> None:
                 for level, value in enumerate(passthrough["MedalCBRequirementLevel"]):
                     settings.medal_cb_req_level[Levels(level)] = int(value)
 
+                settings.half_medal_percentage = passthrough["HalfMedalPercentage"]
                 settings.mermaid_gb_pearls = passthrough["MermaidPearls"]
                 settings.BossBananas = passthrough["BossBananas"]
                 settings.boss_maps = passthrough["BossMaps"]

--- a/archipelago/Options.py
+++ b/archipelago/Options.py
@@ -784,12 +784,26 @@ class MicroHints(Choice):
 class HalfMedals(Toggle):
     """Determines if Half Medals are added to the pool.
 
-    If medal_cb_req is set to 50, you will get a check at 25 Colored Bananas.
+    Half Medals send at a fraction of the colored bananas a full Medal needs, controlled by the
+    Half Medal Percentage option.
     """
 
     display_name = "Half Medals in Pool"
 
     default = False
+
+
+class HalfMedalPercentage(Range):
+    """The percentage of the full medal colored banana requirement that a Half Medal requires.
+
+    Only applies when Half Medals are in the pool. With the default 50, a Half Medal sends at half
+    the colored bananas a full Medal needs (e.g. medal req 40 -> Half Medal at 20).
+    """
+
+    display_name = "Half Medal Percentage"
+    range_start = 1
+    range_end = 99
+    default = 50
 
 
 class ShuffledBonusBarrels(OptionList):
@@ -1408,6 +1422,7 @@ class DK64Options(PerGameCommonOptions):
     logic_type: LogicType
     tricks_selected: TricksSelected
     half_medals_in_pool: HalfMedals
+    half_medal_percentage: HalfMedalPercentage
     glitches_selected: GlitchesSelected
     hard_mode_selected: HardModeSelected
     mirror_mode: MirrorMode
@@ -1506,6 +1521,7 @@ dk64_option_groups: List[OptionGroup] = [
             Dropsanity,
             HintItemRandomization,
             HalfMedals,
+            HalfMedalPercentage,
             SnideTurninsToThePool,
             SnideMaximum,
         ],

--- a/archipelago/Regions.py
+++ b/archipelago/Regions.py
@@ -235,6 +235,9 @@ def create_region(
             # Skip hint locations if hints are not in the pool
             if location_obj.type == Types.Hint and Types.Hint not in logic_holder.settings.shuffled_location_types:
                 continue
+            # Skip half medals if half medals are not in the pool
+            if location_obj.type == Types.HalfMedal and Types.HalfMedal not in logic_holder.settings.shuffled_location_types:
+                continue
             # Skip locations marked as inaccessible by smaller shops
             if hasattr(location_obj, "smallerShopsInaccessible") and location_obj.smallerShopsInaccessible and logic_holder.settings.smaller_shops:
                 continue
@@ -332,7 +335,7 @@ def create_region(
             # Shops cannot have shopkeepers or Rainbow Coins due to technical issues
             if location_obj.type == Types.Shop:
                 add_item_rule(location, lambda item: not (item.player == player and item.name in ["Cranky", "Funky", "Candy", "Snide", "Rainbow Coin"]))
-            if location_obj.type == Types.Key and logic_holder.settings.win_condition_item in (WinConditionComplex.req_bosses, WinConditionComplex.krools_challenge):
+            if location_obj.type == Types.Key and location_logic.id != Locations.HelmKey and logic_holder.settings.win_condition_item in (WinConditionComplex.req_bosses, WinConditionComplex.krools_challenge):
                 token_location = DK64Location(player, location_obj.name + " Token", None, new_region)
                 set_rule(token_location, lambda state, player=player, location_logic=location_logic: hasDK64RLocation(state, player, location_logic))
                 token_location.place_locked_item(DK64Item("Boss Defeated", ItemClassification.progression_skip_balancing, None, player))

--- a/archipelago/Regions.py
+++ b/archipelago/Regions.py
@@ -335,7 +335,11 @@ def create_region(
             # Shops cannot have shopkeepers or Rainbow Coins due to technical issues
             if location_obj.type == Types.Shop:
                 add_item_rule(location, lambda item: not (item.player == player and item.name in ["Cranky", "Funky", "Candy", "Snide", "Rainbow Coin"]))
-            if location_obj.type == Types.Key and location_logic.id != Locations.HelmKey and logic_holder.settings.win_condition_item in (WinConditionComplex.req_bosses, WinConditionComplex.krools_challenge):
+            if (
+                location_obj.type == Types.Key
+                and location_logic.id != Locations.HelmKey
+                and logic_holder.settings.win_condition_item in (WinConditionComplex.req_bosses, WinConditionComplex.krools_challenge)
+            ):
                 token_location = DK64Location(player, location_obj.name + " Token", None, new_region)
                 set_rule(token_location, lambda state, player=player, location_logic=location_logic: hasDK64RLocation(state, player, location_logic))
                 token_location.place_locked_item(DK64Item("Boss Defeated", ItemClassification.progression_skip_balancing, None, player))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyxdelta==0.2.3
 pillow==12.1.1
-git+https://github.com/Killklli/EmuLoader.git@v0.1.3
+git+https://github.com/Killklli/EmuLoader.git@v0.1.4

--- a/wiki/articles.json
+++ b/wiki/articles.json
@@ -134,8 +134,8 @@
         "link": "WikiEditing"
     },
     {
-        "name": "Plando Colors",
-        "link": "PlandoColors"
+        "name": "Random Settings: Easy",
+        "link": "RandomSettingsEasy"
     },
     {
         "name": "Custom Locations: Coins",
@@ -146,6 +146,10 @@
         "link": "CustomLocationsColoredBananas"
     },
     {
+        "name": "Custom Locations: Kasplats",
+        "link": "CustomLocationsKasplats"
+    },
+    {
         "name": "Custom Locations: Doors",
         "link": "CustomLocationsDoors"
     },
@@ -154,27 +158,23 @@
         "link": "CustomLocationsFairies"
     },
     {
-        "name": "Custom Locations: Kasplats",
-        "link": "CustomLocationsKasplats"
-    },
-    {
-        "name": "Custom Locations: Miscellaneous",
-        "link": "CustomLocationsMiscellaneous"
+        "name": "Random Settings: Standard",
+        "link": "RandomSettingsStandard"
     },
     {
         "name": "Random Settings: Difficult",
         "link": "RandomSettingsDifficult"
     },
     {
+        "name": "Plando Colors",
+        "link": "PlandoColors"
+    },
+    {
+        "name": "Custom Locations: Miscellaneous",
+        "link": "CustomLocationsMiscellaneous"
+    },
+    {
         "name": "Random Settings: Difficult With Qol Shuffle",
         "link": "RandomSettingsDifficultWithQolShuffle"
-    },
-    {
-        "name": "Random Settings: Easy",
-        "link": "RandomSettingsEasy"
-    },
-    {
-        "name": "Random Settings: Standard",
-        "link": "RandomSettingsStandard"
     }
 ]


### PR DESCRIPTION
- Added half medal percentage as a new yaml option
  - If half medals are in the pool, you can adjust the percentage of the half medal value
  -  eg. a value of 25% with 50 cbs for a medal will make half medals require 12 CBs (12.5 rounded down)
- Fixed an issue where Ares and Gopher would not connect
- Fixed an unintended bug/feature where the end of helm would count as a boss defeated token